### PR TITLE
fix(lexical): correct MustNot-only query semantics across all paths

### DIFF
--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -531,6 +531,21 @@ impl InvertedIndexSearcher {
             return Ok(collector);
         }
 
+        // MustNot-only booleans have no positive clause to parallelize:
+        // the per-clause merge below would invert a single negation (the
+        // single-clause shortcut runs the negated query as-is) or return
+        // nothing (the survivor set starts empty without Must/Should
+        // hits). Route them through the serial matcher path, whose
+        // universe is the present-live doc set (#997).
+        if clauses.iter().all(|clause| clause.occur == Occur::MustNot) {
+            return self.search_with_collector_deadline(
+                boolean_query.clone_box(),
+                collector,
+                false,
+                deadline,
+            );
+        }
+
         // Single clause: no need for parallel execution
         if clauses.len() == 1 {
             return self.search_with_collector_deadline(

--- a/laurus/src/lexical/query/boolean.rs
+++ b/laurus/src/lexical/query/boolean.rs
@@ -9,11 +9,11 @@ use crate::lexical::index::inverted::per_segment_view::PerSegmentReaderView;
 use crate::lexical::index::inverted::reader::InvertedIndexReader;
 use crate::lexical::query::Query;
 use crate::lexical::query::matcher::{
-    AllMatcher, ConjunctionMatcher, ConjunctionNotMatcher, DisjunctionMatcher, EmptyMatcher,
-    Matcher, NotMatcher, PreComputedMatcher,
+    ConjunctionMatcher, ConjunctionNotMatcher, DisjunctionMatcher, EmptyMatcher, Matcher,
+    PreComputedMatcher,
 };
 use crate::lexical::query::scorer::{BM25Scorer, Scorer};
-use crate::lexical::reader::LexicalIndexReader;
+use crate::lexical::reader::{LexicalIndexReader, scan_doc_ids};
 
 /// Occurrence requirements for boolean clauses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,9 +256,17 @@ impl Query for BooleanQuery {
                     Box::new(ConjunctionMatcher::new(matchers))
                 }
             } else {
-                // No required clauses, but we have MUST_NOT clauses and no SHOULD clauses
-                // Match all documents and exclude the ones matching MUST_NOT
-                Box::new(AllMatcher::new(reader.max_doc()))
+                // No required clauses, but we have MUST_NOT clauses and no
+                // SHOULD clauses: match every present, live document and
+                // exclude the MUST_NOT matches. The universe is the ids
+                // actually present in the reader (segment-bounded under the
+                // fanout, correct for sparse id spaces) minus soft-deleted
+                // docs — not the dense `0..max_doc()` range, which yielded
+                // cross-segment, phantom, and deleted ids (#997).
+                let universe: Vec<u64> = scan_doc_ids(reader)?
+                    .filter(|&doc_id| !reader.is_deleted(doc_id))
+                    .collect();
+                Box::new(PreComputedMatcher::new(universe))
             };
 
             // If minimum_should_match is set and we have SHOULD clauses, combine them with MUST
@@ -301,29 +309,16 @@ impl Query for BooleanQuery {
                 }
 
                 if !negative_matchers.is_empty() {
-                    if required_clauses.is_empty() {
-                        // Only MUST_NOT clauses - use NotMatcher
-                        if negative_matchers.len() == 1 {
-                            Ok(Box::new(NotMatcher::new(
-                                negative_matchers.into_iter().next().unwrap(),
-                                reader.max_doc(),
-                            )))
-                        } else {
-                            // Multiple MUST_NOT clauses - combine them with DisjunctionMatcher
-                            let combined_negatives =
-                                Box::new(DisjunctionMatcher::new(negative_matchers));
-                            Ok(Box::new(NotMatcher::new(
-                                combined_negatives,
-                                reader.max_doc(),
-                            )))
-                        }
-                    } else {
-                        // Both MUST and MUST_NOT clauses - use ConjunctionNotMatcher
-                        Ok(Box::new(ConjunctionNotMatcher::new(
-                            positive_matcher,
-                            negative_matchers,
-                        )))
-                    }
+                    // The positive matcher is either the required-clause
+                    // conjunction or the present-live universe (MustNot-only
+                    // shape); either way `ConjunctionNotMatcher` applies the
+                    // exclusions. #997 removed the dense `NotMatcher` path,
+                    // which walked `0..max_doc()` and broke multi-segment
+                    // MustNot-only results.
+                    Ok(Box::new(ConjunctionNotMatcher::new(
+                        positive_matcher,
+                        negative_matchers,
+                    )))
                 } else {
                     // All negative matchers are exhausted, just return positive matcher
                     Ok(positive_matcher)
@@ -452,11 +447,25 @@ impl Query for BooleanQuery {
             return Ok(true);
         }
 
-        // Check if any clause can match
+        // MustNot clauses only restrict the result set; their own
+        // emptiness says nothing about whether the query can match. An
+        // exhausted negative excludes NOTHING — the query matches the
+        // whole universe, not nothing (#997).
+        let mut has_positive = false;
         for clause in &self.clauses {
+            if clause.occur == Occur::MustNot {
+                continue;
+            }
+            has_positive = true;
             if !clause.query.is_empty(reader)? {
                 return Ok(false);
             }
+        }
+
+        if !has_positive {
+            // MustNot-only: matches the present-live universe, which is
+            // empty only when the reader holds no documents.
+            return Ok(reader.doc_count() == 0);
         }
 
         Ok(true)
@@ -839,6 +848,100 @@ mod tests {
         assert!(
             q.cache_key().is_none(),
             "an uncacheable child must make the whole boolean uncacheable"
+        );
+    }
+
+    /// Reader with a sparse id set: ids exist beyond `max_doc()` (sparse
+    /// post-merge id spaces, fanout views reporting the global
+    /// `max_doc`) — see #997.
+    #[derive(Debug)]
+    struct SparseIdReader {
+        ids: Vec<u64>,
+        max_doc: u64,
+    }
+
+    impl crate::lexical::reader::LexicalIndexReader for SparseIdReader {
+        fn doc_count(&self) -> u64 {
+            self.max_doc
+        }
+        fn max_doc(&self) -> u64 {
+            self.max_doc
+        }
+        fn is_deleted(&self, _doc_id: u64) -> bool {
+            false
+        }
+        fn document(
+            &self,
+            _doc_id: u64,
+        ) -> crate::error::Result<Option<crate::lexical::core::document::Document>> {
+            Ok(None)
+        }
+        fn doc_ids(&self) -> crate::error::Result<Vec<u64>> {
+            Ok(self.ids.clone())
+        }
+        fn term_info(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> crate::error::Result<Option<crate::lexical::reader::ReaderTermInfo>> {
+            Ok(None)
+        }
+        fn postings(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> crate::error::Result<Option<Box<dyn crate::lexical::reader::PostingIterator>>>
+        {
+            Ok(None)
+        }
+        fn field_stats(
+            &self,
+            _field: &str,
+        ) -> crate::error::Result<Option<crate::lexical::reader::FieldStats>> {
+            Ok(None)
+        }
+        fn close(&mut self) -> crate::error::Result<()> {
+            Ok(())
+        }
+        fn is_closed(&self) -> bool {
+            false
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    /// #997 regression: a MustNot-only query whose negatives all come up
+    /// empty must match exactly the docs present in the reader — not the
+    /// dense `0..max_doc()` range, which over-scans under the fanout and
+    /// cannot reach ids above `max_doc()`.
+    #[test]
+    fn must_not_only_universe_is_present_docs() {
+        let reader = SparseIdReader {
+            ids: vec![5, 1500],
+            max_doc: 10,
+        };
+        let query = BooleanQueryBuilder::new()
+            .must_not(Box::new(TermQuery::new("body", "absent")))
+            .build();
+
+        let mut matcher = query.matcher(&reader).unwrap();
+        let mut found = Vec::new();
+        while !matcher.is_exhausted() {
+            let doc_id = matcher.doc_id();
+            if doc_id == u64::MAX {
+                break;
+            }
+            found.push(doc_id);
+            if !matcher.next().unwrap() {
+                break;
+            }
+        }
+
+        assert_eq!(
+            found,
+            vec![5, 1500],
+            "universe must be the present ids, not 0..max_doc()"
         );
     }
 }

--- a/laurus/src/lexical/query/matcher.rs
+++ b/laurus/src/lexical/query/matcher.rs
@@ -83,7 +83,15 @@ impl Matcher for EmptyMatcher {
     }
 }
 
-/// A matcher that matches all documents.
+/// A matcher that matches every doc id in the dense range `[0, max_doc)`.
+///
+/// Note: this yields *ids*, not documents — the range includes ids that
+/// were never assigned, ids owned by other segments (when `max_doc` is a
+/// fanout-global value), and soft-deleted docs. #997 therefore replaced
+/// its production use (the MustNot-only universe) with a
+/// [`PreComputedMatcher`] over the reader's present, live doc ids; this
+/// type remains for API compatibility and for callers that genuinely
+/// want the dense range.
 #[derive(Debug)]
 pub struct AllMatcher {
     current_doc: u64,
@@ -708,7 +716,14 @@ impl Matcher for ConjunctionNotMatcher {
     }
 }
 
-/// A matcher that matches all documents except those matched by the negative matcher.
+/// A matcher that matches every doc id in the dense range `[0, max_doc)`
+/// except those matched by the negative matcher.
+///
+/// Note: like [`AllMatcher`], the dense universe includes never-assigned,
+/// cross-segment, and soft-deleted ids. #997 replaced its production use
+/// (MustNot-only boolean queries) with a [`ConjunctionNotMatcher`] over a
+/// present-live-docs [`PreComputedMatcher`] universe; this type remains
+/// for API compatibility.
 #[derive(Debug)]
 pub struct NotMatcher {
     /// The matcher for documents to exclude.

--- a/laurus/src/lexical/query/parser.rs
+++ b/laurus/src/lexical/query/parser.rs
@@ -254,8 +254,12 @@ impl LexicalQueryParser {
             }
         }
 
-        // If only one term, return it directly
-        if terms.len() == 1 {
+        // If only one term, return it directly — unless it is prohibited
+        // (`-term`): dropping the `Occur` here would silently turn the
+        // negation into a positive query (#997). MustNot must stay
+        // wrapped in a BooleanQuery so the matcher applies it against
+        // the present-live universe.
+        if terms.len() == 1 && !matches!(terms[0].0, Occur::MustNot) {
             return Ok(terms.into_iter().next().unwrap().1);
         }
 
@@ -1072,6 +1076,30 @@ mod tests {
         let parser = create_test_parser().with_default_field("content");
         let query = parser.parse("hello -world").unwrap();
         assert!(format!("{query:?}").contains("BooleanQuery"));
+    }
+
+    /// #997 regression: a lone prohibited clause must keep its negation.
+    /// The single-term unwrap used to discard the `Occur`, silently
+    /// turning `-term` into a positive query.
+    #[test]
+    fn test_prohibited_only_query_keeps_negation() {
+        let parser = create_test_parser().with_default_field("content");
+
+        let query = parser.parse("-content:spam").unwrap();
+        let debug = format!("{query:?}");
+        assert!(
+            debug.contains("BooleanQuery"),
+            "a lone prohibited clause must stay wrapped in a BooleanQuery: {debug}"
+        );
+        assert!(
+            debug.contains("MustNot"),
+            "the MustNot occur must survive parsing: {debug}"
+        );
+
+        // Same for the default-field form.
+        let query = parser.parse("-spam").unwrap();
+        let debug = format!("{query:?}");
+        assert!(debug.contains("MustNot"), "default-field form: {debug}");
     }
 
     #[test]

--- a/laurus/tests/boolean_must_not_test.rs
+++ b/laurus/tests/boolean_must_not_test.rs
@@ -1,0 +1,194 @@
+//! Integration tests for issue #997 — MustNot-only boolean queries on
+//! multi-segment indices.
+//!
+//! Before #997 these queries walked the dense `0..max_doc()` universe,
+//! which under the per-segment fan-out is the *global* doc count: each
+//! segment could only exclude its own negative matches, so the merged
+//! results contained cross-segment duplicates, docs that should have
+//! been excluded, phantom ids, and soft-deleted docs — and ids above
+//! `max_doc()` (sparse post-merge id spaces) were unreachable.
+
+use std::sync::Arc;
+
+use laurus::Document;
+use laurus::lexical::core::field::{FieldOption, TextOption};
+use laurus::lexical::query::{BooleanQueryBuilder, Query, TermQuery};
+use laurus::lexical::{LexicalIndexConfig, LexicalSearchRequest, LexicalStore};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+fn body_doc(text: &str) -> Document {
+    Document::builder().add_text("body", text).build()
+}
+
+fn new_store() -> LexicalStore {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = LexicalIndexConfig::builder()
+        .add_field("body", FieldOption::Text(TextOption::default()))
+        .build();
+    LexicalStore::new(storage, config).unwrap()
+}
+
+fn must_not_alpha() -> Box<dyn Query> {
+    Box::new(
+        BooleanQueryBuilder::new()
+            .must_not(Box::new(TermQuery::new("body", "alpha")))
+            .build(),
+    )
+}
+
+fn search_hits(store: &LexicalStore, query: Box<dyn Query>) -> Vec<u64> {
+    let mut ids: Vec<u64> = store
+        .search(LexicalSearchRequest::new(query))
+        .unwrap()
+        .hits
+        .iter()
+        .map(|hit| hit.doc_id)
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+/// #997: a MustNot-only query on a multi-segment index must return each
+/// non-matching doc exactly once — no cross-segment duplicates, no docs
+/// that match the negated term in another segment, no phantom ids.
+#[test]
+fn must_not_only_multi_segment_returns_each_doc_once() {
+    let store = new_store();
+
+    // Segment 1: doc 2 matches the negated term.
+    store.upsert_document(1, body_doc("bravo charlie")).unwrap();
+    store.upsert_document(2, body_doc("alpha bravo")).unwrap();
+    store.commit().unwrap();
+    // Segment 2: doc 5 matches the negated term.
+    store.upsert_document(3, body_doc("delta echo")).unwrap();
+    store.upsert_document(4, body_doc("foxtrot")).unwrap();
+    store.upsert_document(5, body_doc("alpha golf")).unwrap();
+    store.commit().unwrap();
+    // Segment 3: no matches for the negated term.
+    store.upsert_document(6, body_doc("hotel india")).unwrap();
+    store.commit().unwrap();
+
+    assert_eq!(
+        search_hits(&store, must_not_alpha()),
+        vec![1, 3, 4, 6],
+        "every non-alpha doc exactly once; no duplicates, exclusions honored, no phantoms"
+    );
+}
+
+/// #997: the parallel execution path must honor MustNot-only semantics
+/// too. Before the fix, a single-clause MustNot-only query run with
+/// `parallel = true` returned the *negated* docs (semantic inversion),
+/// and a multi-clause one returned nothing.
+#[test]
+fn must_not_only_parallel_matches_serial() {
+    let store = new_store();
+
+    store.upsert_document(1, body_doc("bravo charlie")).unwrap();
+    store.upsert_document(2, body_doc("alpha bravo")).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(3, body_doc("delta echo")).unwrap();
+    store.commit().unwrap();
+
+    // Single MustNot clause, parallel.
+    let mut request = LexicalSearchRequest::new(must_not_alpha());
+    request.params.parallel = true;
+    let mut ids: Vec<u64> = store
+        .search(request)
+        .unwrap()
+        .hits
+        .iter()
+        .map(|hit| hit.doc_id)
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 3], "parallel single-clause MustNot-only");
+
+    // Two MustNot clauses, parallel.
+    let query = Box::new(
+        BooleanQueryBuilder::new()
+            .must_not(Box::new(TermQuery::new("body", "alpha")))
+            .must_not(Box::new(TermQuery::new("body", "echo")))
+            .build(),
+    );
+    let mut request = LexicalSearchRequest::new(query);
+    request.params.parallel = true;
+    let mut ids: Vec<u64> = store
+        .search(request)
+        .unwrap()
+        .hits
+        .iter()
+        .map(|hit| hit.doc_id)
+        .collect();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1], "parallel multi-clause MustNot-only");
+}
+
+/// #997: docs whose ids lie above `max_doc()` (= Σ doc_count; sparse
+/// post-merge id spaces) must still appear in MustNot-only results.
+#[test]
+fn must_not_only_includes_ids_above_max_doc() {
+    let store = new_store();
+
+    // Segment 1: low ids, doc 2 matches the negated term.
+    store.upsert_document(1, body_doc("bravo")).unwrap();
+    store.upsert_document(2, body_doc("alpha")).unwrap();
+    store.commit().unwrap();
+    // Segment 2: ids far above Σ doc_count (= 4).
+    store.upsert_document(100, body_doc("charlie")).unwrap();
+    store.upsert_document(101, body_doc("delta")).unwrap();
+    store.commit().unwrap();
+
+    assert_eq!(
+        search_hits(&store, must_not_alpha()),
+        vec![1, 100, 101],
+        "ids above max_doc() must not be missed"
+    );
+}
+
+/// #997: negating a term that matches nothing must return every live
+/// doc — an exhausted negative excludes nothing. The old
+/// `BooleanQuery::is_empty` treated an all-empty-clause boolean as
+/// unmatchable, so the searcher's early exit returned zero hits.
+#[test]
+fn must_not_only_with_absent_term_matches_everything() {
+    let store = new_store();
+
+    store.upsert_document(1, body_doc("bravo")).unwrap();
+    store.upsert_document(2, body_doc("charlie")).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(3, body_doc("delta")).unwrap();
+    store.commit().unwrap();
+
+    let query = Box::new(
+        BooleanQueryBuilder::new()
+            .must_not(Box::new(TermQuery::new("body", "zzz")))
+            .build(),
+    );
+    assert_eq!(
+        search_hits(&store, query),
+        vec![1, 2, 3],
+        "an exhausted negative excludes nothing — the query matches everything"
+    );
+}
+
+/// #997: a doc superseded by an upsert (its old copy is soft-deleted in
+/// the earlier segment) must appear exactly once, and soft-deleted
+/// copies must not surface as hits.
+#[test]
+fn must_not_only_excludes_soft_deleted_copies() {
+    let store = new_store();
+
+    // Segment 1: original version of doc 1.
+    store.upsert_document(1, body_doc("bravo")).unwrap();
+    store.commit().unwrap();
+    // Segment 2: doc 1 upserted (segment-1 copy tombstoned) + one alpha doc.
+    store.upsert_document(1, body_doc("charlie")).unwrap();
+    store.upsert_document(2, body_doc("alpha")).unwrap();
+    store.commit().unwrap();
+
+    assert_eq!(
+        search_hits(&store, must_not_alpha()),
+        vec![1],
+        "doc 1 exactly once; the tombstoned copy must not add a duplicate hit"
+    );
+}


### PR DESCRIPTION
Closes #997

## Summary

What was filed as a performance issue turned out to be **four compounding correctness bugs in MustNot-only boolean queries** — and the repo had no end-to-end test that executed one, which is why none of them was ever caught. Full analysis: [investigation](https://github.com/mosuka/laurus/issues/997#issuecomment-5326113174), [plan update 1](https://github.com/mosuka/laurus/issues/997#issuecomment-5326367718), [plan update 2](https://github.com/mosuka/laurus/issues/997#issuecomment-5326497435).

1. **Universe corruption (the filed issue, worse than expected).** The three MustNot-only arms walked the dense `0..max_doc()` universe, which under the per-segment fan-out is the *global* doc count while each segment can only exclude its own negative matches. Merged results contained cross-segment duplicates, docs matching the negated term in other segments, phantom never-assigned ids, and soft-deleted docs; ids above `max_doc()` (sparse post-merge id spaces) were unreachable. The e2e gate reproduced it vividly: expected `[1, 3, 4, 6]`, got `[0, 0, 1, 1, 2, 3, 3, 4, 4, 5]`. **Fix**: one universe — the reader's present, live doc ids (`scan_doc_ids` from #995 + `is_deleted` filter) as a `PreComputedMatcher`, combined with negatives via the existing `ConjunctionNotMatcher`. `AllMatcher`/`NotMatcher` become production-unused but stay (public API) with warning notes. No `LeafMatcher` hot-path impact (MustNot matchers never reach it).
2. **Parallel path inversion.** With `parallel = true`, a single-clause MustNot-only query hit the single-clause shortcut, which ran the *negated* query as-is — returning exactly the docs that should be excluded; multi-clause ones produced an empty survivor set — returning nothing. **Fix**: MustNot-only booleans route through the serial matcher path (there is no positive clause to parallelize).
3. **DSL parser dropped a lone negation.** `parse_boolean_query`'s single-term unwrap discarded the `Occur`, silently turning a standalone `-term` (or `(-term)`) into a positive query — so the DSL surface could never even reach the matcher fix. **Fix**: prohibited clauses stay wrapped in a `BooleanQuery`.
4. **`is_empty` early-exit.** A boolean whose clauses are all empty was treated as unmatchable, so negating a term with no matches returned zero hits instead of every live doc (an exhausted negative excludes *nothing*). **Fix**: MustNot clauses are excluded from the emptiness check; a MustNot-only boolean is empty only when the reader holds no documents.

Results change intentionally: duplicates disappear, exclusions are honored across segments, deleted/phantom docs stop appearing, `-term` DSL works, and exhausted negatives match everything. Complexity drops from O(segments × total_docs) to O(total_docs) across segments.

## Tests (each proven RED before its fix)

First-ever MustNot-only execution tests:

- `must_not_only_multi_segment_returns_each_doc_once` (e2e) — the corruption gate above.
- `must_not_only_includes_ids_above_max_doc` (e2e) — sparse-id under-scan.
- `must_not_only_excludes_soft_deleted_copies` (e2e) — tombstoned copies stay hidden.
- `must_not_only_parallel_matches_serial` (e2e) — parallel single/multi-clause semantics.
- `must_not_only_with_absent_term_matches_everything` (e2e) — exhausted-negative semantics.
- `must_not_only_universe_is_present_docs` (unit) — sparse-id universe.
- `test_prohibited_only_query_keeps_negation` (unit) — parser keeps the `Occur`.

`cargo test --workspace`: 1869 passed / 0 failed. `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`: clean.

## Verification at scale (98 segments / 34,512 docs, idle, 3 runs)

Semantic comparison (wall-clock comparison is meaningless when the baseline returns wrong results):

| DSL query | correct answer | `main` (before) | this PR |
| --- | --- | --- | --- |
| `-body:ipsum` (every doc contains ipsum) | 0 hits | **returns the ipsum docs (inverted)** | 0 hits ✓ |
| `-body:zzz` (nothing matches zzz) | all 34,512 docs | **0 hits** | all docs, **0.03–0.04 s** ✓ |

## Docs

No `docs/src` changes: the MustNot universe internals are undocumented surface; the behavioral contract is captured in code doc comments (`AllMatcher`/`NotMatcher` notes) and the new tests.
