### PR TITLE
perf(engine): resolve search-result documents in one batched, cached pass

### DIFF
--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1581,19 +1581,33 @@ impl Engine {
         Ok(docs)
     }
 
-    /// Check if a field should be stored based on the schema.
+    /// Check if a field should be stored, decided against an
+    /// already-acquired schema guard.
     ///
     /// - `_id`: always stored (system field)
     /// - Lexical fields: stored only if `stored=true`
     /// - Vector fields: always stored
     /// - Unknown fields: not stored
-    fn is_field_stored(&self, name: &str) -> bool {
+    ///
+    /// Takes the guard rather than locking internally so callers that
+    /// test many fields (i.e. [`Self::filter_stored_fields`] and the
+    /// search-result resolver, which run once per returned hit) acquire
+    /// the schema lock once instead of once per field (#1010).
+    ///
+    /// # Arguments
+    ///
+    /// * `schema` - The already-locked schema.
+    /// * `name` - The field name to test.
+    ///
+    /// # Returns
+    ///
+    /// `true` when the field's value is kept in the document store.
+    fn is_field_stored_in(schema: &Schema, name: &str) -> bool {
         use crate::engine::schema::FieldOption;
 
         if name == "_id" {
             return true;
         }
-        let schema = self.schema.read();
         if let Some(field_opt) = schema.fields.get(name) {
             match field_opt {
                 FieldOption::Text(o) => o.stored,
@@ -1617,9 +1631,12 @@ impl Engine {
     /// The document log (WAL) stores ALL fields for recovery, but the
     /// document store only keeps stored fields to save space.
     fn filter_stored_fields(&self, doc: &Document) -> Document {
+        // One schema lock for the whole document, not one per field
+        // (#1010): this runs once per returned search hit.
+        let schema = self.schema.read();
         let mut stored_doc = Document::new();
         for (name, val) in &doc.fields {
-            if self.is_field_stored(name) {
+            if Self::is_field_stored_in(&schema, name) {
                 stored_doc.fields.insert(name.clone(), val.clone());
             }
         }
@@ -1655,19 +1672,36 @@ impl Engine {
         &self,
         internal_ids: &[u64],
     ) -> Result<HashMap<u64, (String, Option<Document>)>> {
+        // One batched store call instead of one lookup per id (#1010):
+        // the store opens each segment file once and seeks in offset
+        // order, and consults / populates the document cache for the
+        // whole batch under a single lock.
+        let mut fetched = self.log.get_documents_batch(internal_ids)?;
+
+        // One schema lock for every document in the batch, rather than
+        // one per field per document (#1010).
+        let schema = self.schema.read();
         let mut results = HashMap::with_capacity(internal_ids.len());
         for &id in internal_ids {
-            if let Some(doc) = self.log.get_document(id)? {
-                let external_id = doc
-                    .fields
-                    .get("_id")
-                    .and_then(|v| v.as_text())
-                    .map(|s| s.to_string())
-                    .unwrap_or_else(|| format!("unknown_{}", id));
-                let filtered = self.filter_stored_fields(&doc);
-                results.insert(id, (external_id, Some(filtered)));
-            } else {
-                results.insert(id, (format!("unknown_{}", id), None));
+            match fetched.remove(&id) {
+                Some(doc) => {
+                    let external_id = doc
+                        .fields
+                        .get("_id")
+                        .and_then(|v| v.as_text())
+                        .map(|s| s.to_string())
+                        .unwrap_or_else(|| format!("unknown_{}", id));
+                    let mut filtered = Document::new();
+                    for (name, val) in doc.fields {
+                        if Self::is_field_stored_in(&schema, &name) {
+                            filtered.fields.insert(name, val);
+                        }
+                    }
+                    results.insert(id, (external_id, Some(filtered)));
+                }
+                None => {
+                    results.insert(id, (format!("unknown_{}", id), None));
+                }
             }
         }
         Ok(results)
@@ -2258,14 +2292,18 @@ impl Engine {
                 .take(request_limit)
                 .collect();
             let ids: Vec<u64> = paginated.iter().map(|h| h.doc_id).collect();
-            let resolved = self.resolve_ids_and_documents_batch(&ids)?;
+            let mut resolved = self.resolve_ids_and_documents_batch(&ids)?;
             let mut results = Vec::with_capacity(paginated.len());
             for hit in paginated {
-                if let Some((external_id, document)) = resolved.get(&hit.doc_id) {
+                // `remove` moves the id and document out instead of
+                // cloning them per hit (#1010). Hits carry distinct doc
+                // ids — they come from a collector's top-K — so no entry
+                // is needed twice.
+                if let Some((external_id, document)) = resolved.remove(&hit.doc_id) {
                     results.push(SearchResult {
-                        id: external_id.clone(),
+                        id: external_id,
                         score: hit.score,
-                        document: document.clone(),
+                        document,
                     });
                 }
             }
@@ -2278,14 +2316,18 @@ impl Engine {
                 .take(request_limit)
                 .collect();
             let ids: Vec<u64> = paginated.iter().map(|h| h.doc_id).collect();
-            let resolved = self.resolve_ids_and_documents_batch(&ids)?;
+            let mut resolved = self.resolve_ids_and_documents_batch(&ids)?;
             let mut results = Vec::with_capacity(paginated.len());
             for hit in paginated {
-                if let Some((external_id, document)) = resolved.get(&hit.doc_id) {
+                // `remove` moves the id and document out instead of
+                // cloning them per hit (#1010). Hits carry distinct doc
+                // ids — they come from a collector's top-K — so no entry
+                // is needed twice.
+                if let Some((external_id, document)) = resolved.remove(&hit.doc_id) {
                     results.push(SearchResult {
-                        id: external_id.clone(),
+                        id: external_id,
                         score: hit.score,
-                        document: document.clone(),
+                        document,
                     });
                 }
             }
@@ -2391,20 +2433,23 @@ impl Engine {
         // Collect IDs that need resolution (either missing external ID or
         // missing document).
         let ids_to_resolve: Vec<u64> = intermediate.iter().map(|(doc_id, _, _)| *doc_id).collect();
-        let resolved = self.resolve_ids_and_documents_batch(&ids_to_resolve)?;
+        let mut resolved = self.resolve_ids_and_documents_batch(&ids_to_resolve)?;
 
         let mut results = Vec::with_capacity(intermediate.len());
         for (doc_id, score, document) in intermediate {
-            if let Some((external_id, resolved_doc)) = resolved.get(&doc_id) {
+            // `remove` moves the id and document out instead of cloning
+            // them per hit (#1010); the fused map is keyed by doc id, so
+            // each entry is wanted exactly once.
+            if let Some((external_id, resolved_doc)) = resolved.remove(&doc_id) {
                 // Prefer the document already fetched by the lexical search;
                 // fall back to the batch-resolved copy.
                 let final_doc = if document.is_some() {
                     document
                 } else {
-                    resolved_doc.clone()
+                    resolved_doc
                 };
                 results.push(SearchResult {
-                    id: external_id.clone(),
+                    id: external_id,
                     score,
                     document: final_doc,
                 });

--- a/laurus/src/store/document.rs
+++ b/laurus/src/store/document.rs
@@ -751,6 +751,23 @@ impl UnifiedDocumentStore {
             }
         }
 
+        // Then the LRU cache, under a single lock for the whole batch
+        // rather than one lock per document as `get_document` takes
+        // (#1010). Without this the batch path bypassed the cache
+        // entirely, so wiring it into the search path would have made
+        // repeated / paginated queries slower.
+        {
+            let mut cache = self.doc_cache.lock();
+            for &doc_id in &id_set {
+                if results.contains_key(&doc_id) {
+                    continue;
+                }
+                if let Some(doc) = cache.get(&doc_id) {
+                    results.insert(doc_id, doc.clone());
+                }
+            }
+        }
+
         // Find remaining IDs not yet resolved.
         let remaining: std::collections::HashSet<u64> = id_set
             .iter()
@@ -762,7 +779,12 @@ impl UnifiedDocumentStore {
             return Ok(results);
         }
 
-        // Batch-load from segments (one file open per segment).
+        // Batch-load from segments (one file open per segment). Segments
+        // are ordered oldest-first and a later one overwrites an earlier
+        // hit, matching `get_document`'s newest-wins resolution (which
+        // reaches the same answer by scanning `.rev()` and taking the
+        // first hit).
+        let mut loaded: HashMap<u64, Document> = HashMap::new();
         for segment in &self.segments {
             let segment_ids: std::collections::HashSet<u64> = remaining
                 .iter()
@@ -775,13 +797,24 @@ impl UnifiedDocumentStore {
 
             if let Some(reader) = self.reader_cache.get(&segment.id) {
                 let batch = reader.get_documents_batch(&segment_ids)?;
-                results.extend(batch);
+                loaded.extend(batch);
             } else {
                 let reader = DocumentSegmentReader::new(self.storage.clone(), segment.clone());
                 let batch = reader.get_documents_batch(&segment_ids)?;
-                results.extend(batch);
+                loaded.extend(batch);
             }
         }
+
+        // Populate the LRU with what we just read, mirroring
+        // `get_document` (#1010), so a repeat of the same query is served
+        // from cache.
+        if !loaded.is_empty() {
+            let mut cache = self.doc_cache.lock();
+            for (doc_id, doc) in &loaded {
+                cache.put(*doc_id, doc.clone());
+            }
+        }
+        results.extend(loaded);
 
         Ok(results)
     }

--- a/laurus/src/store/log.rs
+++ b/laurus/src/store/log.rs
@@ -2156,4 +2156,87 @@ mod tests {
              alongside the retained tail"
         );
     }
+
+    /// #1010: the batch fetch must agree with N individual fetches,
+    /// including the newest-wins resolution when the same doc id exists
+    /// in several committed segments (`get_document` scans segments in
+    /// reverse and takes the first hit; the batch path scans forward and
+    /// overwrites — both must land on the newest copy).
+    #[test]
+    fn get_documents_batch_matches_individual_gets() {
+        let log = make_log();
+
+        let body = |t: &str| {
+            Document::builder()
+                .add_field("body", DataValue::Text(t.to_string()))
+                .build()
+        };
+
+        // Segment 1: docs 1 and 2.
+        log.store_document(1, body("one-old"));
+        log.store_document(2, body("two"));
+        log.commit_documents().unwrap();
+        // Segment 2: doc 1 superseded, doc 3 added.
+        log.store_document(1, body("one-new"));
+        log.store_document(3, body("three"));
+        log.commit_documents().unwrap();
+
+        let ids = [1u64, 2, 3, 999];
+        let batch = log.get_documents_batch(&ids).unwrap();
+
+        for id in ids {
+            let single = log.get_document(id).unwrap();
+            assert_eq!(
+                batch.get(&id).map(|d| d.fields.get("body")),
+                single.as_ref().map(|d| d.fields.get("body")),
+                "batch and single fetch must agree for doc {id}"
+            );
+        }
+        assert_eq!(
+            batch.get(&1).unwrap().fields.get("body"),
+            Some(&DataValue::Text("one-new".to_string())),
+            "the newest copy must win across segments"
+        );
+        assert!(!batch.contains_key(&999), "missing ids must be absent");
+    }
+
+    /// #1010: the batch path now populates and reads the document cache.
+    /// A doc superseded after being cached must still resolve to its new
+    /// content — i.e. the cache stays coherent.
+    #[test]
+    fn get_documents_batch_stays_coherent_after_update() {
+        let log = make_log();
+
+        let body = |t: &str| {
+            Document::builder()
+                .add_field("body", DataValue::Text(t.to_string()))
+                .build()
+        };
+
+        log.store_document(1, body("before"));
+        log.commit_documents().unwrap();
+
+        // Warm the cache through the batch path.
+        let warm = log.get_documents_batch(&[1]).unwrap();
+        assert_eq!(
+            warm.get(&1).unwrap().fields.get("body"),
+            Some(&DataValue::Text("before".to_string()))
+        );
+
+        // Supersede it and re-fetch: the stale cached copy must not win.
+        log.store_document(1, body("after"));
+        log.commit_documents().unwrap();
+
+        let refetched = log.get_documents_batch(&[1]).unwrap();
+        assert_eq!(
+            refetched.get(&1).unwrap().fields.get("body"),
+            Some(&DataValue::Text("after".to_string())),
+            "the batch path must not serve a stale cached document"
+        );
+        // And the single-document path must agree.
+        assert_eq!(
+            log.get_document(1).unwrap().unwrap().fields.get("body"),
+            Some(&DataValue::Text("after".to_string()))
+        );
+    }
 }


### PR DESCRIPTION
Closes #1010

## Summary

`Engine::resolve_ids_and_documents_batch` — reached by **all three search paths** (lexical-only, vector-only, hybrid fusion) — was batched in name only. On the existing limit sweep, the same query over the same corpus took 65.8 µs at limit=10 and 1177 µs at limit=500 *with an identical scan in both*: roughly **2.3 µs of every returned hit was document resolution, not search**. Analysis: [investigation & plan](https://github.com/mosuka/laurus/issues/1010#issuecomment-5356048106).

Three compounding causes, all fixed:

- **The batch API was never used.** The function looped `DocumentLog::get_document` per id, ignoring `DocumentLog::get_documents_batch` (which opens each segment file once and seeks in offset order) — a method that had **no callers anywhere in the repo**. That batch path also neither read nor populated the document LRU that `get_document` uses, so wiring it in as-is would have made repeated and paginated queries *slower*. It now mirrors `get_document`'s three stages: pending docs → **one LRU lock for the whole batch** → segment batch-load for the misses, **populating the LRU** with what it read.
- **The schema lock was taken per field.** `filter_stored_fields` called `is_field_stored` per field, each acquiring `schema.read()` — five acquisitions for a five-field document, per hit. The decision now takes an already-held guard, so the lock is acquired once per batch; the now-callerless `is_field_stored` is removed.
- **Redundant deep clones.** The three result loops borrowed from the resolved map and cloned both the external id and the `Document` per hit; they now consume the map, and the field filter consumes the fetched document's fields instead of cloning them — **two fewer deep clones per returned hit**.

## Measurement

Separate-session before/after numbers proved unreliable (a "cold" run came out faster than "warm", and limit=10 swung 2× — neither explainable by this change; the idle check in use also matched its own process). Those were discarded and replaced by an **interleaved after → before → after run in a single session** (`git stash` between builds), so A1/A2 bracket B1 and expose any environment drift.

| limit | A1 (after) | **B1 (before)** | A2 (after) | improvement |
| --- | --- | --- | --- | --- |
| 10 | 32.1 µs | **65.8 µs** | 43.2 µs | −34% … −51% |
| 50 | 84.0 µs | **135.6 µs** | 100.0 µs | −26% … −38% |
| 100 | 159.0 µs | **234.6 µs** | 162.3 µs | −31% … −32% |
| 500 | 688.8 µs | **1177.2 µs** | 787.1 µs | −33% … −41% |

The A1↔A2 spread (up to ~35%) is the environment's noise band; **B1 lies outside the after range at every limit**, so the improvement is larger than the noise. Per-hit resolution cost, taken as the slope `(t500 − t10)/490`: **2.27 µs → 1.34 µs (A1) / 1.52 µs (A2)**, i.e. ~1.5–1.7× faster per returned hit.

A separate "cold" run was planned but is not meaningful here: `LAURUS_BENCH_REBUILD` forces a *corpus* rebuild (setup), not a cold document cache. Each bench run constructs a fresh `Engine`, so the document LRU starts empty and warms during criterion's warm-up — meaning the measured window is always LRU-warm, which is precisely the condition where the newly added cache population could regress. The table above is that check.

## Tests

- `get_documents_batch_matches_individual_gets` — batch agrees with N individual fetches, **including newest-wins for a doc id present in several segments** (`get_document` scans segments in reverse and takes the first hit; the batch path scans forward and overwrites — both must land on the newest copy), plus missing-id handling.
- `get_documents_batch_stays_coherent_after_update` — the gate for the newly added LRU population: a document superseded after being cached must resolve to its new content through both the batch and single paths.

`cargo test --workspace`: 1888 passed / 0 failed. `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`: clean. No docs changes — public behavior and contracts are unchanged.

## Context

Found while scoping #944 Phase B: the new field-sort benchmark showed a K-dependent cost that the scan could not explain. #944 stays open for its Phase B decision, which this change also makes easier to evaluate — its benchmark will now reflect scan cost more directly.
