### PR TITLE
fix(lint): restore CI on Rust 1.98

### DIFF
--- a/laurus-server/src/gateway.rs
+++ b/laurus-server/src/gateway.rs
@@ -3,6 +3,13 @@
 //! Provides HTTP/JSON endpoints that act as a proxy to the gRPC server.
 //! `User Request (HTTP/JSON) → gRPC Gateway (axum) → gRPC Server (tonic) → Engine`
 
+// Handlers reject with axum's own `Response`, the idiomatic rejection
+// shape for this framework. At 128 bytes it trips `result_large_err`
+// (raised to an error by `-D warnings` since Rust 1.98), but the type is
+// axum's, not ours: boxing it would add an allocation to every error
+// path without shrinking anything we control.
+#![allow(clippy::result_large_err)]
+
 mod convert;
 mod document;
 mod error;

--- a/laurus/benches/common.rs
+++ b/laurus/benches/common.rs
@@ -194,8 +194,8 @@ pub fn load_fvecs(
         }
         reader.read_exact(&mut vec_buf)?;
         let mut v = Vec::with_capacity(dim);
-        for chunk in vec_buf.chunks_exact(4) {
-            v.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        for chunk in vec_buf.as_chunks::<4>().0 {
+            v.push(f32::from_le_bytes(*chunk));
         }
         out.push(v);
         if let Some(cap) = max

--- a/laurus/examples/pq_brute_force_probe.rs
+++ b/laurus/examples/pq_brute_force_probe.rs
@@ -69,8 +69,8 @@ fn read_fvecs(path: &Path, expect_dim: usize, max: Option<usize>) -> Vec<Vec<f32
         assert_eq!(dim, expect_dim, "dim mismatch in {}", path.display());
         reader.read_exact(&mut vec_buf).expect("vec body");
         let mut v = Vec::with_capacity(dim);
-        for chunk in vec_buf.chunks_exact(4) {
-            v.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        for chunk in vec_buf.as_chunks::<4>().0 {
+            v.push(f32::from_le_bytes(*chunk));
         }
         out.push(v);
         if let Some(cap) = max

--- a/laurus/examples/sift_rerank_probe.rs
+++ b/laurus/examples/sift_rerank_probe.rs
@@ -66,8 +66,8 @@ fn read_fvecs(path: &Path, expect_dim: usize, max: Option<usize>) -> Vec<Vec<f32
         assert_eq!(dim, expect_dim, "dim mismatch in {}", path.display());
         reader.read_exact(&mut vec_buf).expect("vec body");
         let mut v = Vec::with_capacity(dim);
-        for chunk in vec_buf.chunks_exact(4) {
-            v.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        for chunk in vec_buf.as_chunks::<4>().0 {
+            v.push(f32::from_le_bytes(*chunk));
         }
         out.push(v);
         if let Some(cap) = max

--- a/laurus/src/util/simd.rs
+++ b/laurus/src/util/simd.rs
@@ -12,8 +12,7 @@ pub mod ascii {
         let mut result = Vec::with_capacity(bytes.len());
 
         // Process 8 bytes at a time for better cache efficiency
-        let chunks = bytes.chunks_exact(8);
-        let remainder = chunks.remainder();
+        let (chunks, remainder) = bytes.as_chunks::<8>();
 
         for chunk in chunks {
             let mut processed = [0u8; 8];
@@ -65,11 +64,10 @@ pub mod ascii {
             return input.iter().position(|&b| b.is_ascii_whitespace());
         }
 
-        let mut chunks = input.chunks_exact(8);
-        let remainder = chunks.remainder();
+        let (chunks, remainder) = input.as_chunks::<8>();
         let mut chunk_idx = 0;
 
-        for chunk in &mut chunks {
+        for chunk in chunks {
             for (byte_idx, &byte) in chunk.iter().enumerate() {
                 if byte == b' ' || byte == b'\t' || byte == b'\n' || byte == b'\r' {
                     return Some(chunk_idx * 8 + byte_idx);
@@ -115,13 +113,12 @@ pub mod numeric {
         let k1_plus_1 = f32x8::splat(k1 + 1.0);
         let k1_vec = f32x8::splat(k1);
 
-        let tf_chunks = term_freqs.chunks_exact(8);
-        let norm_chunks = norm_factors.chunks_exact(8);
-        let tf_remainder = tf_chunks.remainder();
+        let (tf_chunks, tf_remainder) = term_freqs.as_chunks::<8>();
+        let (norm_chunks, _) = norm_factors.as_chunks::<8>();
 
-        for (tf_chunk, norm_chunk) in tf_chunks.zip(norm_chunks) {
-            let tf = f32x8::from(tf_chunk);
-            let norm = f32x8::from(norm_chunk);
+        for (tf_chunk, norm_chunk) in tf_chunks.iter().zip(norm_chunks) {
+            let tf = f32x8::from(*tf_chunk);
+            let norm = f32x8::from(*norm_chunk);
             // BM25 TF: tf * (k1 + 1) / (tf + k1 * norm)
             let numerator = tf * k1_plus_1;
             let denominator = tf + k1_vec * norm;
@@ -160,15 +157,16 @@ pub mod numeric {
         let len = tf_scores.len();
         let mut results = Vec::with_capacity(len);
 
-        let tf_chunks = tf_scores.chunks_exact(8);
-        let idf_chunks = idf_scores.chunks_exact(8);
-        let boost_chunks = boosts.chunks_exact(8);
-        let tf_remainder = tf_chunks.remainder();
+        let (tf_chunks, tf_remainder) = tf_scores.as_chunks::<8>();
+        let (idf_chunks, _) = idf_scores.as_chunks::<8>();
+        let (boost_chunks, _) = boosts.as_chunks::<8>();
 
-        for ((tf_chunk, idf_chunk), boost_chunk) in tf_chunks.zip(idf_chunks).zip(boost_chunks) {
-            let tf = f32x8::from(tf_chunk);
-            let idf = f32x8::from(idf_chunk);
-            let boost = f32x8::from(boost_chunk);
+        for ((tf_chunk, idf_chunk), boost_chunk) in
+            tf_chunks.iter().zip(idf_chunks).zip(boost_chunks)
+        {
+            let tf = f32x8::from(*tf_chunk);
+            let idf = f32x8::from(*idf_chunk);
+            let boost = f32x8::from(*boost_chunk);
             let result = idf * tf * boost;
             results.extend_from_slice(&result.to_array());
         }

--- a/laurus/src/vector/core/distance.rs
+++ b/laurus/src/vector/core/distance.rs
@@ -129,14 +129,12 @@ impl DistanceMetric {
         let mut norm_a_sum = f32x8::ZERO;
         let mut norm_b_sum = f32x8::ZERO;
 
-        let chunks_a = a.chunks_exact(8);
-        let chunks_b = b.chunks_exact(8);
-        let rem_a = chunks_a.remainder();
-        let rem_b = chunks_b.remainder();
+        let (chunks_a, rem_a) = a.as_chunks::<8>();
+        let (chunks_b, rem_b) = b.as_chunks::<8>();
 
-        for (ca, cb) in chunks_a.zip(chunks_b) {
-            let va = f32x8::from(ca);
-            let vb = f32x8::from(cb);
+        for (ca, cb) in chunks_a.iter().zip(chunks_b) {
+            let va = f32x8::from(*ca);
+            let vb = f32x8::from(*cb);
             dot_sum += va * vb;
             norm_a_sum += va * va;
             norm_b_sum += vb * vb;
@@ -168,14 +166,12 @@ impl DistanceMetric {
         let mut dot_sum = f32x8::ZERO;
         let mut norm_b_sum = f32x8::ZERO;
 
-        let chunks_a = a.chunks_exact(8);
-        let chunks_b = b.chunks_exact(8);
-        let rem_a = chunks_a.remainder();
-        let rem_b = chunks_b.remainder();
+        let (chunks_a, rem_a) = a.as_chunks::<8>();
+        let (chunks_b, rem_b) = b.as_chunks::<8>();
 
-        for (ca, cb) in chunks_a.zip(chunks_b) {
-            let va = f32x8::from(ca);
-            let vb = f32x8::from(cb);
+        for (ca, cb) in chunks_a.iter().zip(chunks_b) {
+            let va = f32x8::from(*ca);
+            let vb = f32x8::from(*cb);
             dot_sum += va * vb;
             norm_b_sum += vb * vb;
         }
@@ -197,13 +193,11 @@ impl DistanceMetric {
         use wide::f32x8;
 
         let mut sum = f32x8::ZERO;
-        let chunks_a = a.chunks_exact(8);
-        let chunks_b = b.chunks_exact(8);
-        let rem_a = chunks_a.remainder();
-        let rem_b = chunks_b.remainder();
+        let (chunks_a, rem_a) = a.as_chunks::<8>();
+        let (chunks_b, rem_b) = b.as_chunks::<8>();
 
-        for (ca, cb) in chunks_a.zip(chunks_b) {
-            sum += f32x8::from(ca) * f32x8::from(cb);
+        for (ca, cb) in chunks_a.iter().zip(chunks_b) {
+            sum += f32x8::from(*ca) * f32x8::from(*cb);
         }
 
         let mut dot_product: f32 = sum.reduce_add();
@@ -218,13 +212,11 @@ impl DistanceMetric {
         use wide::f32x8;
 
         let mut sum = f32x8::ZERO;
-        let chunks_a = a.chunks_exact(8);
-        let chunks_b = b.chunks_exact(8);
-        let rem_a = chunks_a.remainder();
-        let rem_b = chunks_b.remainder();
+        let (chunks_a, rem_a) = a.as_chunks::<8>();
+        let (chunks_b, rem_b) = b.as_chunks::<8>();
 
-        for (ca, cb) in chunks_a.zip(chunks_b) {
-            let diff = f32x8::from(ca) - f32x8::from(cb);
+        for (ca, cb) in chunks_a.iter().zip(chunks_b) {
+            let diff = f32x8::from(*ca) - f32x8::from(*cb);
             sum += diff * diff;
         }
 
@@ -240,14 +232,12 @@ impl DistanceMetric {
         use wide::f32x8;
 
         let mut sum = f32x8::ZERO;
-        let chunks_a = a.chunks_exact(8);
-        let chunks_b = b.chunks_exact(8);
-        let rem_a = chunks_a.remainder();
-        let rem_b = chunks_b.remainder();
+        let (chunks_a, rem_a) = a.as_chunks::<8>();
+        let (chunks_b, rem_b) = b.as_chunks::<8>();
 
-        for (ca, cb) in chunks_a.zip(chunks_b) {
-            let va = f32x8::from(ca);
-            let vb = f32x8::from(cb);
+        for (ca, cb) in chunks_a.iter().zip(chunks_b) {
+            let va = f32x8::from(*ca);
+            let vb = f32x8::from(*cb);
             sum += (va - vb).abs();
         }
 
@@ -277,10 +267,9 @@ impl DistanceMetric {
             DistanceMetric::Cosine | DistanceMetric::Angular => {
                 use wide::f32x8;
                 let mut sum = f32x8::ZERO;
-                let chunks = query.chunks_exact(8);
-                let rem = chunks.remainder();
+                let (chunks, rem) = query.as_chunks::<8>();
                 for c in chunks {
-                    let v = f32x8::from(c);
+                    let v = f32x8::from(*c);
                     sum += v * v;
                 }
                 let mut s: f32 = sum.reduce_add();

--- a/laurus/src/vector/core/distance_quantized.rs
+++ b/laurus/src/vector/core/distance_quantized.rs
@@ -269,11 +269,9 @@ pub fn dot_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
 pub fn dot_u8_to_i32_scalar(a: &[u8], b: &[u8]) -> i32 {
     debug_assert_eq!(a.len(), b.len());
     let mut acc = i32x8::ZERO;
-    let chunks_a = a.chunks_exact(8);
-    let chunks_b = b.chunks_exact(8);
-    let rem_a = chunks_a.remainder();
-    let rem_b = chunks_b.remainder();
-    for (ca, cb) in chunks_a.zip(chunks_b) {
+    let (chunks_a, rem_a) = a.as_chunks::<8>();
+    let (chunks_b, rem_b) = b.as_chunks::<8>();
+    for (ca, cb) in chunks_a.iter().zip(chunks_b) {
         let va = i32x8::from([
             ca[0] as i32,
             ca[1] as i32,
@@ -334,11 +332,9 @@ pub fn sq_diff_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
 pub fn sq_diff_u8_to_i32_scalar(a: &[u8], b: &[u8]) -> i32 {
     debug_assert_eq!(a.len(), b.len());
     let mut acc = i32x8::ZERO;
-    let chunks_a = a.chunks_exact(8);
-    let chunks_b = b.chunks_exact(8);
-    let rem_a = chunks_a.remainder();
-    let rem_b = chunks_b.remainder();
-    for (ca, cb) in chunks_a.zip(chunks_b) {
+    let (chunks_a, rem_a) = a.as_chunks::<8>();
+    let (chunks_b, rem_b) = b.as_chunks::<8>();
+    for (ca, cb) in chunks_a.iter().zip(chunks_b) {
         let va = i32x8::from([
             ca[0] as i32,
             ca[1] as i32,
@@ -400,11 +396,9 @@ pub fn abs_diff_u8_to_i32(a: &[u8], b: &[u8]) -> i32 {
 pub fn abs_diff_u8_to_i32_scalar(a: &[u8], b: &[u8]) -> i32 {
     debug_assert_eq!(a.len(), b.len());
     let mut acc = i32x8::ZERO;
-    let chunks_a = a.chunks_exact(8);
-    let chunks_b = b.chunks_exact(8);
-    let rem_a = chunks_a.remainder();
-    let rem_b = chunks_b.remainder();
-    for (ca, cb) in chunks_a.zip(chunks_b) {
+    let (chunks_a, rem_a) = a.as_chunks::<8>();
+    let (chunks_b, rem_b) = b.as_chunks::<8>();
+    for (ca, cb) in chunks_a.iter().zip(chunks_b) {
         let va = i32x8::from([
             ca[0] as i32,
             ca[1] as i32,

--- a/laurus/src/vector/core/quantization.rs
+++ b/laurus/src/vector/core/quantization.rs
@@ -499,13 +499,11 @@ fn l2_squared_slice(a: &[f32], b: &[f32]) -> f32 {
 
     debug_assert_eq!(a.len(), b.len());
     let mut acc = f32x8::ZERO;
-    let chunks_a = a.chunks_exact(8);
-    let chunks_b = b.chunks_exact(8);
-    let rem_a = chunks_a.remainder();
-    let rem_b = chunks_b.remainder();
+    let (chunks_a, rem_a) = a.as_chunks::<8>();
+    let (chunks_b, rem_b) = b.as_chunks::<8>();
 
-    for (ca, cb) in chunks_a.zip(chunks_b) {
-        let diff = f32x8::from(ca) - f32x8::from(cb);
+    for (ca, cb) in chunks_a.iter().zip(chunks_b) {
+        let diff = f32x8::from(*ca) - f32x8::from(*cb);
         acc += diff * diff;
     }
 

--- a/laurus/tests/vector_recall_test.rs
+++ b/laurus/tests/vector_recall_test.rs
@@ -951,8 +951,8 @@ fn read_fvecs_unit_norm(
         assert_eq!(dim, expect_dim, "dim mismatch in {}", path.display());
         reader.read_exact(&mut vec_buf).expect("vec body");
         let mut v = Vec::with_capacity(dim);
-        for chunk in vec_buf.chunks_exact(4) {
-            v.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+        for chunk in vec_buf.as_chunks::<4>().0 {
+            v.push(f32::from_le_bytes(*chunk));
         }
         let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
         if norm > 0.0 {


### PR DESCRIPTION
Closes #1013

CI has been red on every branch since 2026-08-21. No code caused it: Rust **1.98.0** (released 2026-08-18) reached the runners, and every workflow installs the toolchain with `dtolnay/rust-toolchain@stable` with no `rust-toolchain.toml` pinning it. main's last green run was 2026-08-20 on 1.97.1, so **any PR opened from 2026-08-21 onward fails regardless of its contents** — #1012 is currently blocked by exactly this.

The CI log understates the problem: `laurus` (lib) stops compiling at the first lint, so only one of the two failures is visible there. Reproducing locally on 1.98.0 surfaces both.

## `chunks_exact_to_as_chunks` — new lint, 30 sites

`as_chunks::<N>()` returns `(&[[T; N]], &[T])`, so the `chunks_exact(N)` + `.remainder()` pair collapses into a single binding:

```rust
// before
let chunks_a = a.chunks_exact(8);
let chunks_b = b.chunks_exact(8);
let rem_a = chunks_a.remainder();
let rem_b = chunks_b.remainder();
for (ca, cb) in chunks_a.zip(chunks_b) {
    let va = f32x8::from(ca);

// after
let (chunks_a, rem_a) = a.as_chunks::<8>();
let (chunks_b, rem_b) = b.as_chunks::<8>();
for (ca, cb) in chunks_a.iter().zip(chunks_b) {
    let va = f32x8::from(*ca);
```

The element type changes from `&[T]` to `&[T; N]`. Indexing (`ca[0]`), `.iter()` and `f32::from_le_bytes` all accept that unchanged — in the byte-decoding loops the `try_into().unwrap()` disappears entirely, which is a small correctness win too.

Touched: `laurus/src/util/simd.rs`, `laurus/src/vector/core/{distance,distance_quantized,quantization}.rs`, `laurus/benches/common.rs`, `laurus/examples/{sift_rerank_probe,pq_brute_force_probe}.rs`, `laurus/tests/vector_recall_test.rs`.

## `result_large_err` — 10 sites, allowed rather than rewritten

The gateway handlers return `Result<Json<Value>, Response>`, where the error is **axum's own `Response`** at 128 bytes — the idiomatic rejection shape for the framework. The lint's suggestion is to box it, but that would add an allocation to every error path without shrinking anything this repo owns.

So `laurus-server/src/gateway.rs` carries a module-level `#![allow(clippy::result_large_err)]` with the reason in a comment. A parent module's lint attribute covers modules declared with `mod x;`, so one site covers all six gateway files.

## Verification

- `cargo clippy --all-targets --features embeddings-all -- -D warnings` on **Rust 1.98.0** — exit 0. This is the exact command CI runs.
- `cargo fmt --all --check` — exit 0.
- `cargo test --workspace` — **1895 passed / 0 failed**.

No behaviour change is intended: this is a mechanical slice-API migration plus one documented `allow`.

## Note on performance

`as_chunks` touches the SIMD distance kernels, which previous work (#652, #837) tuned. Benchmarks on the development host are currently noise-dominated, so I did not attempt to measure a delta and am not claiming one. The generated code should be at least equivalent — a statically-known chunk length is precisely why the lint exists — but that is reasoning, not a measurement.

## Follow-up worth considering (not in this PR)

CI implicitly tracking `stable` means any Rust release can break every open PR without warning, as it just did. Pinning through `rust-toolchain.toml` would turn toolchain upgrades into a deliberate, reviewable change. Noted in #1013 rather than bundled into the unblock.
