### PR TITLE
fix(lexical): bound geo fallback scans and share one candidate pass

### DIFF
--- a/docs/ja/src/concepts/bkd_tree.md
+++ b/docs/ja/src/concepts/bkd_tree.md
@@ -175,4 +175,4 @@ graph TD
 - [Lexical インデクシング](indexing/lexical_indexing.md) — `.bkd`
   セグメントファイルがセグメント全体のレイアウト内のどこに位置するか。
 - [Lexical 検索](search/lexical_search.md) — `NumericRangeQuery`、
-  `GeoQuery`、`Geo3dDistanceQuery` の Rust API エントリポイント。
+  `GeoDistanceQuery` / `GeoBoundingBoxQuery`、`Geo3dDistanceQuery` の Rust API エントリポイント。

--- a/docs/ja/src/concepts/search/lexical_search.md
+++ b/docs/ja/src/concepts/search/lexical_search.md
@@ -163,23 +163,30 @@ let query = NumericRangeQuery::new(
 `indexed = false, stored = true` と設定されたフィールド）では、そのセグメントに
 実際に存在する保存済みドキュメントのみを走査するフォールバックを使用します。
 
-### GeoQuery
+### GeoDistanceQuery / GeoBoundingBoxQuery
 
 2D 地理座標（WGS84 緯度・経度）に基づいてドキュメントをマッチングします。
 
 ```rust
-use laurus::lexical::query::geo::GeoQuery;
+use laurus::lexical::query::geo::{GeoBoundingBoxQuery, GeoDistanceQuery};
 
 // Find documents within 10 km (= 10 000 m) of Tokyo Station (35.6812, 139.7671)
-let query = GeoQuery::within_radius("location", 35.6812, 139.7671, 10_000.0)?; // distance in metres
+let query = GeoDistanceQuery::within_radius("location", 35.6812, 139.7671, 10_000.0)?; // distance in metres
 
 // Find documents within a bounding box (min_lat, min_lon, max_lat, max_lon)
-let query = GeoQuery::within_bounding_box(
+let query = GeoBoundingBoxQuery::within_bounding_box(
     "location",
     35.0, 139.0,  // min (lat, lon)
     36.0, 140.0,  // max (lat, lon)
 )?;
 ```
+
+どちらのクエリも距離ベースでスコアリングします（近いドキュメントほど高スコア。
+円の中心、またはボックスの中心からの線形減衰）。マッチングにはセグメントに
+BKD tree があればそれを使用し、対象フィールドの BKD tree を持たないセグメント
+（例: そのフィールドを持つドキュメントが 1 件もないセグメントや、
+`indexed = false, stored = true` と設定されたフィールド）では、そのセグメントに
+実際に存在する保存済みドキュメントのみを走査するフォールバックを使用します。
 
 ### Geo3dDistanceQuery / Geo3dBoundingBoxQuery / Geo3dNearestQuery
 
@@ -215,6 +222,11 @@ let q = Geo3dNearestQuery::new("position", centre, 10)
 | `Geo3dDistanceQuery` | `1 - distance / radius` を `[0, 1]` にクランプ |
 | `Geo3dBoundingBoxQuery` | マッチした全ドキュメントで定数 `1.0` |
 | `Geo3dNearestQuery` | 最も近いヒットが `1.0`、返却された集合内で最も遠いヒットが `0.0` となるよう正規化 |
+
+geo3d クエリはフィールドがインデックスされていること（`indexed = true`、
+デフォルト）を必要とします。これらは完全にフィールドの BKD tree 上で動作し、
+BKD tree を持たないセグメントからはヒットを返しません — 3D クエリには
+保存済みドキュメントへのフォールバックはありません。
 
 ### SpanQuery
 

--- a/docs/ja/src/getting_started/examples.md
+++ b/docs/ja/src/getting_started/examples.md
@@ -32,7 +32,7 @@ cargo run --example quickstart
 cargo run --example lexical_search
 ```
 
-デモ内容: `TermQuery`、`PhraseQuery`、`FuzzyQuery`、`WildcardQuery`、`NumericRangeQuery`、`GeoQuery`、`BooleanQuery`、`SpanQuery`
+デモ内容: `TermQuery`、`PhraseQuery`、`FuzzyQuery`、`WildcardQuery`、`NumericRangeQuery`、`GeoDistanceQuery` / `GeoBoundingBoxQuery`、`BooleanQuery`、`SpanQuery`
 
 ### vector_search
 

--- a/docs/src/concepts/bkd_tree.md
+++ b/docs/src/concepts/bkd_tree.md
@@ -179,4 +179,4 @@ internal-node descent entirely.
 - [Lexical Indexing](indexing/lexical_indexing.md) — where the `.bkd` segment
   file fits within the broader segment layout.
 - [Lexical Search](search/lexical_search.md) — `NumericRangeQuery`,
-  `GeoQuery`, and `Geo3dDistanceQuery` programmatic entry points.
+  `GeoDistanceQuery` / `GeoBoundingBoxQuery`, and `Geo3dDistanceQuery` programmatic entry points.

--- a/docs/src/concepts/search/lexical_search.md
+++ b/docs/src/concepts/search/lexical_search.md
@@ -163,23 +163,30 @@ when the segment has one; segments without a BKD tree for the field
 field configured `indexed = false, stored = true`) fall back to scanning
 only the stored documents actually present in that segment.
 
-### GeoQuery
+### GeoDistanceQuery / GeoBoundingBoxQuery
 
-Matches documents by 2D geographic location (WGS84 latitude / longitude).
+Match documents by 2D geographic location (WGS84 latitude / longitude).
 
 ```rust
-use laurus::lexical::query::geo::GeoQuery;
+use laurus::lexical::query::geo::{GeoBoundingBoxQuery, GeoDistanceQuery};
 
 // Find documents within 10 km (= 10 000 m) of Tokyo Station (35.6812, 139.7671)
-let query = GeoQuery::within_radius("location", 35.6812, 139.7671, 10_000.0)?; // distance in metres
+let query = GeoDistanceQuery::within_radius("location", 35.6812, 139.7671, 10_000.0)?; // distance in metres
 
 // Find documents within a bounding box (min_lat, min_lon, max_lat, max_lon)
-let query = GeoQuery::within_bounding_box(
+let query = GeoBoundingBoxQuery::within_bounding_box(
     "location",
     35.0, 139.0,  // min (lat, lon)
     36.0, 140.0,  // max (lat, lon)
 )?;
 ```
+
+Both queries score by distance (closer documents rank higher: linear decay
+from the circle's centre, or from the box's centre). Matching uses the
+field's BKD tree when the segment has one; segments without a BKD tree for
+the field (for example, segments none of whose documents carry the field,
+or a field configured `indexed = false, stored = true`) fall back to
+scanning only the stored documents actually present in that segment.
 
 ### Geo3dDistanceQuery / Geo3dBoundingBoxQuery / Geo3dNearestQuery
 
@@ -215,6 +222,11 @@ let q = Geo3dNearestQuery::new("position", centre, 10)
 | `Geo3dDistanceQuery` | `1 - distance / radius`, clamped to `[0, 1]`. |
 | `Geo3dBoundingBoxQuery` | Constant `1.0` for every match. |
 | `Geo3dNearestQuery` | Normalised so the closest hit is `1.0`, the farthest in the returned set is `0.0`. |
+
+Geo3d queries require the field to be indexed (`indexed = true`, the
+default): they run entirely on the field's BKD tree and return no hits
+from segments that lack one — there is no stored-document fallback for
+3D queries.
 
 ### SpanQuery
 

--- a/docs/src/getting_started/examples.md
+++ b/docs/src/getting_started/examples.md
@@ -32,7 +32,7 @@ Comprehensive example of all lexical query types, using both the Builder API and
 cargo run --example lexical_search
 ```
 
-Demonstrates: `TermQuery`, `PhraseQuery`, `FuzzyQuery`, `WildcardQuery`, `NumericRangeQuery`, `GeoQuery`, `BooleanQuery`, `SpanQuery`.
+Demonstrates: `TermQuery`, `PhraseQuery`, `FuzzyQuery`, `WildcardQuery`, `NumericRangeQuery`, `GeoDistanceQuery` / `GeoBoundingBoxQuery`, `BooleanQuery`, `SpanQuery`.
 
 ### vector_search
 

--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -216,11 +216,10 @@ impl InvertedIndexSearcher {
         }
 
         // Default single-threaded execution
-        // Create a matcher for the query
-        let mut matcher = query.matcher(self.reader.as_ref())?;
-
-        // Create a scorer for the query
-        let scorer = query.scorer(self.reader.as_ref())?;
+        // Create the matcher and scorer in one pass (#996: queries with
+        // an expensive shared candidate computation, e.g. geo, build
+        // both from a single run of it).
+        let (mut matcher, scorer) = query.matcher_scorer(self.reader.as_ref())?;
 
         // SIMD-batched default loop (#506). The scalar path collected
         // one doc at a time via `scorer.score`; this version gathers up

--- a/laurus/src/lexical/query.rs
+++ b/laurus/src/lexical/query.rs
@@ -115,6 +115,30 @@ pub trait Query: Send + Sync + Debug {
     /// Create a scorer for this query.
     fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>>;
 
+    /// Create the matcher and scorer for this query in one pass.
+    ///
+    /// The default implementation builds them independently via
+    /// [`matcher`](Query::matcher) and [`scorer`](Query::scorer),
+    /// preserving the historical behavior. Queries whose matcher and
+    /// scorer derive from the same expensive candidate computation
+    /// (e.g. geo queries computing per-document distances) override
+    /// this to run that computation once and build both from the
+    /// shared result (#996).
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - The index reader to search.
+    ///
+    /// # Returns
+    ///
+    /// The `(matcher, scorer)` pair for this query.
+    fn matcher_scorer(
+        &self,
+        reader: &dyn LexicalIndexReader,
+    ) -> Result<(Box<dyn Matcher>, Box<dyn Scorer>)> {
+        Ok((self.matcher(reader)?, self.scorer(reader)?))
+    }
+
     /// Get the boost factor for this query.
     fn boost(&self) -> f32;
 

--- a/laurus/src/lexical/query/geo.rs
+++ b/laurus/src/lexical/query/geo.rs
@@ -13,7 +13,7 @@ use crate::error::Result;
 use crate::lexical::query::Query;
 use crate::lexical::query::matcher::Matcher;
 use crate::lexical::query::scorer::Scorer;
-use crate::lexical::reader::LexicalIndexReader;
+use crate::lexical::reader::{LexicalIndexReader, scan_doc_ids};
 
 /// A 2D geographical bounding box, expressed as the south-west `min` corner
 /// and the north-east `max` corner of an axis-aligned lat/lon rectangle.
@@ -285,11 +285,10 @@ impl GeoDistanceQuery {
             return Ok(candidates);
         }
 
-        // Get the maximum document ID to iterate through all documents
-        let max_doc = reader.max_doc();
-
-        // Iterate through all documents in the index
-        for doc_id in 0..max_doc {
+        // Fallback: scan the stored documents present in this reader
+        // (segment-bounded under the fanout; correct for sparse id
+        // spaces — #996).
+        for doc_id in scan_doc_ids(reader)? {
             // Get the document
             if let Some(doc) = reader.document(doc_id)? {
                 // Get the geo field value
@@ -395,6 +394,21 @@ impl Query for GeoDistanceQuery {
     fn scorer(&self, reader: &dyn LexicalIndexReader) -> Result<Box<dyn Scorer>> {
         let matches = self.find_matches(reader)?;
         Ok(Box::new(GeoScorer::new(matches, self.boost)))
+    }
+
+    fn matcher_scorer(
+        &self,
+        reader: &dyn LexicalIndexReader,
+    ) -> Result<(Box<dyn Matcher>, Box<dyn Scorer>)> {
+        // Run the candidate scan once and share it (#996): the scorer's
+        // per-doc distance scores derive from the same matches the
+        // matcher iterates, so ranking is identical to building them
+        // independently.
+        let matches = self.find_matches(reader)?;
+        Ok((
+            Box::new(GeoMatcher::new(matches.clone())),
+            Box::new(GeoScorer::new(matches, self.boost)),
+        ))
     }
 
     fn boost(&self) -> f32 {
@@ -608,11 +622,10 @@ impl GeoBoundingBoxQuery {
             return Ok(candidates);
         }
 
-        // Get the maximum document ID to iterate through all documents
-        let max_doc = reader.max_doc();
-
-        // Iterate through all documents in the index
-        for doc_id in 0..max_doc {
+        // Fallback: scan the stored documents present in this reader
+        // (segment-bounded under the fanout; correct for sparse id
+        // spaces — #996).
+        for doc_id in scan_doc_ids(reader)? {
             // Get the document
             if let Some(doc) = reader.document(doc_id)? {
                 // Get the geo field value
@@ -765,6 +778,21 @@ impl Query for GeoBoundingBoxQuery {
 
     fn set_boost(&mut self, boost: f32) {
         self.boost = boost;
+    }
+
+    fn matcher_scorer(
+        &self,
+        reader: &dyn LexicalIndexReader,
+    ) -> Result<(Box<dyn Matcher>, Box<dyn Scorer>)> {
+        // Run the candidate scan once and share it (#996): the scorer's
+        // per-doc center-distance scores derive from the same matches
+        // the matcher iterates, so ranking is identical to building
+        // them independently.
+        let matches = self.find_matches(reader)?;
+        Ok((
+            Box::new(GeoMatcher::new(matches.clone())),
+            Box::new(GeoScorer::new(matches, self.boost)),
+        ))
     }
 
     fn clone_box(&self) -> Box<dyn Query> {
@@ -1255,5 +1283,174 @@ mod tests {
         // Both should have some bonus, but for different reasons
         assert!(equator_geo_bonus > 0.0);
         assert!(non_equator_geo_bonus > 0.0);
+    }
+
+    /// Reader with a configurable stored-doc id set that counts
+    /// `document()` probes. `max_doc()` deliberately disagrees with the
+    /// id set to model sparse id spaces (post-merge segments, per-segment
+    /// fanout views reporting the global `max_doc`) — see #996 / #994.
+    /// Every present doc carries a `location` geo point near Tokyo.
+    #[derive(Debug)]
+    struct GeoCountingReader {
+        ids: Vec<u64>,
+        max_doc: u64,
+        document_calls: std::sync::atomic::AtomicU64,
+    }
+
+    impl GeoCountingReader {
+        fn new(ids: Vec<u64>, max_doc: u64) -> Self {
+            GeoCountingReader {
+                ids,
+                max_doc,
+                document_calls: std::sync::atomic::AtomicU64::new(0),
+            }
+        }
+
+        fn calls(&self) -> u64 {
+            self.document_calls
+                .load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    impl LexicalIndexReader for GeoCountingReader {
+        fn doc_count(&self) -> u64 {
+            self.max_doc
+        }
+        fn max_doc(&self) -> u64 {
+            self.max_doc
+        }
+        fn is_deleted(&self, _doc_id: u64) -> bool {
+            false
+        }
+        fn document(
+            &self,
+            doc_id: u64,
+        ) -> crate::error::Result<Option<crate::lexical::core::document::Document>> {
+            self.document_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if self.ids.contains(&doc_id) {
+                let doc = crate::data::Document::builder()
+                    .add_field(
+                        "location",
+                        crate::data::DataValue::Geo(GeoPoint::new(35.68, 139.76)),
+                    )
+                    .build();
+                Ok(Some(doc))
+            } else {
+                Ok(None)
+            }
+        }
+        fn doc_ids(&self) -> crate::error::Result<Vec<u64>> {
+            Ok(self.ids.clone())
+        }
+        fn term_info(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> crate::error::Result<Option<crate::lexical::reader::ReaderTermInfo>> {
+            Ok(None)
+        }
+        fn postings(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> crate::error::Result<Option<Box<dyn crate::lexical::reader::PostingIterator>>>
+        {
+            Ok(None)
+        }
+        fn field_stats(
+            &self,
+            _field: &str,
+        ) -> crate::error::Result<Option<crate::lexical::reader::FieldStats>> {
+            Ok(None)
+        }
+        fn close(&mut self) -> crate::error::Result<()> {
+            Ok(())
+        }
+        fn is_closed(&self) -> bool {
+            false
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    fn drain_matcher(mut matcher: Box<dyn Matcher>) -> Vec<u64> {
+        let mut found = Vec::new();
+        while !matcher.is_exhausted() {
+            let doc_id = matcher.doc_id();
+            if doc_id == u64::MAX {
+                break;
+            }
+            found.push(doc_id);
+            if !matcher.next().unwrap() {
+                break;
+            }
+        }
+        found
+    }
+
+    /// #996 regression: the BKD-less bounding-box fallback must probe
+    /// only the doc ids actually present — not the dense `0..max_doc()`
+    /// range, which both over-scans (fanout-global `max_doc`) and
+    /// under-scans (ids above `max_doc` in sparse post-merge segments).
+    #[test]
+    fn bbox_fallback_scans_only_present_doc_ids() {
+        let reader = GeoCountingReader::new(vec![5, 1500], 10);
+        let query =
+            GeoBoundingBoxQuery::within_bounding_box("location", 34.0, 138.0, 37.0, 141.0).unwrap();
+
+        let found = drain_matcher(query.matcher(&reader).unwrap());
+
+        assert_eq!(
+            found,
+            vec![5, 1500],
+            "id above max_doc() must not be missed"
+        );
+        assert_eq!(
+            reader.calls(),
+            2,
+            "fallback must probe only the present ids"
+        );
+    }
+
+    /// #996 regression: `matcher_scorer()` must run the candidate scan
+    /// once, shared between the matcher and the scorer — not once each.
+    #[test]
+    fn matcher_scorer_shares_one_candidate_pass() {
+        let reader = GeoCountingReader::new(vec![5, 1500], 10);
+        let query =
+            GeoBoundingBoxQuery::within_bounding_box("location", 34.0, 138.0, 37.0, 141.0).unwrap();
+
+        let (matcher, scorer) = query.matcher_scorer(&reader).unwrap();
+
+        assert_eq!(
+            reader.calls(),
+            2,
+            "one probe per present id — the candidate pass must run exactly once"
+        );
+        assert_eq!(drain_matcher(matcher), vec![5, 1500]);
+        // The shared result must still feed distance-based scores.
+        assert!(scorer.score(5, 1.0, None) > 0.0);
+    }
+
+    /// #996 regression: same gate for the distance-query fallback.
+    #[test]
+    fn distance_fallback_scans_only_present_doc_ids() {
+        let reader = GeoCountingReader::new(vec![5, 1500], 10);
+        let query = GeoDistanceQuery::within_radius("location", 35.68, 139.76, 50_000.0).unwrap();
+
+        let found = drain_matcher(query.matcher(&reader).unwrap());
+
+        assert_eq!(
+            found,
+            vec![5, 1500],
+            "id above max_doc() must not be missed"
+        );
+        assert_eq!(
+            reader.calls(),
+            2,
+            "fallback must probe only the present ids"
+        );
     }
 }

--- a/laurus/src/lexical/query/geo3d.rs
+++ b/laurus/src/lexical/query/geo3d.rs
@@ -370,6 +370,20 @@ impl Query for Geo3dDistanceQuery {
         )))
     }
 
+    fn matcher_scorer(
+        &self,
+        reader: &dyn LexicalIndexReader,
+    ) -> Result<(Box<dyn Matcher>, Box<dyn Scorer>)> {
+        // Run the BKD sphere traversal once and share it (#996);
+        // ranking is identical to building matcher and scorer
+        // independently.
+        let matches = self.find_matches(reader)?;
+        Ok((
+            Box::new(Geo3dMatcher::new(matches.clone())),
+            Box::new(Geo3dScorer::new(matches, self.boost)),
+        ))
+    }
+
     fn boost(&self) -> f32 {
         self.boost
     }
@@ -532,6 +546,19 @@ impl Query for Geo3dBoundingBoxQuery {
             self.find_matches(reader)?,
             self.boost,
         )))
+    }
+
+    fn matcher_scorer(
+        &self,
+        reader: &dyn LexicalIndexReader,
+    ) -> Result<(Box<dyn Matcher>, Box<dyn Scorer>)> {
+        // Run the BKD range search once and share it (#996); ranking is
+        // identical to building matcher and scorer independently.
+        let matches = self.find_matches(reader)?;
+        Ok((
+            Box::new(Geo3dMatcher::new(matches.clone())),
+            Box::new(Geo3dScorer::new(matches, self.boost)),
+        ))
     }
 
     fn boost(&self) -> f32 {
@@ -859,6 +886,20 @@ impl Query for Geo3dNearestQuery {
         )))
     }
 
+    fn matcher_scorer(
+        &self,
+        reader: &dyn LexicalIndexReader,
+    ) -> Result<(Box<dyn Matcher>, Box<dyn Scorer>)> {
+        // Run the expanding-radius k-NN search (up to ~23 BKD passes)
+        // once and share it (#996); ranking is identical to building
+        // matcher and scorer independently.
+        let matches = self.find_matches(reader)?;
+        Ok((
+            Box::new(Geo3dMatcher::new(matches.clone())),
+            Box::new(Geo3dScorer::new(matches, self.boost)),
+        ))
+    }
+
     fn boost(&self) -> f32 {
         self.boost
     }
@@ -1152,5 +1193,101 @@ mod tests {
         )
         .unwrap_err();
         assert!(format!("{err_z:?}").contains("min.z"));
+    }
+
+    /// Reader counting `get_bkd_tree` lookups. `find_matches` calls it
+    /// exactly once per invocation, so the counter observes how many
+    /// times the candidate search ran (#996).
+    #[derive(Debug)]
+    struct BkdCountingReader {
+        get_bkd_tree_calls: std::sync::atomic::AtomicU64,
+    }
+
+    impl BkdCountingReader {
+        fn new() -> Self {
+            BkdCountingReader {
+                get_bkd_tree_calls: std::sync::atomic::AtomicU64::new(0),
+            }
+        }
+
+        fn calls(&self) -> u64 {
+            self.get_bkd_tree_calls
+                .load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+
+    impl crate::lexical::reader::LexicalIndexReader for BkdCountingReader {
+        fn doc_count(&self) -> u64 {
+            1
+        }
+        fn max_doc(&self) -> u64 {
+            1
+        }
+        fn is_deleted(&self, _doc_id: u64) -> bool {
+            false
+        }
+        fn document(
+            &self,
+            _doc_id: u64,
+        ) -> crate::error::Result<Option<crate::lexical::core::document::Document>> {
+            Ok(None)
+        }
+        fn get_bkd_tree(
+            &self,
+            _field: &str,
+        ) -> crate::error::Result<
+            Option<std::sync::Arc<dyn crate::lexical::index::structures::bkd_tree::BKDTree>>,
+        > {
+            self.get_bkd_tree_calls
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(None)
+        }
+        fn term_info(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> crate::error::Result<Option<crate::lexical::reader::ReaderTermInfo>> {
+            Ok(None)
+        }
+        fn postings(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> crate::error::Result<Option<Box<dyn crate::lexical::reader::PostingIterator>>>
+        {
+            Ok(None)
+        }
+        fn field_stats(
+            &self,
+            _field: &str,
+        ) -> crate::error::Result<Option<crate::lexical::reader::FieldStats>> {
+            Ok(None)
+        }
+        fn close(&mut self) -> crate::error::Result<()> {
+            Ok(())
+        }
+        fn is_closed(&self) -> bool {
+            false
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// #996 regression: `matcher_scorer()` must run `find_matches` once
+    /// (one `get_bkd_tree` lookup), not once for the matcher and once
+    /// for the scorer.
+    #[test]
+    fn matcher_scorer_shares_one_bkd_traversal() {
+        let reader = BkdCountingReader::new();
+        let query = Geo3dDistanceQuery::new("position", GeoEcefPoint::new(0.0, 0.0, 0.0), 1000.0);
+
+        let (_matcher, _scorer) = query.matcher_scorer(&reader).unwrap();
+
+        assert_eq!(
+            reader.calls(),
+            1,
+            "find_matches must run exactly once for the matcher/scorer pair"
+        );
     }
 }

--- a/laurus/src/lexical/query/range.rs
+++ b/laurus/src/lexical/query/range.rs
@@ -9,7 +9,7 @@ use crate::lexical::core::field::NumericType;
 use crate::lexical::query::Query;
 use crate::lexical::query::matcher::{EmptyMatcher, Matcher, PreComputedMatcher};
 use crate::lexical::query::scorer::{BM25Scorer, Scorer};
-use crate::lexical::reader::LexicalIndexReader;
+use crate::lexical::reader::{LexicalIndexReader, scan_doc_ids};
 
 /// Bound type for range queries.
 #[derive(Debug, Clone, PartialEq)]
@@ -609,37 +609,6 @@ impl Scorer for RangeScorer {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-}
-
-/// Enumerate the document ids a stored-document scan should probe.
-///
-/// Prefers [`LexicalIndexReader::doc_ids`], which yields exactly the ids
-/// present in the reader. This keeps the scan segment-bounded under the
-/// per-segment fanout (where `max_doc()` reports the *global* document
-/// count) and correct for sparse id spaces (post-merge segments whose
-/// surviving ids exceed `max_doc()`, non-zero shard offsets) — see #994.
-/// The returned ids are sorted and deduplicated so matchers built from
-/// them observe the ascending doc-id contract.
-///
-/// Readers without id enumeration support (their `doc_ids()` is empty
-/// while `max_doc()` is non-zero) fall back to the legacy dense
-/// `0..max_doc()` range.
-///
-/// # Arguments
-///
-/// * `reader` - The index reader whose document ids should be probed.
-///
-/// # Returns
-///
-/// An iterator over the document ids to probe, in ascending order.
-fn scan_doc_ids(reader: &dyn LexicalIndexReader) -> Result<Box<dyn Iterator<Item = u64>>> {
-    let mut ids = reader.doc_ids()?;
-    if ids.is_empty() && reader.max_doc() > 0 {
-        return Ok(Box::new(0..reader.max_doc()));
-    }
-    ids.sort_unstable();
-    ids.dedup();
-    Ok(Box::new(ids.into_iter()))
 }
 
 impl Query for NumericRangeQuery {

--- a/laurus/src/lexical/query/scorer.rs
+++ b/laurus/src/lexical/query/scorer.rs
@@ -868,8 +868,9 @@ impl BooleanScorer {
     ) -> Result<Self> {
         let mut clauses = Vec::with_capacity(queries.len());
         for query in queries {
-            let matcher = query.matcher(reader)?;
-            let scorer = query.scorer(reader)?;
+            // One pass per clause (#996): queries with an expensive
+            // shared candidate computation build both from a single run.
+            let (matcher, scorer) = query.matcher_scorer(reader)?;
             clauses.push((
                 LeafScorer::from_box(scorer),
                 crate::lexical::query::matcher::LeafMatcher::from_box(matcher),

--- a/laurus/src/lexical/reader.rs
+++ b/laurus/src/lexical/reader.rs
@@ -248,6 +248,39 @@ pub trait LexicalIndexReader: Send + Sync + std::fmt::Debug {
     }
 }
 
+/// Enumerate the document ids a stored-document scan should probe.
+///
+/// Prefers [`LexicalIndexReader::doc_ids`], which yields exactly the ids
+/// present in the reader. This keeps the scan segment-bounded under the
+/// per-segment fanout (where `max_doc()` reports the *global* document
+/// count) and correct for sparse id spaces (post-merge segments whose
+/// surviving ids exceed `max_doc()`, non-zero shard offsets) — see #994,
+/// #996. The returned ids are sorted and deduplicated so matchers built
+/// from them observe the ascending doc-id contract.
+///
+/// Readers without id enumeration support (their `doc_ids()` is empty
+/// while `max_doc()` is non-zero) fall back to the legacy dense
+/// `0..max_doc()` range.
+///
+/// # Arguments
+///
+/// * `reader` - The index reader whose document ids should be probed.
+///
+/// # Returns
+///
+/// An iterator over the document ids to probe, in ascending order.
+pub(crate) fn scan_doc_ids(
+    reader: &dyn LexicalIndexReader,
+) -> Result<Box<dyn Iterator<Item = u64>>> {
+    let mut ids = reader.doc_ids()?;
+    if ids.is_empty() && reader.max_doc() > 0 {
+        return Ok(Box::new(0..reader.max_doc()));
+    }
+    ids.sort_unstable();
+    ids.dedup();
+    Ok(Box::new(ids.into_iter()))
+}
+
 /// Iterator over a posting list for a single term.
 ///
 /// Yields document IDs (and associated term frequencies/positions) in

--- a/laurus/tests/geo_multi_segment_test.rs
+++ b/laurus/tests/geo_multi_segment_test.rs
@@ -1,0 +1,133 @@
+//! Integration tests for issue #996 — 2D geo queries on multi-segment
+//! indices.
+//!
+//! Guards two regressions:
+//!
+//! - the BKD-less fallback must stay segment-bounded and correct for
+//!   sparse doc-id spaces (a stored-only geo field has no BKD tree in
+//!   any segment, so every hit flows through the fallback — this gate
+//!   fails if the fallback misses ids above `max_doc()` or stops
+//!   matching);
+//! - mixed BKD / fallback fan-out (only some segments carry the geo
+//!   field) must return the correct hits.
+
+use std::sync::Arc;
+
+use laurus::Document;
+use laurus::lexical::core::field::{FieldOption, GeoOption, TextOption};
+use laurus::lexical::query::geo::{GeoBoundingBoxQuery, GeoDistanceQuery};
+use laurus::lexical::query::{GeoPoint, Query};
+use laurus::lexical::{LexicalIndexConfig, LexicalSearchRequest, LexicalStore};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+fn geo_doc(lat: f64, lon: f64) -> Document {
+    Document::builder()
+        .add_field(
+            "location",
+            laurus::DataValue::Geo(GeoPoint::try_new(lat, lon).unwrap()),
+        )
+        .build()
+}
+
+fn body_doc(text: &str) -> Document {
+    Document::builder().add_text("body", text).build()
+}
+
+fn search_hits(store: &LexicalStore, query: Box<dyn Query>) -> Vec<u64> {
+    let mut ids: Vec<u64> = store
+        .search(LexicalSearchRequest::new(query))
+        .unwrap()
+        .hits
+        .iter()
+        .map(|hit| hit.doc_id)
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// #996: a stored-only (`indexed = false`) geo field has no BKD tree in
+/// any segment, so every hit must come through the stored-document
+/// fallback. Doc ids are placed above `max_doc()` (= Σ doc_count) to
+/// catch the dense `0..max_doc()` under-scan directly.
+#[test]
+fn stored_only_geo_field_matches_via_fallback_across_segments() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = LexicalIndexConfig::builder()
+        .add_field(
+            "location",
+            FieldOption::Geo(GeoOption {
+                indexed: false,
+                stored: true,
+            }),
+        )
+        .build();
+    let store = LexicalStore::new(storage, config).unwrap();
+
+    // Segment 1: Tokyo and Yokohama, low ids.
+    store.upsert_document(1, geo_doc(35.68, 139.76)).unwrap();
+    store.upsert_document(2, geo_doc(35.44, 139.64)).unwrap();
+    store.commit().unwrap();
+    // Segment 2: Osaka and Sapporo, ids far above Σ doc_count (= 4).
+    store.upsert_document(100, geo_doc(34.69, 135.50)).unwrap();
+    store.upsert_document(101, geo_doc(43.06, 141.35)).unwrap();
+    store.commit().unwrap();
+
+    // Whole-Japan box: every doc, including the high ids the dense
+    // 0..max_doc() scan used to miss.
+    let all_japan = Box::new(
+        GeoBoundingBoxQuery::within_bounding_box("location", 30.0, 128.0, 46.0, 146.0).unwrap(),
+    );
+    assert_eq!(search_hits(&store, all_japan), vec![1, 2, 100, 101]);
+
+    // Osaka-only box: exactly the high-id doc.
+    let osaka_box = Box::new(
+        GeoBoundingBoxQuery::within_bounding_box("location", 34.0, 135.0, 35.0, 136.0).unwrap(),
+    );
+    assert_eq!(search_hits(&store, osaka_box), vec![100]);
+
+    // Distance query around Tokyo station (50 km): Tokyo + Yokohama.
+    let near_tokyo =
+        Box::new(GeoDistanceQuery::within_radius("location", 35.68, 139.76, 50_000.0).unwrap());
+    assert_eq!(search_hits(&store, near_tokyo), vec![1, 2]);
+}
+
+/// #996: mixed BKD / fallback fan-out — only one of three segments
+/// carries the (indexed) geo field; the field-less segments take the
+/// fallback path and must not disturb the result.
+#[test]
+fn geo_query_on_sparse_field_across_segments() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = LexicalIndexConfig::builder()
+        .add_field(
+            "location",
+            FieldOption::Geo(GeoOption {
+                indexed: true,
+                stored: true,
+            }),
+        )
+        .add_field("body", FieldOption::Text(TextOption::default()))
+        .build();
+    let store = LexicalStore::new(storage, config).unwrap();
+
+    // Segment 1: no geo field (no .bkd → fallback path under fanout).
+    store.upsert_document(1, body_doc("alpha")).unwrap();
+    store.upsert_document(2, body_doc("bravo")).unwrap();
+    store.commit().unwrap();
+    // Segment 2: geo docs (BKD path).
+    store.upsert_document(3, geo_doc(35.68, 139.76)).unwrap();
+    store.upsert_document(4, geo_doc(34.69, 135.50)).unwrap();
+    store.commit().unwrap();
+    // Segment 3: no geo field again.
+    store.upsert_document(5, body_doc("charlie")).unwrap();
+    store.commit().unwrap();
+
+    let all_japan = Box::new(
+        GeoBoundingBoxQuery::within_bounding_box("location", 30.0, 128.0, 46.0, 146.0).unwrap(),
+    );
+    assert_eq!(search_hits(&store, all_japan), vec![3, 4]);
+
+    let near_tokyo =
+        Box::new(GeoDistanceQuery::within_radius("location", 35.68, 139.76, 50_000.0).unwrap());
+    assert_eq!(search_hits(&store, near_tokyo), vec![3]);
+}


### PR DESCRIPTION
Closes #996

## Summary

Geo queries had the defect pattern #994/#995 fixed for `NumericRangeQuery` — a BKD-less fallback scanning the *global* doc-id space per segment — plus a duplication of their own: every geo/geo3d query computed its candidate set twice per segment (`matcher()` and `scorer()` each ran `find_matches`; three times as a boolean Must/Should clause — the wasm geo demo's query shape). Full analysis in [the investigation comment](https://github.com/mosuka/laurus/issues/996#issuecomment-5323779897).

**Ranking is completely unchanged.** Geo scoring is distance-based (closer = higher), so unlike #995 the scorer-side pass cannot be dropped; instead one candidate computation is shared.

- **Bounded fallbacks** — `GeoDistanceQuery` / `GeoBoundingBoxQuery`'s BKD-less fallbacks now iterate the doc ids actually present via `scan_doc_ids()` (promoted from `range.rs` to a shared `pub(crate)` helper in `lexical::reader`), instead of `0..max_doc()`. This makes each segment scan only its own docs under the fan-out and fixes the same sparse-id under-scan bug #995 fixed for numeric ranges (ids above `max_doc()` were silently missed — proven RED by the new e2e gate before the fix).
- **One candidate pass** — new defaulted, object-safe `Query::matcher_scorer()` builds the matcher and scorer together. The default preserves the historical behavior for every other query type; all five geo/geo3d types override it to run `find_matches` once, and the default search loop plus `BooleanScorer::new` now use it. Bare geo query: 2×→1× per segment; boolean clause: 3×→2×; `Geo3dNearestQuery`'s duplicated expanding-radius search (up to ~23 BKD passes per call) collapses to one. The filter path (matcher-only, `cache_key`-memoized) was already optimal and is untouched.

## Verification at scale

Index mirroring the #994 shape (34,512 docs → 98 segments via `put docs --commit-every 356`; `location` in 73 docs / 34 segments with BKD). `location:geo_bbox(34.0, 130.0, 44.0, 144.0)`, `main`-built binary vs this branch, idle machine (checked with `pgrep` before measuring), 3 runs per cell:

| | `main` (before) | this PR |
| --- | --- | --- |
| wall-clock | 0.06 s (±0) | **0.02 s (±0)** |
| CPU | 511–555% | 283–308% |
| results | — | **doc ids and scores byte-identical** (ranking-neutrality demonstrated) |

`main` no longer hangs on this shape only because #995's stored-document decode-once fix (already merged) removed the dominant cost layer; this PR removes the remaining algorithmic waste, which grows with segments × total docs.

## Tests (RED-first — each gate proven failing before/with the fix disabled)

- `bbox_fallback_scans_only_present_doc_ids` / `distance_fallback_scans_only_present_doc_ids` (unit): the fallback probes exactly the present ids and finds an id above `max_doc()` (old code probed the dense range and dropped it).
- `matcher_scorer_shares_one_candidate_pass` (unit): one probe per present id for the matcher/scorer pair (default implementation did two passes).
- `matcher_scorer_shares_one_bkd_traversal` (geo3d unit): one `get_bkd_tree` lookup per pair, not two.
- `stored_only_geo_field_matches_via_fallback_across_segments` (e2e): stored-only (`indexed=false`) geo field across 2 segments with doc ids above Σdoc_count — all hits flow through the fallback; old code returned `[1, 2]` instead of `[1, 2, 100, 101]`.
- `geo_query_on_sparse_field_across_segments` (e2e): mixed BKD / fallback fan-out wiring.

Existing gates stay green unchanged: `test_geo_scorer` (pins distance-based `max_score`), the #982 matcher-order tests, and the geo3d distance/normalization suites.

`cargo test --workspace`: 1862 passed / 0 failed. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check`: clean. `markdownlint-cli2`: 0 errors.

## Docs

Fixed stale references to a nonexistent `GeoQuery` type (real factories: `GeoDistanceQuery::within_radius` / `GeoBoundingBoxQuery::within_bounding_box`) in the lexical search guide, BKD tree page, and examples index (EN/JA), and documented the 2D distance scoring + bounded fallback and the geo3d `indexed = true` requirement.

## Out of scope — follow-up issues

- #1000 — 2D geo BKD path reads coordinates from stored documents, silently dropping every hit on `indexed=true, stored=false` fields; should use BKD intersect visitors like geo3d does.
- #1001 — `AdvancedQuery::apply_post_filters` rebuilds the filter matcher per document.
