### PR TITLE
fix(lexical): order mixed-type sort keys instead of treating them as ties

### DIFF
--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -1,7 +1,5 @@
 //! Searcher implementation for executing queries against an index.
 
-use crate::lexical::core::field::FieldValue;
-use std::cmp::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -14,12 +12,7 @@ use crate::util::time::Timer;
 use rayon::prelude::*;
 
 use crate::analysis::analyzer::standard::StandardAnalyzer;
-use crate::data::DataValue::{
-    Bool as Boolean, Bytes, DateTime, Float64 as Float, Geo, Int64 as Integer, Null, Text,
-};
 use crate::error::{LaurusError, Result};
-// Note: Geo and DateTime were removed from FieldValue definition implicitly by switching to DataValue.
-// Only standard types remain. Logic using Geo/DateTime needs update.
 use crate::lexical::index::inverted::bmw::{BlockMaxOrExecutor, is_bmw_eligible};
 use crate::lexical::index::inverted::parsed_query_cache::ParsedQueryCache;
 use crate::lexical::index::inverted::per_segment_view::PerSegmentReaderView;
@@ -922,85 +915,6 @@ impl InvertedIndexSearcher {
                     })
                 }
             }
-        }
-    }
-
-    /// Sort search hits according to the specified sort field.
-    /// This is the old post-collection sorting approach, kept for compatibility.
-    #[allow(dead_code)]
-    fn sort_hits(&self, hits: &mut [SearchHit], sort_by: &SortField) -> Result<()> {
-        match sort_by {
-            SortField::Score => {
-                // Default behavior: already sorted by score from collector
-                // Re-sort to ensure descending order
-                hits.sort_unstable_by(|a, b| b.score.total_cmp(&a.score));
-            }
-            SortField::Field { name, order } => {
-                // Sort by field value
-                hits.sort_unstable_by(|a, b| {
-                    let cmp = self.compare_field_values(a, b, name);
-                    match order {
-                        SortOrder::Asc => cmp,
-                        SortOrder::Desc => cmp.reverse(),
-                    }
-                });
-            }
-        }
-        Ok(())
-    }
-
-    /// Compare two search hits by a specific field value.
-    #[allow(dead_code)]
-    fn compare_field_values(&self, a: &SearchHit, b: &SearchHit, field_name: &str) -> Ordering {
-        let val_a = a.document.as_ref().and_then(|doc| doc.get(field_name));
-        let val_b = b.document.as_ref().and_then(|doc| doc.get(field_name));
-
-        match (val_a, val_b) {
-            (Some(a_val), Some(b_val)) => self.compare_values(a_val, b_val),
-            (Some(_), None) => Ordering::Less, // Documents with value come first
-            (None, Some(_)) => Ordering::Greater, // Documents without value come last
-            (None, None) => Ordering::Equal,
-        }
-    }
-
-    /// Compare two field values.
-    #[allow(dead_code)]
-    fn compare_values(&self, a: &FieldValue, b: &FieldValue) -> Ordering {
-        match (a, b) {
-            // Same type comparisons
-            (Text(a_str), Text(b_str)) => a_str.cmp(b_str),
-            (Integer(a_int), Integer(b_int)) => a_int.cmp(b_int),
-            (Float(a_float), Float(b_float)) => a_float.total_cmp(b_float),
-            (Boolean(a_bool), Boolean(b_bool)) => a_bool.cmp(b_bool),
-            (DateTime(a_dt), DateTime(b_dt)) => a_dt.cmp(b_dt),
-            (Geo(a), Geo(b)) => a
-                .lat
-                .total_cmp(&b.lat)
-                .then_with(|| a.lon.total_cmp(&b.lon)),
-            (Bytes(_, a_bytes), Bytes(_, b_bytes)) => a_bytes.cmp(b_bytes),
-            (Null, Null) => Ordering::Equal,
-
-            // Mixed types ordering precedence
-            // Null < Bool < Int < Float < Text < Bytes
-            (Null, _) => Ordering::Less,
-            (_, Null) => Ordering::Greater,
-
-            (Boolean(_), _) => Ordering::Less,
-            (_, Boolean(_)) => Ordering::Greater,
-
-            (Integer(_), _) => Ordering::Less,
-            (_, Integer(_)) => Ordering::Greater,
-
-            (Float(_), _) => Ordering::Less,
-            (_, Float(_)) => Ordering::Greater,
-
-            (Text(_), _) => Ordering::Less,
-            (_, Text(_)) => Ordering::Greater,
-
-            (Bytes(_, _), _) => Ordering::Less,
-            (_, Bytes(_, _)) => Ordering::Greater,
-
-            _ => Ordering::Equal, // Fallback
         }
     }
 

--- a/laurus/src/lexical/query/collector.rs
+++ b/laurus/src/lexical/query/collector.rs
@@ -293,6 +293,14 @@ impl PartialOrd for FieldScoredDoc {
 /// `Null` always sorts greatest (last in ascending order), independent
 /// of sort direction; direction is applied by the caller via
 /// [`Ordering::reverse`].
+///
+/// Mixed-type pairs (#945): `Int64` vs `Float64` compare numerically —
+/// a dynamic-schema field can store `42` and `42.5` as different
+/// variants, and a type-priority order would be numerically wrong for
+/// them. Every other mixed pair orders by [`sort_type_rank`], a
+/// deterministic type precedence. Same-rank pairs without a per-type
+/// comparison (e.g. two arrays) compare `Equal`; the caller's doc-id
+/// tie-break keeps the final order deterministic.
 fn compare_sort_key(
     a: &crate::lexical::core::field::FieldValue,
     b: &crate::lexical::core::field::FieldValue,
@@ -306,6 +314,8 @@ fn compare_sort_key(
         (FieldValue::Text(a), FieldValue::Text(b)) => a.cmp(b),
         (FieldValue::Int64(a), FieldValue::Int64(b)) => a.cmp(b),
         (FieldValue::Float64(a), FieldValue::Float64(b)) => a.total_cmp(b),
+        (FieldValue::Int64(a), FieldValue::Float64(b)) => (*a as f64).total_cmp(b),
+        (FieldValue::Float64(a), FieldValue::Int64(b)) => a.total_cmp(&(*b as f64)),
         (FieldValue::Bool(a), FieldValue::Bool(b)) => a.cmp(b),
         (FieldValue::DateTime(a), FieldValue::DateTime(b)) => a.cmp(b),
         (FieldValue::Geo(a), FieldValue::Geo(b)) => a
@@ -313,7 +323,31 @@ fn compare_sort_key(
             .total_cmp(&b.lat)
             .then_with(|| a.lon.total_cmp(&b.lon)),
         (FieldValue::Bytes(a, _), FieldValue::Bytes(b, _)) => a.cmp(b),
-        _ => Ordering::Equal,
+        _ => sort_type_rank(a).cmp(&sort_type_rank(b)),
+    }
+}
+
+/// Deterministic precedence for mixed-type sort-key pairs (#945):
+/// `Bool < numeric < DateTime < Text < Geo < GeoEcef < Bytes < Vector <
+/// Int64Array < Float64Array`. `Null` never reaches this (handled first
+/// in [`compare_sort_key`]); `Int64` and `Float64` share a rank because
+/// they compare numerically instead. Exhaustive on purpose: adding a
+/// `FieldValue` variant must force a rank decision here.
+fn sort_type_rank(v: &crate::lexical::core::field::FieldValue) -> u8 {
+    use crate::lexical::core::field::FieldValue;
+
+    match v {
+        FieldValue::Null => 0,
+        FieldValue::Bool(_) => 1,
+        FieldValue::Int64(_) | FieldValue::Float64(_) => 2,
+        FieldValue::DateTime(_) => 3,
+        FieldValue::Text(_) => 4,
+        FieldValue::Geo(_) => 5,
+        FieldValue::GeoEcef(_) => 6,
+        FieldValue::Bytes(_, _) => 7,
+        FieldValue::Vector(_) => 8,
+        FieldValue::Int64Array(_) => 9,
+        FieldValue::Float64Array(_) => 10,
     }
 }
 
@@ -1091,5 +1125,82 @@ mod tests {
         assert_eq!(collector.total_hits(), 0);
         assert_eq!(collector.results().len(), 0);
         assert!(collector.needs_more());
+    }
+
+    /// #945: `Int64` and `Float64` for the same sort field (dynamic
+    /// schema can store `42` and `42.5` as different variants) must
+    /// compare numerically, not fall to the mixed-type fallback.
+    #[test]
+    fn sort_key_compares_int_and_float_numerically() {
+        use crate::lexical::core::field::FieldValue;
+
+        assert_eq!(
+            compare_sort_key(&FieldValue::Int64(1), &FieldValue::Float64(2.5)),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_sort_key(&FieldValue::Float64(2.5), &FieldValue::Int64(3)),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_sort_key(&FieldValue::Float64(3.5), &FieldValue::Int64(3)),
+            Ordering::Greater
+        );
+        assert_eq!(
+            compare_sort_key(&FieldValue::Int64(2), &FieldValue::Float64(2.0)),
+            Ordering::Equal
+        );
+    }
+
+    /// #945: mixed non-numeric type pairs must order by a deterministic
+    /// type rank instead of collapsing to `Equal`.
+    #[test]
+    fn sort_key_orders_mixed_types_by_rank() {
+        use crate::lexical::core::field::FieldValue;
+
+        // numeric < Text
+        assert_eq!(
+            compare_sort_key(&FieldValue::Int64(999), &FieldValue::Text("a".into())),
+            Ordering::Less
+        );
+        assert_eq!(
+            compare_sort_key(&FieldValue::Text("a".into()), &FieldValue::Float64(999.0)),
+            Ordering::Greater
+        );
+        // Bool < numeric
+        assert_eq!(
+            compare_sort_key(&FieldValue::Bool(true), &FieldValue::Int64(0)),
+            Ordering::Less
+        );
+        // Text < Bytes
+        assert_eq!(
+            compare_sort_key(
+                &FieldValue::Text("z".into()),
+                &FieldValue::Bytes(vec![0], None)
+            ),
+            Ordering::Less
+        );
+    }
+
+    /// #945: the documented `Null`-sorts-greatest contract (#608) must
+    /// hold against mixed types too.
+    #[test]
+    fn sort_key_null_stays_greatest() {
+        use crate::lexical::core::field::FieldValue;
+
+        for other in [
+            FieldValue::Bool(true),
+            FieldValue::Int64(i64::MAX),
+            FieldValue::Float64(f64::INFINITY),
+            FieldValue::Text("zzz".into()),
+            FieldValue::Bytes(vec![255], None),
+        ] {
+            assert_eq!(
+                compare_sort_key(&FieldValue::Null, &other),
+                Ordering::Greater,
+                "Null must sort greatest vs {other:?}"
+            );
+            assert_eq!(compare_sort_key(&other, &FieldValue::Null), Ordering::Less);
+        }
     }
 }


### PR DESCRIPTION
Closes #945

## Summary

`compare_sort_key` — the single source of truth for `TopFieldCollector`'s heap order and output order since #608 — collapsed every mixed-type pair to `Ordering::Equal`, so a dynamic-schema sort field holding several value types produced doc-id order instead of value order among those pairs. Details: [investigation & plan comment](https://github.com/mosuka/laurus/issues/945#issuecomment-5352126539), including one correction to the filed premise: the suggested reuse target `compare_values` turned out to be part of a **dead legacy trio** (`sort_hits` → `compare_field_values` → `compare_values`, all `#[allow(dead_code)]`, zero callers) whose Null convention is the *opposite* of the live comparator's documented contract — so the fix extends `compare_sort_key` instead of reusing it.

- **`Int64` ↔ `Float64` compare numerically** (`1 < 2.5 < 3` regardless of representation) — the realistic dynamic-schema case, where type inference stores `42` and `42.5` as different variants; a type-priority order would be numerically wrong for exactly those pairs.
- **Every other mixed pair orders by a deterministic type rank** (`Bool < numeric < DateTime < Text < Geo < GeoEcef < Bytes < Vector < Int64Array < Float64Array`). The rank match is exhaustive on purpose: adding a `FieldValue` variant forces a rank decision at compile time.
- The documented **`Null`-sorts-greatest contract (#608) is unchanged** and now pinned by a dedicated test. Same-rank pairs without a per-type comparison (e.g. two arrays) stay `Equal`; the doc-id tie-break keeps the final order deterministic (stated in the doc comment).
- **Removes the dead legacy trio** in the searcher (79 lines, self-described as "the old post-collection sorting approach, kept for compatibility") and its orphaned imports — private functions, zero callers, and a conflicting Null convention that would be a hazard if ever resurrected (same rationale as #998).

## Tests (RED-first)

- `sort_key_compares_int_and_float_numerically` — proven RED (`Equal` today), both directions plus the `2 == 2.0` equality case.
- `sort_key_orders_mixed_types_by_rank` — proven RED (`Equal` today) for representative pairs.
- `sort_key_null_stays_greatest` — contract-preservation gate (stays green), asserted against every mixed type.

`cargo test --workspace`: 1884 passed / 0 failed. `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`: clean. No docs impact (mixed-type sort internals are undocumented surface).

## Context

Fourth fix in the #608 spin-off family (#943/#1006 → #942/#1007 → this). Remaining sibling: #944 (IndexSort + early-terminating sorted collection — a feature, not a bug).
