### PR TITLE
fix(lexical): stop DocValues from serving stale, per-call-reloaded values

### DIFF
--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -855,10 +855,20 @@ impl SegmentReader {
 
     /// Get a DocValues field value for a document.
     fn get_doc_value(&self, field: &str, doc_id: u64) -> Result<Option<FieldValue>> {
-        // Ensure DocValues are loaded (lazy loading)
-        if !self.loaded.load(Ordering::Acquire) {
-            // Try to load if not loaded yet (this is safe for read-only operations after load)
-            self.ensure_loaded()?;
+        // Mirror `document()`: a soft-deleted doc (e.g. the pre-upsert
+        // copy in an older segment) must not surface its stale value
+        // through the cross-segment first-hit resolution (#943).
+        if self.is_deleted(doc_id)? {
+            return Ok(None);
+        }
+
+        // Load once, on demand; the cache itself is the load gate (the
+        // `loaded` flag is only set by the optional bulk `load()` path,
+        // so gating on it re-parsed the whole `.dv` file per call —
+        // #943, same class as #995). A missing `.dv` file loads as an
+        // empty reader, so misses stay O(1).
+        if self.doc_values.read().unwrap().is_none() {
+            self.load_doc_values()?;
         }
 
         let doc_values = self.doc_values.read().unwrap();
@@ -869,19 +879,14 @@ impl SegmentReader {
         }
     }
 
-    /// Ensure the segment is loaded (for lazy loading support)
-    fn ensure_loaded(&self) -> Result<()> {
-        if !self.loaded.load(Ordering::Acquire) {
-            // Load DocValues only (other data loaded on-demand)
-            self.load_doc_values()?;
-            // Note: We don't set loaded=true here to avoid race conditions
-            // Full load should be done via load() method
-        }
-        Ok(())
-    }
-
     /// Check if DocValues are available for a field.
     fn has_doc_values(&self, field: &str) -> bool {
+        // Load on demand so availability is answered correctly even as
+        // the first operation on a fresh reader (#943); previously this
+        // reported `false` until something else loaded the cache.
+        if self.doc_values.read().unwrap().is_none() && self.load_doc_values().is_err() {
+            return false;
+        }
         let doc_values = self.doc_values.read().unwrap();
         if let Some(reader) = doc_values.as_ref() {
             reader.has_field(field)

--- a/laurus/tests/doc_values_test.rs
+++ b/laurus/tests/doc_values_test.rs
@@ -1,0 +1,34 @@
+//! Integration tests for issue #943 — DocValues availability and
+//! freshness at the reader level.
+
+use std::sync::Arc;
+
+use laurus::lexical::LexicalIndexWriter;
+use laurus::lexical::{InvertedIndexWriter, InvertedIndexWriterConfig};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document};
+
+/// #943: `has_doc_values` must answer correctly as the very first
+/// operation on a fresh reader — it used to report `false` until some
+/// other call happened to load the DocValues cache.
+#[test]
+fn has_doc_values_is_correct_on_a_fresh_reader() {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut writer =
+        InvertedIndexWriter::new(storage, InvertedIndexWriterConfig::default()).unwrap();
+
+    let doc = Document::builder()
+        .add_field("popularity", DataValue::Int64(42))
+        .add_field("body", DataValue::Text("alpha".into()))
+        .build();
+    writer.add_document(doc).unwrap();
+    writer.commit().unwrap();
+
+    let reader = writer.build_reader().unwrap();
+
+    assert!(
+        reader.has_doc_values("popularity"),
+        "doc values exist on disk — a fresh reader must report them"
+    );
+    assert!(!reader.has_doc_values("no_such_field"));
+}

--- a/laurus/tests/lexical_field_sort_test.rs
+++ b/laurus/tests/lexical_field_sort_test.rs
@@ -172,3 +172,133 @@ fn field_sort_with_min_score() {
     );
     assert_eq!(included, vec![9, 8, 7]);
 }
+
+/// #943: a doc upserted across a segment boundary must sort by its NEW
+/// field value. The tombstoned pre-upsert copy's DocValues entry in the
+/// older segment used to shadow it (segments are scanned oldest-first
+/// with no `is_deleted` check).
+#[test]
+fn field_sort_reflects_upserted_value_across_segments() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = LexicalIndexConfig::builder().max_segments(1000).build();
+    let store = LexicalStore::new(storage, config).unwrap();
+
+    // Segment 1: doc 1 with the soon-to-be-stale value + doc 2.
+    store.upsert_document(1, doc(10)).unwrap();
+    store.upsert_document(2, doc(50)).unwrap();
+    store.commit().unwrap();
+    // Segment 2: doc 1 upserted with a new value + doc 3.
+    store.upsert_document(1, doc(99)).unwrap();
+    store.upsert_document(3, doc(20)).unwrap();
+    store.commit().unwrap();
+
+    let query: Box<dyn Query> = Box::new(TermQuery::new("body", "alpha"));
+    let ids = field_sorted_ids(
+        &store,
+        LexicalSearchRequest::new(query)
+            .limit(3)
+            .sort_by_field_desc("popularity"),
+    );
+
+    assert_eq!(
+        ids,
+        vec![1, 2, 3],
+        "doc 1 must sort by its upserted value (99), not the stale 10"
+    );
+}
+
+/// Storage decorator counting `open_input` calls on `.dv` files, so a
+/// test can assert DocValues are loaded once per segment rather than
+/// once per `get_doc_value` call (#943; same pattern as #995's
+/// stored-documents gate).
+#[derive(Debug)]
+struct DvOpenCountingStorage {
+    inner: Arc<dyn Storage>,
+    dv_opens: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl Storage for DvOpenCountingStorage {
+    fn open_input(&self, name: &str) -> laurus::Result<Box<dyn laurus::storage::StorageInput>> {
+        if name.ends_with(".dv") {
+            self.dv_opens
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        self.inner.open_input(name)
+    }
+    fn create_output(&self, name: &str) -> laurus::Result<Box<dyn laurus::storage::StorageOutput>> {
+        self.inner.create_output(name)
+    }
+    fn create_output_append(
+        &self,
+        name: &str,
+    ) -> laurus::Result<Box<dyn laurus::storage::StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+    fn delete_file(&self, name: &str) -> laurus::Result<()> {
+        self.inner.delete_file(name)
+    }
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+    fn list_files(&self) -> laurus::Result<Vec<String>> {
+        self.inner.list_files()
+    }
+    fn file_size(&self, name: &str) -> laurus::Result<u64> {
+        self.inner.file_size(name)
+    }
+    fn rename_file(&self, from: &str, to: &str) -> laurus::Result<()> {
+        self.inner.rename_file(from, to)
+    }
+    fn metadata(&self, name: &str) -> laurus::Result<laurus::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+    fn create_temp_output(
+        &self,
+        prefix: &str,
+    ) -> laurus::Result<(String, Box<dyn laurus::storage::StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+    fn sync(&self) -> laurus::Result<()> {
+        self.inner.sync()
+    }
+    fn close(&mut self) -> laurus::Result<()> {
+        Ok(())
+    }
+}
+
+/// #943: repeated field-sorted searches must load each segment's `.dv`
+/// file once — not re-parse it on every per-hit `get_doc_value` call.
+#[test]
+fn doc_values_load_once_per_segment() {
+    let dv_opens = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let storage: Arc<dyn Storage> = Arc::new(DvOpenCountingStorage {
+        inner: Arc::new(MemoryStorage::new(MemoryStorageConfig::default())),
+        dv_opens: dv_opens.clone(),
+    });
+    let config = LexicalIndexConfig::builder().max_segments(1000).build();
+    let store = LexicalStore::new(storage, config).unwrap();
+
+    store.upsert_document(1, doc(10)).unwrap();
+    store.upsert_document(2, doc(50)).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(3, doc(99)).unwrap();
+    store.upsert_document(4, doc(20)).unwrap();
+    store.commit().unwrap();
+
+    for _ in 0..2 {
+        let query: Box<dyn Query> = Box::new(TermQuery::new("body", "alpha"));
+        let ids = field_sorted_ids(
+            &store,
+            LexicalSearchRequest::new(query)
+                .limit(4)
+                .sort_by_field_desc("popularity"),
+        );
+        assert_eq!(ids, vec![3, 2, 4, 1]);
+    }
+
+    assert_eq!(
+        dv_opens.load(std::sync::atomic::Ordering::Relaxed),
+        2,
+        ".dv must be loaded once per segment, not per get_doc_value call"
+    );
+}


### PR DESCRIPTION
Closes #943

## Summary

As filed: `SegmentReader::get_doc_value` had no `is_deleted` guard, and `InvertedIndexReader::get_doc_value` resolves a doc id across segments by **first hit in oldest-first order** — so after an upsert, the tombstoned old copy's DocValues entry shadowed the live one, and field-sorted search (`TopFieldCollector`, per collected hit) and faceting silently used the stale pre-update value. Details: [investigation & plan comment](https://github.com/mosuka/laurus/issues/943#issuecomment-5350499644).

- **Fix A (the filed bug)**: the guard now mirrors `document()` — a soft-deleted doc returns `None`, making the cross-segment first hit the first **live** hit. No iteration-order change needed: upsert tombstones the superseded copy (proven behavior, gated since #1002's `must_not_only_excludes_soft_deleted_copies`), so live duplicates don't exist.
- **Fix B (two more defects found in the same functions)**:
  - `get_doc_value` gated loading on the `loaded` flag, which is never set in production, so the whole `.dv` file was **re-read and re-parsed on every call** — once per collected hit in field-sorted search (the same defect class #995 fixed for stored documents). The gate now checks the cache itself; a missing `.dv` loads once as an empty reader (no per-call retry).
  - `has_doc_values` read the cache **without loading it**, reporting `false` until something else happened to populate it — the facet feature's availability probe got a wrong answer on a fresh reader. It now loads on demand.

## Tests (RED-first — each proven failing on current `main`)

- `field_sort_reflects_upserted_value_across_segments` (e2e): doc upserted across a segment boundary must sort by its new value — previously returned `[2, 3, 1]` instead of `[1, 2, 3]` (doc 1 sorted by the stale value).
- `doc_values_load_once_per_segment` (e2e, `.dv` open-counting storage): two field-sorted searches load each segment's `.dv` exactly once — previously reloaded per `get_doc_value` call.
- `has_doc_values_is_correct_on_a_fresh_reader`: correct as the very first operation.

The existing #608 field-sort suite (5 tests) stays green unchanged.

`cargo test --workspace`: 1878 passed / 0 failed. `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`: clean. No docs impact (DocValues internals are undocumented surface).
