### PR TITLE
fix(lexical/query): sort Geo/Geo3d matcher matches by doc id

### DIFF
--- a/laurus/src/lexical/query/geo.rs
+++ b/laurus/src/lexical/query/geo.rs
@@ -823,9 +823,14 @@ pub struct GeoMatcher {
 
 impl GeoMatcher {
     /// Create a new geo matcher.
+    ///
+    /// Sorts matches into ascending document-id order: `Matcher` iteration
+    /// order is a trait contract — boolean conjunction / disjunction drivers
+    /// interleave `skip_to` calls and assume monotonically increasing doc
+    /// ids. Distance-based ranking is the scorer's concern ([`GeoScorer`]
+    /// looks scores up by doc id), so standalone geo ranking is unaffected.
     pub fn new(mut matches: Vec<GeoMatch>) -> Self {
-        // Sort matches by distance (closest first)
-        matches.sort_by(|a, b| a.distance_m.total_cmp(&b.distance_m));
+        matches.sort_by_key(|m| m.doc_id);
 
         GeoMatcher {
             matches,
@@ -854,7 +859,8 @@ impl Matcher for GeoMatcher {
     }
 
     fn skip_to(&mut self, target: u64) -> Result<bool> {
-        // Find first document ID >= target in order
+        // Forward scan for the first doc id >= target; valid because
+        // `GeoMatcher::new` sorts matches by ascending doc id.
         while self.current_index < self.matches.len() {
             let doc_id = self.matches[self.current_index].doc_id;
             if doc_id >= target {
@@ -931,6 +937,56 @@ impl Scorer for GeoScorer {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a `GeoMatch` whose distance deliberately disagrees with its
+    /// doc-id order, to exercise the matcher's re-sort.
+    fn geo_match(doc_id: u64, distance_m: f64) -> GeoMatch {
+        GeoMatch {
+            doc_id,
+            point: GeoPoint::new(0.0, 0.0),
+            distance_m,
+            relevance_score: 1.0,
+        }
+    }
+
+    /// `Matcher` iteration must be in ascending doc-id order even when the
+    /// input list is distance-ordered (regression for hits dropped from
+    /// boolean conjunctions, GitHub issue #982).
+    #[test]
+    fn test_geo_matcher_iterates_in_doc_id_order() {
+        // Distance order: 7, 1, 4 — doc-id order must win.
+        let mut matcher = GeoMatcher::new(vec![
+            geo_match(7, 10.0),
+            geo_match(1, 20.0),
+            geo_match(4, 30.0),
+        ]);
+
+        let mut seen = vec![matcher.doc_id()];
+        while matcher.next().unwrap() {
+            seen.push(matcher.doc_id());
+        }
+        assert_eq!(seen, vec![1, 4, 7]);
+    }
+
+    /// `skip_to` must find every doc id >= target, exactly as a zig-zag
+    /// conjunction driver expects (regression for GitHub issue #982).
+    #[test]
+    fn test_geo_matcher_skip_to_honors_doc_id_order() {
+        let mut matcher = GeoMatcher::new(vec![
+            geo_match(7, 10.0),
+            geo_match(1, 20.0),
+            geo_match(4, 30.0),
+        ]);
+
+        assert!(matcher.skip_to(2).unwrap());
+        assert_eq!(matcher.doc_id(), 4);
+        assert!(matcher.skip_to(4).unwrap());
+        assert_eq!(matcher.doc_id(), 4);
+        assert!(matcher.skip_to(5).unwrap());
+        assert_eq!(matcher.doc_id(), 7);
+        assert!(!matcher.skip_to(8).unwrap());
+        assert!(matcher.is_exhausted());
+    }
 
     #[test]
     fn test_geo_point_creation() {
@@ -1074,12 +1130,12 @@ mod tests {
 
         let mut matcher = GeoMatcher::new(matches);
 
-        // Should return documents in distance-sorted order (closest first)
-        // After sorting: doc_id: 3 (1 km) comes before doc_id: 1 (2 km)
-        assert_eq!(matcher.doc_id(), 3); // Initial position: closest document
+        // Iterates in ascending doc-id order (the `Matcher` contract used
+        // by boolean drivers) — distance ranking is the scorer's job.
+        assert_eq!(matcher.doc_id(), 1);
 
         assert!(matcher.next().unwrap()); // Move to next
-        assert_eq!(matcher.doc_id(), 1); // Second document (farther)
+        assert_eq!(matcher.doc_id(), 3);
 
         assert!(!matcher.next().unwrap()); // No more documents
     }

--- a/laurus/src/lexical/query/geo3d.rs
+++ b/laurus/src/lexical/query/geo3d.rs
@@ -255,10 +255,16 @@ pub struct Geo3dMatcher {
 }
 
 impl Geo3dMatcher {
-    /// Wrap a pre-sorted match list. Callers are expected to pass the
-    /// distance-ascending list produced by
-    /// [`Geo3dDistanceQuery::find_matches`].
-    pub fn new(matches: Vec<Geo3dMatch>) -> Self {
+    /// Wrap a match list, re-sorting it into ascending document-id order.
+    ///
+    /// [`Geo3dDistanceQuery::find_matches`] produces distance-ascending
+    /// lists for ranking, but `Matcher` iteration order is a trait
+    /// contract — boolean conjunction / disjunction drivers interleave
+    /// `skip_to` calls and assume monotonically increasing doc ids.
+    /// Distance ranking stays with [`Geo3dScorer`], which looks scores up
+    /// by doc id.
+    pub fn new(mut matches: Vec<Geo3dMatch>) -> Self {
+        matches.sort_by_key(|m| m.doc_id);
         Self { matches, cursor: 0 }
     }
 }
@@ -283,8 +289,8 @@ impl Matcher for Geo3dMatcher {
     }
 
     fn skip_to(&mut self, target: u64) -> Result<bool> {
-        // Linear scan over the distance-sorted list; matches the
-        // semantics of `GeoMatcher::skip_to` in 2D.
+        // Forward scan for the first doc id >= target; valid because
+        // `Geo3dMatcher::new` sorts matches by ascending doc id.
         while self.cursor < self.matches.len() {
             if self.matches[self.cursor].doc_id >= target {
                 return Ok(true);
@@ -905,6 +911,52 @@ mod tests {
 
     fn cell(min: [f64; 3], max: [f64; 3]) -> AABB {
         AABB::new(min.to_vec(), max.to_vec()).unwrap()
+    }
+
+    /// Build a `Geo3dMatch` whose distance deliberately disagrees with its
+    /// doc-id order, to exercise the matcher's re-sort.
+    fn geo3d_match(doc_id: u64, distance_m: f64) -> Geo3dMatch {
+        Geo3dMatch {
+            doc_id,
+            distance_m,
+            score: 1.0,
+        }
+    }
+
+    /// `Matcher` iteration must be in ascending doc-id order even when the
+    /// input list is distance-ordered (regression for hits dropped from
+    /// boolean conjunctions, GitHub issue #982).
+    #[test]
+    fn geo3d_matcher_iterates_in_doc_id_order() {
+        let mut matcher = Geo3dMatcher::new(vec![
+            geo3d_match(7, 10.0),
+            geo3d_match(1, 20.0),
+            geo3d_match(4, 30.0),
+        ]);
+
+        let mut seen = vec![matcher.doc_id()];
+        while matcher.next().unwrap() {
+            seen.push(matcher.doc_id());
+        }
+        assert_eq!(seen, vec![1, 4, 7]);
+    }
+
+    /// `skip_to` must find every doc id >= target, exactly as a zig-zag
+    /// conjunction driver expects (regression for GitHub issue #982).
+    #[test]
+    fn geo3d_matcher_skip_to_honors_doc_id_order() {
+        let mut matcher = Geo3dMatcher::new(vec![
+            geo3d_match(7, 10.0),
+            geo3d_match(1, 20.0),
+            geo3d_match(4, 30.0),
+        ]);
+
+        assert!(matcher.skip_to(2).unwrap());
+        assert_eq!(matcher.doc_id(), 4);
+        assert!(matcher.skip_to(5).unwrap());
+        assert_eq!(matcher.doc_id(), 7);
+        assert!(!matcher.skip_to(8).unwrap());
+        assert!(matcher.is_exhausted());
     }
 
     fn visitor(cx: f64, cy: f64, cz: f64, radius: f64) -> SphereVisitor {

--- a/laurus/tests/geo_conjunction_search_test.rs
+++ b/laurus/tests/geo_conjunction_search_test.rs
@@ -1,0 +1,129 @@
+//! Regression tests for GitHub issue #982: boolean conjunctions that
+//! contain a geo clause (`+(term) +location:geo_bbox(...)`) dropped hits
+//! because `GeoMatcher` iterated in distance order while `skip_to`
+//! assumed ascending doc-id order. Mirrors the WASM `Index.search` path
+//! (DSL string via `SearchRequestBuilder::query_dsl`) and the geo demo
+//! schema shape (Japanese-analyzed default fields + a Geo field).
+
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::{DataValue, Document, Engine, GeoPoint, Result, Schema, SearchRequestBuilder};
+
+const GEO_DEMO_SCHEMA_JSON: &str = r#"
+{
+    "default_fields": ["title", "description", "category"],
+    "fields": {
+        "title": { "Text": {
+            "indexed": true, "stored": true, "term_vectors": false,
+            "analyzer": { "language": "japanese", "mode": "normal", "dict": "embedded://ipadic" }
+        }},
+        "description": { "Text": {
+            "indexed": true, "stored": true, "term_vectors": false,
+            "analyzer": { "language": "japanese", "mode": "normal", "dict": "embedded://ipadic" }
+        }},
+        "category": { "Text": {
+            "indexed": true, "stored": true, "term_vectors": false,
+            "analyzer": { "language": "japanese", "mode": "normal", "dict": "embedded://ipadic" }
+        }},
+        "location": { "Geo": { "indexed": true, "stored": true } }
+    }
+}
+"#;
+
+async fn geo_demo_engine() -> Result<Engine> {
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let schema: Schema = serde_json::from_str(GEO_DEMO_SCHEMA_JSON).expect("valid schema JSON");
+    let engine = Engine::new(storage, schema).await?;
+
+    engine
+        .put_document(
+            "ueno",
+            Document::builder()
+                .add_field("title", "上野恩賜公園")
+                .add_field("description", "美術館や動物園が集まる広大な公園。")
+                .add_field("category", "公園")
+                .add_field("location", DataValue::Geo(GeoPoint::new(35.712, 139.771)))
+                .build(),
+        )
+        .await?;
+    engine
+        .put_document(
+            "odaiba",
+            Document::builder()
+                .add_field("title", "お台場海浜公園")
+                .add_field("description", "東京湾を一望できるベイエリアの公園。")
+                .add_field("category", "公園")
+                .add_field("location", DataValue::Geo(GeoPoint::new(35.630, 139.773)))
+                .build(),
+        )
+        .await?;
+    engine
+        .put_document(
+            "tower",
+            Document::builder()
+                .add_field("title", "東京タワー")
+                .add_field("description", "芝公園にそびえる赤と白の電波塔。")
+                .add_field("category", "展望")
+                .add_field("location", DataValue::Geo(GeoPoint::new(35.658, 139.745)))
+                .build(),
+        )
+        .await?;
+    engine.commit().await?;
+    Ok(engine)
+}
+
+async fn dsl_hits(engine: &Engine, dsl: &str) -> Result<Vec<String>> {
+    let request = SearchRequestBuilder::new()
+        .limit(10)
+        .query_dsl(dsl.to_string())
+        .build();
+    let results = engine.search(request).await?;
+    Ok(results.iter().map(|h| h.id.clone()).collect())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bbox_alone_matches_all_docs() -> Result<()> {
+    let engine = geo_demo_engine().await?;
+    let ids = dsl_hits(&engine, "location:geo_bbox(35.6, 139.5, 35.8, 140.0)").await?;
+    assert_eq!(ids.len(), 3, "bbox covers all three docs, got {ids:?}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bare_japanese_term_matches() -> Result<()> {
+    let engine = geo_demo_engine().await?;
+    let ids = dsl_hits(&engine, "公園").await?;
+    assert!(
+        ids.len() >= 2,
+        "公園 appears in all three docs' default fields, got {ids:?}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn required_group_japanese_term_matches() -> Result<()> {
+    let engine = geo_demo_engine().await?;
+    let ids = dsl_hits(&engine, "+(公園)").await?;
+    assert!(
+        ids.len() >= 2,
+        "+(公園) should match like the bare term, got {ids:?}"
+    );
+    Ok(())
+}
+
+/// The exact query shape the geo demo builds: required text group AND
+/// required geo bounding-box clause.
+#[tokio::test(flavor = "multi_thread")]
+async fn required_group_and_bbox_conjunction_matches() -> Result<()> {
+    let engine = geo_demo_engine().await?;
+    let ids = dsl_hits(
+        &engine,
+        "+(公園) +location:geo_bbox(35.6, 139.5, 35.8, 140.0)",
+    )
+    .await?;
+    assert!(
+        ids.len() >= 2,
+        "conjunction of matching term and covering bbox must hit, got {ids:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Boolean conjunctions containing a geo clause silently dropped hits: on the geo demo, `+(公園) +location:geo_bbox(...)` returned 0 hits over documents that plainly matched both clauses, while each clause alone worked.

`GeoMatcher::new` sorted its match list by ascending **distance**, and `Geo3dMatcher` documented a distance-ascending input contract — while both `skip_to` implementations scan forward for the first `doc_id >= target`, which is only valid on a **doc-id-ascending** list. Boolean conjunction drivers interleave `skip_to` calls assuming monotonically increasing doc ids, so which documents survived depended on the accidental alignment of distance order with doc-id order.

## Changes

- Sort matches by ascending `doc_id` in `GeoMatcher::new` and `Geo3dMatcher::new`; document the ordering contract at both constructors and `skip_to` sites. Distance ranking stays with `GeoScorer` / `Geo3dScorer` (score lookup by doc id), so standalone geo query ranking is unchanged; `find_matches` keeps relevance order for its direct consumers.
- `test_geo_matcher` pinned the old distance-ordered iteration — updated to the doc-id contract.
- New matcher-level unit tests (2D + 3D) for iteration order and `skip_to` from distance-ordered input.
- New engine-level regression test `geo_conjunction_search_test.rs` mirroring the WASM search path (DSL string, Japanese-analyzed fields, Geo field): RED before the fix (1 of 3 expected docs), GREEN after.

A sweep of all 16 `impl Matcher` sites found no other matcher iterating out of doc-id order.

## Verification

- Full `-p laurus --lib` suite: 1331 passed
- All geo/bkd integration test files pass
- `cargo fmt --check` (stable + 1.97) and `cargo clippy --all-targets -- -D warnings` clean

Closes #982
