### PR TITLE
perf(lexical): parallelize multi-segment field-sorted search (#944 Phase A)

### DIFF
--- a/laurus/benches/lexical_search_bench.rs
+++ b/laurus/benches/lexical_search_bench.rs
@@ -667,6 +667,70 @@ fn bench_term_query_varying_limit(c: &mut Criterion) {
     group.finish();
 }
 
+/// Field-sorted top-K (#944 Phase A). The corpus's `year` integer field
+/// is DocValues-backed, so `sort_by(year)` exercises the
+/// `TopFieldCollector` path end-to-end. Parameterised over segment
+/// count: the single-segment case measures the scan itself; the
+/// multi-segment case measures the per-segment fanout.
+fn bench_field_sorted_query(c: &mut Criterion) {
+    use laurus::lexical::search::searcher::{SortField, SortOrder};
+
+    let rt = Runtime::new().unwrap();
+    let corpus_n = *corpus_sizes()
+        .last()
+        .expect("corpus_sizes() must be non-empty");
+
+    for &segment_count in &[1usize, 4] {
+        let engine = cached_engine(&rt, EngineShape::Uniform, corpus_n, segment_count);
+
+        // Sanity probe: the sorted search must return hits.
+        let probe = rt.block_on(async {
+            let query = Box::new(TermQuery::new("body", "programming"));
+            let request = SearchRequestBuilder::new()
+                .lexical_query(LexicalSearchQuery::Obj(query))
+                .sort_by(SortField::Field {
+                    name: "year".into(),
+                    order: SortOrder::Desc,
+                })
+                .limit(10)
+                .build();
+            engine.search(request).await.unwrap()
+        });
+        assert!(
+            !probe.is_empty(),
+            "field_sort probe must return at least one hit (corpus={corpus_n}, segments={segment_count})"
+        );
+
+        let mut group = c.benchmark_group(format!("lexical/field_sort/seg_{segment_count}"));
+        apply_sample_size(&mut group, &[corpus_n]);
+
+        for &limit in &[10, 100] {
+            group.bench_with_input(
+                BenchmarkId::new(format!("corpus_{corpus_n}/top"), limit),
+                &limit,
+                |b, &limit| {
+                    b.to_async(&rt).iter(|| {
+                        let engine = &engine;
+                        async move {
+                            let query = Box::new(TermQuery::new("body", "programming"));
+                            let request = SearchRequestBuilder::new()
+                                .lexical_query(LexicalSearchQuery::Obj(query))
+                                .sort_by(SortField::Field {
+                                    name: "year".into(),
+                                    order: SortOrder::Desc,
+                                })
+                                .limit(limit)
+                                .build();
+                            black_box(engine.search(request).await.unwrap())
+                        }
+                    });
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
 fn bench_boolean_query(c: &mut Criterion) {
     let rt = Runtime::new().unwrap();
     let mut group = c.benchmark_group("lexical/boolean_query");
@@ -1181,6 +1245,7 @@ criterion_group!(
     benches,
     bench_term_query,
     bench_term_query_varying_limit,
+    bench_field_sorted_query,
     bench_boolean_query,
     bench_topk_or_skewed_tf,
     bench_topk_or_multi_segment,

--- a/laurus/src/lexical/index/inverted/per_segment_view.rs
+++ b/laurus/src/lexical/index/inverted/per_segment_view.rs
@@ -169,6 +169,23 @@ impl LexicalIndexReader for PerSegmentReaderView {
         seg.doc_ids()
     }
 
+    fn get_doc_value(
+        &self,
+        field: &str,
+        doc_id: u64,
+    ) -> Result<Option<crate::lexical::core::field::FieldValue>> {
+        // Segment-local DocValues so per-segment field-sorted collection
+        // works under the fanout (#944); the trait default returned
+        // `None`, which would sort every document as `Null`.
+        let seg = self.segment.read().unwrap();
+        seg.get_doc_value(field, doc_id)
+    }
+
+    fn has_doc_values(&self, field: &str) -> bool {
+        let seg = self.segment.read().unwrap();
+        seg.has_doc_values(field)
+    }
+
     fn term_info(&self, field: &str, term: &str) -> Result<Option<ReaderTermInfo>> {
         // Combine: global doc_freq / total_freq + per-segment posting
         // offset, max_score_factor, and (critically) the per-segment

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -854,7 +854,7 @@ impl SegmentReader {
     }
 
     /// Get a DocValues field value for a document.
-    fn get_doc_value(&self, field: &str, doc_id: u64) -> Result<Option<FieldValue>> {
+    pub(crate) fn get_doc_value(&self, field: &str, doc_id: u64) -> Result<Option<FieldValue>> {
         // Mirror `document()`: a soft-deleted doc (e.g. the pre-upsert
         // copy in an older segment) must not surface its stale value
         // through the cross-segment first-hit resolution (#943).
@@ -880,7 +880,7 @@ impl SegmentReader {
     }
 
     /// Check if DocValues are available for a field.
-    fn has_doc_values(&self, field: &str) -> bool {
+    pub(crate) fn has_doc_values(&self, field: &str) -> bool {
         // Load on demand so availability is answered correctly even as
         // the first operation on a fresh reader (#943); previously this
         // reported `false` until something else loaded the cache.

--- a/laurus/src/lexical/index/inverted/searcher.rs
+++ b/laurus/src/lexical/index/inverted/searcher.rs
@@ -506,6 +506,142 @@ impl InvertedIndexSearcher {
         Ok(collector)
     }
 
+    /// Field-sorted per-segment fanout (#944 Phase A).
+    ///
+    /// Runs the query independently on every segment with a per-segment
+    /// [`TopFieldCollector`] (in parallel off-wasm), then re-collects
+    /// the per-segment top-K into a fresh global-reader collector so
+    /// ordering — including the doc-id tie-break — matches the
+    /// single-pass path exactly. The merge re-resolves at most
+    /// `limit × segment_count` DocValues.
+    ///
+    /// `total_hits` sums the per-segment totals: segments partition the
+    /// live documents (tombstoned copies are filtered at posting-decode
+    /// level), so the documented true-match-count contract for
+    /// field-sorted searches is preserved.
+    ///
+    /// The generic [`Self::search_per_segment_fanout`] is deliberately
+    /// not reused: it is gated on `bmw_capable()` and hard-codes a
+    /// per-segment [`TopDocsCollector`], both of which are
+    /// score-competitiveness concepts that do not apply to field sort.
+    ///
+    /// # Arguments
+    ///
+    /// * `query` - The query to execute on each segment.
+    /// * `field_name` - The sort field.
+    /// * `ascending` - Sort direction.
+    /// * `limit` - Global top-K (also the per-segment K, so the merge
+    ///   can pick any combination of per-segment hits).
+    /// * `min_score` - Minimum score threshold, applied per segment.
+    /// * `deadline` - Optional cooperative deadline, propagated to each
+    ///   per-segment search.
+    ///
+    /// # Returns
+    ///
+    /// The merged, field-ordered hits and the true total match count.
+    fn search_field_sorted_fanout(
+        &self,
+        query: Box<dyn Query>,
+        field_name: &str,
+        ascending: bool,
+        limit: usize,
+        min_score: f32,
+        deadline: Option<Deadline>,
+    ) -> Result<(Vec<SearchHit>, u64)> {
+        let inverted_reader = self
+            .reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .expect("search_field_sorted_fanout requires InvertedIndexReader");
+
+        let global_doc_count = inverted_reader.doc_count();
+        let global_max_doc = inverted_reader.max_doc();
+        let global_term_info_fn = {
+            let reader_arc = self.reader.clone();
+            std::sync::Arc::new(
+                move |field: &str,
+                      term: &str|
+                      -> Result<Option<crate::lexical::reader::ReaderTermInfo>> {
+                    reader_arc.term_info(field, term)
+                },
+            )
+        };
+        let global_matching_doc_ids_fn = {
+            let reader_arc = self.reader.clone();
+            std::sync::Arc::new(
+                move |query: &dyn Query| -> Result<Arc<roaring::RoaringTreemap>> {
+                    if let Some(inverted) =
+                        reader_arc.as_any().downcast_ref::<InvertedIndexReader>()
+                    {
+                        inverted.matching_doc_ids(query)
+                    } else {
+                        let matcher = query.matcher(reader_arc.as_ref())?;
+                        Ok(Arc::new(
+                            crate::lexical::index::inverted::query_cache::drain_matcher(matcher)?,
+                        ))
+                    }
+                },
+            )
+        };
+
+        let segments = inverted_reader.segment_readers().to_vec();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let segment_iter = segments.par_iter();
+        #[cfg(target_arch = "wasm32")]
+        let segment_iter = segments.iter();
+
+        let per_segment_results: Vec<Result<(Vec<SearchHit>, u64)>> = segment_iter
+            .map(|seg_arc| -> Result<(Vec<SearchHit>, u64)> {
+                let view = PerSegmentReaderView::new(
+                    seg_arc.clone(),
+                    global_doc_count,
+                    global_max_doc,
+                    global_term_info_fn.clone(),
+                    global_matching_doc_ids_fn.clone(),
+                );
+                let view_reader: Arc<dyn LexicalIndexReader> = Arc::new(view);
+                let temp_searcher = InvertedIndexSearcher::from_arc(view_reader);
+                let temp_collector = TopFieldCollector::with_min_score(
+                    limit,
+                    min_score,
+                    field_name.to_string(),
+                    ascending,
+                    temp_searcher.reader.as_ref(),
+                );
+                let collected = temp_searcher.search_with_collector_deadline(
+                    query.clone_box(),
+                    temp_collector,
+                    false,
+                    deadline,
+                )?;
+                Ok((collected.results(), collected.total_hits()))
+            })
+            .collect();
+
+        // Merge: re-collect the per-segment top-K into a global-reader
+        // collector (same comparator + doc-id tie-break as the
+        // single-pass path). `min_score` was already applied per
+        // segment, and scores are unchanged, so re-applying it here is
+        // a no-op either way.
+        let mut merged = TopFieldCollector::with_min_score(
+            limit,
+            min_score,
+            field_name.to_string(),
+            ascending,
+            self.reader.as_ref(),
+        );
+        let mut total_hits = 0u64;
+        for seg_result in per_segment_results {
+            let (seg_hits, seg_total) = seg_result?;
+            total_hits += seg_total;
+            for hit in seg_hits {
+                merged.collect(hit.doc_id, hit.score)?;
+            }
+        }
+        Ok((merged.results(), total_hits))
+    }
+
     /// Execute a BooleanQuery with parallel sub-query execution.
     ///
     /// Each clause is executed in parallel, then boolean logic is applied:
@@ -732,24 +868,42 @@ impl InvertedIndexSearcher {
         // Create collector based on sort type
         let (mut hits, total_hits) = match &params.sort_by {
             SortField::Field { name, order } => {
-                // Use TopFieldCollector for field-based sorting
                 let ascending = matches!(order, SortOrder::Asc);
-                let collector = TopFieldCollector::with_min_score(
-                    params.limit,
-                    params.min_score,
-                    name.clone(),
-                    ascending,
-                    self.reader.as_ref(),
-                );
+                if self
+                    .reader
+                    .as_any()
+                    .downcast_ref::<InvertedIndexReader>()
+                    .is_some_and(|r| r.segment_count() >= 2)
+                {
+                    // Multi-segment: per-segment field-sorted fanout
+                    // (#944 Phase A).
+                    self.search_field_sorted_fanout(
+                        query.clone_box(),
+                        name,
+                        ascending,
+                        params.limit,
+                        params.min_score,
+                        deadline,
+                    )?
+                } else {
+                    // Use TopFieldCollector for field-based sorting
+                    let collector = TopFieldCollector::with_min_score(
+                        params.limit,
+                        params.min_score,
+                        name.clone(),
+                        ascending,
+                        self.reader.as_ref(),
+                    );
 
-                let result_collector = self.search_with_collector_deadline(
-                    query.clone_box(),
-                    collector,
-                    params.parallel,
-                    deadline,
-                )?;
+                    let result_collector = self.search_with_collector_deadline(
+                        query.clone_box(),
+                        collector,
+                        params.parallel,
+                        deadline,
+                    )?;
 
-                (result_collector.results(), result_collector.total_hits())
+                    (result_collector.results(), result_collector.total_hits())
+                }
             }
             SortField::Score => {
                 // Use TopDocsCollector for score-based sorting
@@ -848,24 +1002,41 @@ impl InvertedIndexSearcher {
             // Check if we should use field-based sorting during collection
             match &request.params.sort_by {
                 SortField::Field { name, order } => {
-                    // Use TopFieldCollector for field-based sorting
                     let ascending = matches!(order, SortOrder::Asc);
-                    let collector = TopFieldCollector::with_min_score(
-                        request.params.limit,
-                        request.params.min_score,
-                        name.clone(),
-                        ascending,
-                        self.reader.as_ref(),
-                    );
+                    let (mut hits, total_hits) = if self
+                        .reader
+                        .as_any()
+                        .downcast_ref::<InvertedIndexReader>()
+                        .is_some_and(|r| r.segment_count() >= 2)
+                    {
+                        // Multi-segment: per-segment field-sorted fanout
+                        // (#944 Phase A).
+                        self.search_field_sorted_fanout(
+                            query.clone_box(),
+                            name,
+                            ascending,
+                            request.params.limit,
+                            request.params.min_score,
+                            None,
+                        )?
+                    } else {
+                        // Use TopFieldCollector for field-based sorting
+                        let collector = TopFieldCollector::with_min_score(
+                            request.params.limit,
+                            request.params.min_score,
+                            name.clone(),
+                            ascending,
+                            self.reader.as_ref(),
+                        );
 
-                    let result_collector = self.search_with_collector_parallel(
-                        query.clone_box(),
-                        collector,
-                        request.params.parallel,
-                    )?;
+                        let result_collector = self.search_with_collector_parallel(
+                            query.clone_box(),
+                            collector,
+                            request.params.parallel,
+                        )?;
 
-                    let mut hits = result_collector.results();
-                    let total_hits = result_collector.total_hits();
+                        (result_collector.results(), result_collector.total_hits())
+                    };
 
                     // Load documents if requested
                     if request.params.load_documents {
@@ -1577,6 +1748,57 @@ mod tests {
     /// PR-F follow-up #476 Phase 1: a non-`bmw_capable` collector
     /// (here: `CountCollector`) must skip both the BMW fast path and
     /// the per-segment fanout, so multi-segment count queries still
+    /// #944 Phase A prerequisite: the per-segment view must forward
+    /// DocValues access to its segment — with the trait defaults a
+    /// per-segment `TopFieldCollector` would see every doc as `Null`.
+    #[test]
+    fn per_segment_view_forwards_doc_values() {
+        use crate::lexical::core::field::FieldValue;
+        use crate::lexical::index::inverted::per_segment_view::PerSegmentReaderView;
+        use crate::lexical::index::inverted::writer::{
+            InvertedIndexWriter, InvertedIndexWriterConfig,
+        };
+        use crate::lexical::writer::LexicalIndexWriter;
+
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut writer =
+            InvertedIndexWriter::new(storage, InvertedIndexWriterConfig::default()).unwrap();
+        writer
+            .add_document(
+                crate::Document::builder()
+                    .add_integer("popularity", 42)
+                    .build(),
+            )
+            .unwrap();
+        writer.commit().unwrap();
+        let reader = writer.build_reader().unwrap();
+        let inverted = reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .unwrap();
+        let seg = inverted.segment_readers()[0].clone();
+
+        let view = PerSegmentReaderView::new(
+            seg,
+            inverted.doc_count(),
+            inverted.max_doc(),
+            std::sync::Arc::new(|_: &str, _: &str| Ok(None)),
+            std::sync::Arc::new(|_: &dyn crate::lexical::query::Query| {
+                Ok(std::sync::Arc::new(RoaringTreemap::new()))
+            }),
+        );
+
+        assert!(
+            view.has_doc_values("popularity"),
+            "view must forward has_doc_values to its segment"
+        );
+        let value = view.get_doc_value("popularity", 0).unwrap();
+        assert!(
+            matches!(value, Some(FieldValue::Int64(42))),
+            "view must forward get_doc_value to its segment; got {value:?}"
+        );
+    }
+
     /// hit the legacy aggregation path.
     #[test]
     fn per_segment_fanout_falls_back_for_count_collector() {

--- a/laurus/tests/lexical_field_sort_test.rs
+++ b/laurus/tests/lexical_field_sort_test.rs
@@ -108,14 +108,59 @@ fn field_sort_asc_single_segment() {
 fn field_sort_multi_segment() {
     let (store, _storage) = store_with_segments(4);
     let query: Box<dyn Query> = Box::new(TermQuery::new("body", "alpha"));
-    let ids = field_sorted_ids(
+    let results = store
+        .search(
+            LexicalSearchRequest::new(query)
+                .limit(3)
+                .sort_by_field_desc("popularity"),
+        )
+        .unwrap();
+
+    assert_eq!(
+        results.hits.iter().map(|h| h.doc_id).collect::<Vec<_>>(),
+        vec![9, 8, 7]
+    );
+    // #944 Phase A: the per-segment fanout must preserve the documented
+    // true-match-count contract by summing per-segment totals.
+    assert_eq!(
+        results.total_hits, 12,
+        "total_hits must remain the true match count under the fanout"
+    );
+}
+
+/// #944 Phase A: `min_score` must be honored on the multi-segment
+/// fanout path too (per-segment collectors apply it).
+#[test]
+fn field_sort_multi_segment_with_min_score() {
+    let (store, _storage) = store_with_segments(4);
+    let query: Box<dyn Query> = Box::new(TermQuery::new("body", "alpha"));
+
+    let all = store
+        .search(
+            LexicalSearchRequest::new(query.clone_box())
+                .limit(3)
+                .sort_by_field_desc("popularity"),
+        )
+        .unwrap();
+    let uniform_score = all.hits[0].score;
+
+    let excluded = field_sorted_ids(
+        &store,
+        LexicalSearchRequest::new(query.clone_box())
+            .limit(3)
+            .min_score(uniform_score + 1.0)
+            .sort_by_field_desc("popularity"),
+    );
+    assert!(excluded.is_empty());
+
+    let included = field_sorted_ids(
         &store,
         LexicalSearchRequest::new(query)
             .limit(3)
+            .min_score(0.0)
             .sort_by_field_desc("popularity"),
     );
-
-    assert_eq!(ids, vec![9, 8, 7]);
+    assert_eq!(included, vec![9, 8, 7]);
 }
 
 #[test]


### PR DESCRIPTION
Refs #944 (Phase A of the owner-approved phasing — the issue stays open for the Phase B go/no-go)

## Summary

Field-sorted searches bypassed the per-segment fan-out entirely (the fan-out gate is `bmw_capable`-based and its per-segment collector is hard-coded to `TopDocsCollector`), so a multi-segment sorted search ran a **serial full scan against the global cross-segment reader**. Plan and design constraints: [investigation](https://github.com/mosuka/laurus/issues/944#issuecomment-5353258693) / [Phase A plan](https://github.com/mosuka/laurus/issues/944#issuecomment-5354876292).

- A dedicated `search_field_sorted_fanout` runs the query on every segment in parallel with a per-segment `TopFieldCollector` over a `PerSegmentReaderView`, then re-collects the per-segment top-K into a global-reader collector — same comparator and doc-id tie-break, so ordering matches the single-pass path exactly (≤ limit × segments DocValues re-resolutions in the merge).
- **The documented true-match-count contract is preserved**: `total_hits` sums the per-segment totals (segments partition the live documents; tombstoned copies are filtered at posting decode), now pinned by a multi-segment assertion. No docs changes needed.
- **Prerequisite fix, proven RED first**: `PerSegmentReaderView` lacked `get_doc_value` / `has_doc_values` overrides (trait defaults `None`/`false`), so a per-segment field collector would have sorted every doc as `Null`.
- The generic fan-out, the `Collector` trait, single-segment and score-sorted paths are all untouched. No format or config changes.

## Benchmark (new — the first field-sort bench)

`bench_field_sorted_query` (segments × limit sweep over the corpus's existing `year` field), 5,000 docs, criterion medians on the same idle machine:

| Case | before | after | delta |
| --- | --- | --- | --- |
| seg_1 / top-10 | 150.4 µs | 138.4 µs | unchanged path (±8% run noise) |
| seg_1 / top-100 | 329.2 µs | 322.6 µs | unchanged path (noise) |
| **seg_4 / top-10** | **202.7 µs** | **120.4 µs** | **−41%** |
| seg_4 / top-100 | 368.6 µs | 363.3 µs | −1.5% (noise) |

Top-10 (the common case) shows the parallel win clearly; at top-100 on this small corpus the K×segments merge re-resolution offsets the gain — larger corpora shift the balance toward the fan-out (`LAURUS_BENCH_LARGE` for the 100k corpus when evaluating Phase B).

## Tests

- `per_segment_view_forwards_doc_values` (RED-first) — the prerequisite DV forwarding.
- `field_sort_multi_segment` extended with the `total_hits == true match count` contract assertion; new `field_sort_multi_segment_with_min_score` covers `min_score` plumbing on the fan-out path.
- The whole existing field-sort suite (8 tests) passes unchanged — the multi-segment ones now exercise the new path.

`cargo test --workspace`: 1886 passed / 0 failed. `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`: clean.

## What Phase B would add (left open on #944)

The scan volume itself is unchanged — order-of-magnitude wins for K ≪ N require the `.sortidx` sidecar + opt-in early termination (documented-contract change), to be decided with this benchmark as the measurement base.
