### PR TITLE
perf(lexical/index): make the posting weights section optional (format v3)

### DIFF
--- a/docs/ja/src/concepts/indexing/lexical_indexing.md
+++ b/docs/ja/src/concepts/indexing/lexical_indexing.md
@@ -65,13 +65,55 @@ Posting List の各エントリには以下の情報が含まれます。
 | Document ID | 内部 `u64` 識別子 |
 | Term Frequency | そのドキュメント内でタームが出現する回数 |
 | Positions（オプション） | ドキュメント内でタームが出現する位置（フレーズクエリに必要） |
-| Weight | このポスティングのスコアウェイト |
+| Weight | このポスティングのスコアウェイト。既定値は `1.0` で、Laurus が書き出すポスティングは常にこの値を持つ。リスト内のすべてのウェイトが `1.0` の場合、ウェイトセクションはディスクから完全に省かれる（v3） |
+
+### On-Disk Posting レイアウト
+
+Posting list は **structure-of-arrays** レイアウトで保存され、各フィールドが
+それぞれ連続したセクションに書かれます。ドキュメント ID とターム頻度は
+固定長の **128 整数ブロック**単位でビットパックされ（ドキュメント ID は
+Frame-of-Reference + ソート済みデルタ）、端数の末尾ブロックは varint に
+フォールバックします。これは Tantivy および Lucene 9 が採用する on-disk
+形式と同じで、[`bitpacking`](https://crates.io/crates/bitpacking) クレートに
+よる SIMD デコードが効きます。
+
+```text
+[term, total_frequency, doc_frequency, posting_count N, any_positions, any_weights]
+[Skip levels              — v2 以降: num_levels + レベルごと (len + u32 doc_ids)]
+[Section 1: doc_ids       — N/128 ビットパックブロック + varint 末尾]
+[Section 2: frequencies   — N/128 ビットパックブロック + varint 末尾]
+[Section 3: weights       — N 個の生 f32（any_weights == 1 のときのみ）]
+[Section 4: positions     — ポスティングごとのフラグ + varint デルタ（存在する場合のみ）]
+```
+
+2 つのヘッダフラグが 2 つの省略可能セクションを制御します。`any_positions` は
+従来から Section 4 を制御しており、`any_weights` は **v3** で追加され、同じ形で
+Section 3 を制御します。Laurus が書き出すポスティングは常に既定値 `1.0` の
+ウェイトを持つため、writer が生成するセグメントでは Section 3 が常に省かれ、
+posting list は v2 と比べて `4N - 1` バイト小さくなります ── ポスティング
+あたり 4 バイトの削減から、リストあたり 1 バイトのフラグを差し引いた値です。
+10 億ポスティングでは、書き込み・読み出し・キャッシュのいずれもしなくて
+済むバイト数が約 4 GB になります。
+
+この削減によって形式が lossy になることはありません。`1.0` 以外のウェイトが
+1 つでもあればフラグが立って Section 3 が復活し、すべての値が厳密に往復します。
+
+セグメント内のドキュメント ID は `u32` に収まる必要があります。`u32::MAX` を
+超える値のエンコードは、ビットパックされたセグメントを黙って破損させないよう、
+明確なエラーで即座に失敗します。
+
+デコーダは SoA ネイティブの高速パス（`PostingList::decode_soa`）を提供し、
+中間的な `Vec<Posting>` の再構築を挟まずに `doc_id` と `frequency` の
+parallel な `Vec<u32>` スライスをディスクから直接生成します。クエリ
+イテレータはこのスライスを保持するため、`next()` は 40 バイトの `Posting`
+構造体をストライドせず、密なスライス上で `u32` カーソルを 1 つ進めるだけで
+済みます。
 
 ### Multi-Level Skip Table
 
 `N ≥ 8` ポスティングを持つ posting list はヘッダ直後に
-Lucene-90 互換のマルチレベルスキップテーブル（v2 フォーマット）を
-持ちます。各レベルは `doc_ids` 上の固定ストライド窓の "末尾 doc id" を
+Lucene-90 互換のマルチレベルスキップテーブル（v2 フォーマットで導入され、
+v3 でも変更なし）を持ちます。各レベルは `doc_ids` 上の固定ストライド窓の "末尾 doc id" を
 保持し、レベル 0 は `SKIP_INTERVAL = 8` ポスティングごとに 1 エントリ、
 レベル 1 は `8²`、トップレベルは 1 エントリに収束するまで重ねます。
 
@@ -83,9 +125,12 @@ Lucene-90 互換のマルチレベルスキップテーブル（v2 フォーマ�
 `O(N / block_size)` ウォークと比べて大幅に少なくなります。
 
 スキップテーブルは Lucene 9 / Tantivy と同様に posting list の
-ファイル内に同居させ、別ファイル化はしません。スキップテーブルが
-on-disk に保存されていない v1 形式のセグメントもそのまま読めます ──
-SoA デコーダがロード時に `doc_ids` から再構築します。
+ファイル内に同居させ、別ファイル化はしません。古いセグメントもそのまま
+読めます ── スキップテーブルを on-disk に持たない v1 形式は SoA デコーダが
+ロード時に `doc_ids` から再構築し、v2 形式は無条件のウェイトセクションを
+そのまま読みます。どのデコーダを使うかは、マジックとバージョン番号を持つ
+唯一のセグメント単位ファイルである `.dict` のバージョンで決まるため、
+posting のペイロード自体を推測的に読む必要はありません。
 
 ### Term Dictionary の 2 層構造
 
@@ -93,7 +138,7 @@ SoA デコーダがロード時に `doc_ids` から再構築します。
 それぞれの最適化目標を分離しています。
 
 - **ディスク層** — `.dict` ファイルは Lucene `BlockTreeTermsWriter`
-  風のブロックツリーレイアウト（マジック `LTDD`、スキーマ v1）。
+  風のブロックツリーレイアウト（マジック `LTDD`、スキーマ v3）。
   100k ユニーク 5-10 バイトタームのコーパスで `.dict` は ~12.5
   バイト/ターム と、旧 parallel-array 形式比 **約 70% 削減**
 - **メモリ層** — build / load 時に `AHashMap<term, ordinal>` 索引、
@@ -184,7 +229,7 @@ graph TB
 
 | ファイル拡張子 | 内容 |
 | :--- | :--- |
-| `.dict` | Term Dictionary。v1 `LTDD` ブロックツリーレイアウト（FST + 128 ターム単位の front-coded ブロック + bit-packed `TermInfo`）。セグメント open 時に `AHashMap` バックの in-memory クエリ層へ展開 |
+| `.dict` | Term Dictionary。v3 `LTDD` ブロックツリーレイアウト（FST + 128 ターム単位の front-coded ブロック + bit-packed `TermInfo`）。セグメント open 時に `AHashMap` バックの in-memory クエリ層へ展開 |
 | `.post` | Posting Lists（ドキュメント ID、ターム頻度、位置情報） |
 | `.bkd` | 数値・日付・`Geo`（2D）・`Geo3d`（3D ECEF）フィールドの [BKD ツリー](../bkd_tree.md) データ |
 | `.docs` | 格納されたフィールド値（元のドキュメント内容） |

--- a/docs/src/concepts/indexing/lexical_indexing.md
+++ b/docs/src/concepts/indexing/lexical_indexing.md
@@ -65,7 +65,7 @@ Each entry in a posting list contains:
 | Document ID | Internal `u64` identifier (per-segment value must fit in `u32`) |
 | Term Frequency | How many times the term appears in this document |
 | Positions (optional) | Where in the document the term appears (needed for phrase queries) |
-| Weight | Score weight for this posting |
+| Weight | Score weight for this posting. Defaults to `1.0`, which is what every posting written by Laurus carries; a list in which every weight is `1.0` omits the weights section from disk entirely (v3) |
 
 ### On-Disk Posting Layout
 
@@ -78,13 +78,25 @@ yields fast SIMD-accelerated decoding through the
 [`bitpacking`](https://crates.io/crates/bitpacking) crate.
 
 ```text
-[term, total_frequency, doc_frequency, posting_count N, any_positions]
-[Skip levels              — v2 only: num_levels + per-level (len + u32 doc_ids)]
+[term, total_frequency, doc_frequency, posting_count N, any_positions, any_weights]
+[Skip levels              — v2 onward: num_levels + per-level (len + u32 doc_ids)]
 [Section 1: doc_ids       — N/128 bit-packed blocks + varint tail]
 [Section 2: frequencies   — N/128 bit-packed blocks + varint tail]
-[Section 3: weights       — N raw f32 values]
+[Section 3: weights       — N raw f32 values (only when any_weights == 1)]
 [Section 4: positions     — per-posting flag + varint deltas (only if any)]
 ```
+
+Two header flags gate the two optional sections. `any_positions` has always
+gated Section 4; `any_weights` was added in **v3** and gates Section 3 the
+same way. Because every posting Laurus writes carries the default weight of
+`1.0`, Section 3 is absent from every segment the writer produces, and a
+posting list is `4N - 1` bytes smaller than its v2 equivalent — four bytes
+recovered per posting, less the one flag byte per list. At a billion
+postings that is roughly 4 GB that no longer has to be written, read, or
+cached.
+
+The saving does not make the format lossy: a single weight other than `1.0`
+sets the flag, restores Section 3, and every value round-trips exactly.
 
 Per-segment doc IDs must fit in `u32`. Encoding a value beyond `u32::MAX`
 fails fast with a clear error to prevent silent corruption of the
@@ -99,8 +111,9 @@ over a dense slice instead of striding across a 40-byte `Posting` struct.
 ### Multi-Level Skip Table
 
 A posting list of `N ≥ 8` postings carries a Lucene-90-style
-multi-level skip table immediately after the header (v2 format,
-introduced for `skip_to` performance on seek-heavy workloads).
+multi-level skip table immediately after the header (introduced in
+the v2 format for `skip_to` performance on seek-heavy workloads, and
+unchanged in v3).
 Each level stores the "last doc id" of a fixed-stride window over
 `doc_ids`; level 0 has one entry per `SKIP_INTERVAL = 8` postings,
 level 1 covers `8²` postings, and so on until the top level
@@ -115,9 +128,13 @@ is `O(log_8 N + SKIP_INTERVAL)` per call — for `N = 1 M` that is
 single-level `block_cache` paid before.
 
 The table is co-located with the posting list rather than stored in a
-separate file, matching Lucene 9 / Tantivy. Segments written in the
-legacy v1 format (without the on-disk skip table) remain readable —
-the SoA decoder rebuilds the table from `doc_ids` at load time.
+separate file, matching Lucene 9 / Tantivy. Older segments remain
+readable: v1 segments (without the on-disk skip table) have it rebuilt
+from `doc_ids` at load time, and v2 segments are read with their
+unconditional weights section intact. Which decoder applies is
+determined by the sibling `.dict` file's version — the only
+segment-level file carrying a magic and a version number — so the
+posting payload itself never has to be probed.
 
 ### Term Dictionary Storage Layers
 
@@ -126,7 +143,7 @@ on-disk compactness from in-memory query speed:
 
 - **Disk layer** — the `.dict` file uses a Lucene
   `BlockTreeTermsWriter`-style block-tree layout (magic `LTDD`,
-  schema v1). This produces a compact file: at 100k unique 5-10 byte
+  schema v3). This produces a compact file: at 100k unique 5-10 byte
   terms a `.dict` is ~12.5 bytes / term, roughly **70 % smaller** than
   the prior parallel-array on-disk format.
 - **In-memory query layer** — at build / load time the dictionary
@@ -221,7 +238,7 @@ graph TB
 
 | File Extension | Contents |
 | :--- | :--- |
-| `.dict` | Term dictionary in the v1 `LTDD` block-tree layout (FST over per-block representative terms + 128-term blocks of front-coded term bytes + bit-packed `TermInfo`). Loaded into an `AHashMap`-backed in-memory query layer at segment open. |
+| `.dict` | Term dictionary in the v3 `LTDD` block-tree layout (FST over per-block representative terms + 128-term blocks of front-coded term bytes + bit-packed `TermInfo`). Loaded into an `AHashMap`-backed in-memory query layer at segment open. |
 | `.post` | Posting lists (document IDs, term frequencies, positions) |
 | `.bkd` | [BKD tree](../bkd_tree.md) data for numeric, date, `Geo` (2D), and `Geo3d` (3D ECEF) fields |
 | `.docs` | Stored field values (the original document content) |

--- a/laurus/src/lexical/index/inverted/core/posting.rs
+++ b/laurus/src/lexical/index/inverted/core/posting.rs
@@ -319,7 +319,15 @@ pub struct DecodedPostingList {
     pub doc_ids: Vec<u32>,
     /// Term frequencies. Parallel to `doc_ids` / `weights`.
     pub frequencies: Vec<u32>,
-    /// Per-document weights. Parallel to `doc_ids` / `frequencies`.
+    /// Per-document weights. Parallel to `doc_ids` / `frequencies`, or
+    /// **empty**, which means every weight is the `1.0` default.
+    ///
+    /// The empty form is what a v3 segment produces when it omitted
+    /// Section 3, and what reader paths that do not consume weights
+    /// leave behind. Consumers must therefore not assume
+    /// `weights.len() == doc_ids.len()`;
+    /// [`Self::into_posting_list`] expands the empty form on demand
+    /// (#553).
     pub weights: Vec<f32>,
     /// Optional per-posting positions sidecar. `None` when **no** posting in
     /// this list carries position data (the common case for boolean / BM25
@@ -402,11 +410,21 @@ impl DecodedPostingList {
             None => Box::new(std::iter::repeat_with(|| None).take(n)),
         };
 
+        // An empty `weights` means "all 1.0" — the v3 decoder leaves it
+        // empty when the segment omitted Section 3 (#553). Zipping it
+        // directly would truncate the result to zero postings, so expand
+        // it lazily here, exactly as `positions: None` is expanded above.
+        let weights_iter: Box<dyn Iterator<Item = f32>> = if self.weights.is_empty() {
+            Box::new(std::iter::repeat_n(1.0, n))
+        } else {
+            Box::new(self.weights.into_iter())
+        };
+
         let postings: Vec<Posting> = self
             .doc_ids
             .into_iter()
             .zip(self.frequencies)
-            .zip(self.weights)
+            .zip(weights_iter)
             .zip(positions_iter)
             .map(|(((did, freq), w), pos)| Posting {
                 doc_id: did as u64,
@@ -422,6 +440,54 @@ impl DecodedPostingList {
             total_frequency: self.total_frequency,
             doc_frequency: self.doc_frequency,
         }
+    }
+}
+
+/// On-disk version of a single posting-list payload.
+///
+/// The versions form a ladder: each adds one capability and keeps
+/// everything before it. Carrying the version as a type rather than as a
+/// pair of booleans keeps "what does v2 contain?" answerable in one
+/// place, which matters because the axes are independent — v3 differs
+/// from v2 only in the weights section, and from v1 in both.
+///
+/// Which version a segment is in is not recorded in the payload itself.
+/// It comes from the sibling `.dict` file's header, the only
+/// segment-level file carrying a magic and a version (#503).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PostingFormat {
+    /// The original layout: no on-disk skip table (readers rebuild it
+    /// from `doc_ids`), weights always present.
+    V1,
+    /// Adds the multi-level skip table between the header and Section 1
+    /// (#503).
+    V2,
+    /// Adds the `any_weights` header byte and makes Section 3
+    /// conditional on it (#553).
+    V3,
+}
+
+impl PostingFormat {
+    /// Whether the payload carries a multi-level skip table between the
+    /// header and Section 1.
+    ///
+    /// # Returns
+    ///
+    /// `true` for v2 and later.
+    fn has_skip_levels(self) -> bool {
+        matches!(self, Self::V2 | Self::V3)
+    }
+
+    /// Whether the header carries the `any_weights` byte that gates
+    /// Section 3.
+    ///
+    /// # Returns
+    ///
+    /// `true` for v3 and later. When `false`, Section 3 is
+    /// unconditionally present, which is how v1 and v2 payloads are
+    /// read.
+    fn has_weight_flag(self) -> bool {
+        matches!(self, Self::V3)
     }
 }
 
@@ -576,11 +642,15 @@ impl PostingList {
     ///
     /// * `writer` - The structured output writer.
     pub fn encode<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
-        self.encode_header_and_payload(writer, /* with_skip_levels */ false)
+        self.encode_header_and_payload(writer, PostingFormat::V1)
     }
 
     /// Encode the posting list in v2 format, which adds a multi-level
     /// skip table after the header (#503).
+    ///
+    /// Superseded by [`Self::encode_v3`] for new segments; kept so that
+    /// v2 payloads can still be produced in round-trip and
+    /// backward-compatibility tests.
     ///
     /// The header and payload sections (doc_ids / frequencies / weights /
     /// positions) are byte-identical to [`Self::encode`]; the only
@@ -611,17 +681,74 @@ impl PostingList {
     ///
     /// * `writer` - The structured output writer.
     pub fn encode_v2<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
-        self.encode_header_and_payload(writer, /* with_skip_levels */ true)
+        self.encode_header_and_payload(writer, PostingFormat::V2)
     }
 
-    /// Shared encoder used by both [`Self::encode`] (v1) and
-    /// [`Self::encode_v2`]. The two only differ in whether the
-    /// **Skip levels** section is emitted between the header and
-    /// Section 1.
+    /// Encode the posting list in v3 format, which makes the weights
+    /// section optional (#553).
+    ///
+    /// v3 adds an `any_weights: u8` header byte immediately after
+    /// `any_positions`, mirroring how `any_positions` already gates
+    /// Section 4, and emits **Section 3 only when some posting carries a
+    /// weight other than `1.0`**:
+    ///
+    /// ```text
+    /// [term: string]
+    /// [total_frequency: varint]
+    /// [doc_frequency: varint]
+    /// [posting_count N: varint]
+    /// [any_positions: u8]
+    /// [any_weights: u8]                       (new in v3)
+    ///
+    /// // Skip levels — unchanged from v2
+    /// [num_skip_levels: u8]
+    /// repeat num_skip_levels times:
+    ///   [level_len: varint] [doc_id: u32] * level_len
+    ///
+    /// // Sections 1 and 2 — unchanged from v1/v2
+    ///
+    /// // Section 3: weights — only when any_weights == 1
+    /// repeat N times: [weight: f32]
+    ///
+    /// // Section 4: positions — only when any_positions == 1
+    /// ```
+    ///
+    /// Every posting the writer produces carries the default weight of
+    /// `1.0`, so in practice Section 3 disappears entirely and the list
+    /// shrinks by `4N - 1` bytes: four per posting, less the one header
+    /// byte per list.
+    ///
+    /// The saving is not paid for with a lossy format. A non-`1.0`
+    /// weight still round-trips exactly, because it flips `any_weights`
+    /// and brings Section 3 back.
+    ///
+    /// Which decoder a reader must use is gated by the sibling `.dict`
+    /// file's version, not by anything in this payload — see
+    /// [`BlockTermDictionary::posting_format_version`](crate::lexical::index::structures::dictionary::BlockTermDictionary::posting_format_version).
+    ///
+    /// # Arguments
+    ///
+    /// * `writer` - The structured output writer.
+    pub fn encode_v3<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
+        self.encode_header_and_payload(writer, PostingFormat::V3)
+    }
+
+    /// Shared encoder for every on-disk version.
+    ///
+    /// The versions differ on two independent axes, both carried by
+    /// [`PostingFormat`]: whether the **Skip levels** section is emitted
+    /// between the header and Section 1 (v2 onward), and whether the
+    /// **weights** section is gated by an `any_weights` header byte
+    /// rather than written unconditionally (v3 onward).
+    ///
+    /// # Arguments
+    ///
+    /// * `writer` - The structured output writer.
+    /// * `format` - The on-disk version to emit.
     fn encode_header_and_payload<W: StorageOutput>(
         &self,
         writer: &mut StructWriter<W>,
-        with_skip_levels: bool,
+        format: PostingFormat,
     ) -> Result<()> {
         writer.write_string(&self.term)?;
         writer.write_varint(self.total_frequency)?;
@@ -633,7 +760,15 @@ impl PostingList {
         let any_positions = self.postings.iter().any(|p| p.positions.is_some());
         writer.write_u8(u8::from(any_positions))?;
 
-        if with_skip_levels {
+        // v3 onward: one byte per posting *list* buys the right to drop
+        // four bytes per *posting*. Written even when N is 0 so the
+        // decoder's header read stays fixed-width.
+        let any_weights = format.has_weight_flag() && self.postings.iter().any(|p| p.weight != 1.0);
+        if format.has_weight_flag() {
+            writer.write_u8(u8::from(any_weights))?;
+        }
+
+        if format.has_skip_levels() {
             // Build the skip table from the in-memory postings. The
             // doc_ids we send through `build_skip_levels` must match
             // the ones the bit-packer is about to emit — we already
@@ -724,9 +859,13 @@ impl PostingList {
             writer.write_varint(freq as u64)?;
         }
 
-        // Section 3: weights (raw f32).
-        for posting in &self.postings {
-            writer.write_f32(posting.weight)?;
+        // Section 3: weights (raw f32). v1/v2 always carry it; v3 emits
+        // it only when some posting deviates from the 1.0 default, which
+        // no writer in this crate ever does (#553).
+        if !format.has_weight_flag() || any_weights {
+            for posting in &self.postings {
+                writer.write_f32(posting.weight)?;
+            }
         }
 
         // Section 4: positions (only when at least one posting carries them).
@@ -765,7 +904,7 @@ impl PostingList {
     /// * `reader` - The structured input reader positioned at a posting-list
     ///   header.
     pub fn decode_soa<R: StorageInput>(reader: &mut StructReader<R>) -> Result<DecodedPostingList> {
-        Self::decode_soa_inner(reader, /* with_skip_levels */ false)
+        Self::decode_soa_inner(reader, PostingFormat::V1)
     }
 
     /// Decode a posting list previously written by [`Self::encode_v2`]
@@ -780,16 +919,48 @@ impl PostingList {
     pub fn decode_soa_v2<R: StorageInput>(
         reader: &mut StructReader<R>,
     ) -> Result<DecodedPostingList> {
-        Self::decode_soa_inner(reader, /* with_skip_levels */ true)
+        Self::decode_soa_inner(reader, PostingFormat::V2)
     }
 
-    /// Shared decoder used by both [`Self::decode_soa`] (v1) and
-    /// [`Self::decode_soa_v2`]. The two only differ in whether the
-    /// **Skip levels** section is consumed from the input stream; v1
-    /// rebuilds the skip table from `doc_ids` at the end instead.
+    /// Decode a posting list previously written by [`Self::encode_v3`]
+    /// (#553).
+    ///
+    /// When the segment omitted Section 3 — the ordinary case, since
+    /// every weight is `1.0` — the returned
+    /// [`DecodedPostingList::weights`] is left **empty** rather than
+    /// filled with `n` copies of `1.0`. Materialising them would add an
+    /// allocation to the read path to represent exactly the information
+    /// the format just finished not storing. Empty therefore means
+    /// "all `1.0`", and
+    /// [`DecodedPostingList::into_posting_list`] expands it on demand.
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - The structured input reader positioned at a v3
+    ///   posting-list header.
+    pub fn decode_soa_v3<R: StorageInput>(
+        reader: &mut StructReader<R>,
+    ) -> Result<DecodedPostingList> {
+        Self::decode_soa_inner(reader, PostingFormat::V3)
+    }
+
+    /// Shared decoder for every on-disk version.
+    ///
+    /// The versions differ on two independent axes, both carried by
+    /// [`PostingFormat`]: whether the **Skip levels** section is
+    /// consumed from the input stream (v2 onward; v1 rebuilds the table
+    /// from `doc_ids` at the end instead), and whether the **weights**
+    /// section is gated by an `any_weights` header byte rather than
+    /// always present (v3 onward).
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - The structured input reader positioned at a
+    ///   posting-list header.
+    /// * `format` - The on-disk version the stream is known to be in.
     fn decode_soa_inner<R: StorageInput>(
         reader: &mut StructReader<R>,
-        with_skip_levels: bool,
+        format: PostingFormat,
     ) -> Result<DecodedPostingList> {
         let term = reader.read_string()?;
         let total_frequency = reader.read_varint()?;
@@ -797,11 +968,19 @@ impl PostingList {
         let n = reader.read_varint()? as usize;
         let any_positions = reader.read_u8()? != 0;
 
+        // v3 onward: does Section 3 exist at all? Older versions always
+        // wrote it, so they read as if the flag were set (#553).
+        let any_weights = if format.has_weight_flag() {
+            reader.read_u8()? != 0
+        } else {
+            true
+        };
+
         // v2-only section: multi-level skip table. Always present (even
         // for short posting lists where `num_skip_levels = 0`), so the
         // byte layout stays deterministic.
         let mut disk_skip_levels: Vec<Vec<u32>> = Vec::new();
-        if with_skip_levels {
+        if format.has_skip_levels() {
             let num_levels = reader.read_u8()? as usize;
             disk_skip_levels.reserve(num_levels);
             for _ in 0..num_levels {
@@ -881,10 +1060,15 @@ impl PostingList {
             frequencies.push(reader.read_varint()? as u32);
         }
 
-        // Section 3: weights.
-        let mut weights: Vec<f32> = Vec::with_capacity(n);
-        for _ in 0..n {
-            weights.push(reader.read_f32()?);
+        // Section 3: weights — absent in v3 when every weight is the
+        // 1.0 default. Left empty rather than expanded, so the common
+        // case costs no allocation; empty means all-1.0 (#553).
+        let mut weights: Vec<f32> = Vec::new();
+        if any_weights {
+            weights.reserve_exact(n);
+            for _ in 0..n {
+                weights.push(reader.read_f32()?);
+            }
         }
 
         // Section 4: positions (only materialised when at least one posting
@@ -918,7 +1102,7 @@ impl PostingList {
         // do not, so build the table from the decoded `doc_ids` at load
         // time. The build cost is paid once per segment open, not per
         // query, so the fallback path stays cheap.
-        let skip_levels = if with_skip_levels {
+        let skip_levels = if format.has_skip_levels() {
             disk_skip_levels
         } else {
             build_skip_levels(&doc_ids)
@@ -960,6 +1144,25 @@ impl PostingList {
     ///   posting-list header.
     pub fn decode_v2<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
         Ok(Self::decode_soa_v2(reader)?.into_posting_list())
+    }
+
+    /// Decode a posting list previously written by [`Self::encode_v3`]
+    /// into AoS form (#553).
+    ///
+    /// A v3 segment that omitted Section 3 yields postings whose
+    /// `weight` is `1.0`, reconstructed from the empty-weights
+    /// convention rather than read from disk.
+    ///
+    /// # Arguments
+    ///
+    /// * `reader` - The structured input reader positioned at a v3
+    ///   posting-list header.
+    ///
+    /// # Returns
+    ///
+    /// The decoded posting list.
+    pub fn decode_v3<R: StorageInput>(reader: &mut StructReader<R>) -> Result<Self> {
+        Ok(Self::decode_soa_v3(reader)?.into_posting_list())
     }
 }
 
@@ -1147,10 +1350,15 @@ impl TermPostingIndex {
 
     /// On-disk version of the [`TermPostingIndex`] format used by
     /// [`Self::write_to_storage`]. Version 2 introduces the
-    /// multi-level skip table per posting list (#503); v1 segments
-    /// remain readable via [`Self::read_from_storage`]'s back-compat
-    /// branch.
-    const ON_DISK_VERSION: u32 = 2;
+    /// multi-level skip table per posting list (#503); version 3 makes
+    /// the per-posting weights section conditional (#553). v1 and v2
+    /// containers remain readable via [`Self::read_from_storage`]'s
+    /// back-compat branches.
+    ///
+    /// Note that this `INVX` container is **not** what gates production
+    /// segment reads — those dispatch on the sibling `.dict` header. See
+    /// [`BlockTermDictionary::posting_format_version`](crate::lexical::index::structures::dictionary::BlockTermDictionary::posting_format_version).
+    const ON_DISK_VERSION: u32 = 3;
 
     /// Write the inverted index to storage.
     pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
@@ -1165,9 +1373,10 @@ impl TermPostingIndex {
         let mut sorted_terms: Vec<_> = self.terms.iter().collect();
         sorted_terms.sort_by_key(|(term, _)| *term);
 
-        // v2: every posting list carries an on-disk skip table.
+        // v3: every posting list carries an on-disk skip table, and
+        // omits its weights section unless some weight is not 1.0.
         for (_, posting_list) in sorted_terms {
-            posting_list.encode_v2(writer)?;
+            posting_list.encode_v3(writer)?;
         }
 
         Ok(())
@@ -1182,7 +1391,7 @@ impl TermPostingIndex {
         }
 
         let version = reader.read_u32()?;
-        if version != 1 && version != 2 {
+        if !matches!(version, 1..=3) {
             return Err(LaurusError::index(format!(
                 "Unsupported index version: {version}"
             )));
@@ -1196,12 +1405,18 @@ impl TermPostingIndex {
 
         // Dispatch posting-list decode by on-disk version. v1 segments
         // do not carry skip levels; the SoA decoder rebuilds them at
-        // load time (#503 back-compat fallback).
+        // load time (#503 back-compat fallback). v3 additionally gates
+        // the weights section on a header byte (#553).
+        //
+        // Matched exactly rather than with an ordered comparison: a
+        // `>=` here would hand a newer payload to an older decoder,
+        // which misreads the added header byte as the next field and
+        // corrupts silently instead of failing.
         for _ in 0..posting_list_count {
-            let posting_list = if version == 1 {
-                PostingList::decode(reader)?
-            } else {
-                PostingList::decode_v2(reader)?
+            let posting_list = match version {
+                1 => PostingList::decode(reader)?,
+                2 => PostingList::decode_v2(reader)?,
+                _ => PostingList::decode_v3(reader)?,
             };
             terms.insert(posting_list.term.clone(), posting_list);
         }
@@ -1990,6 +2205,370 @@ mod tests {
             let got = loaded.get_posting_list(term).expect("term loaded");
             assert_eq!(got.postings.len(), want.postings.len(), "term={term}");
         }
+    }
+
+    /// #553 — the deterministic size gate. Dropping the always-1.0
+    /// weights section must shrink a v3 payload by exactly `4N - 1`
+    /// bytes against v2: four bytes per posting recovered, less the one
+    /// `any_weights` header byte per list.
+    ///
+    /// An exact assertion rather than "v3 is smaller" — an exact number
+    /// fails loudly if the header or a section silently changes size,
+    /// which is the whole point of gating a format change on bytes.
+    #[test]
+    fn v3_omits_weight_section_saving_exactly_four_bytes_per_posting() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+        // N = 0 is the one case where v3 is *larger*: there are no
+        // weights to drop but the flag byte is still written, so the
+        // header stays fixed-width. Asserted rather than skipped.
+        {
+            let empty = PostingList::new("empty".to_string());
+            let measure = |path: &str, v3: bool| -> u64 {
+                let output = storage.create_output(path).unwrap();
+                let mut writer = StructWriter::new(output);
+                if v3 {
+                    empty.encode_v3(&mut writer).unwrap();
+                } else {
+                    empty.encode_v2(&mut writer).unwrap();
+                }
+                let len = writer.position();
+                writer.close().unwrap();
+                len
+            };
+            assert_eq!(
+                measure("v3_empty.bin", true) - measure("v2_empty.bin", false),
+                1,
+                "an empty list pays the flag byte and recovers nothing"
+            );
+        }
+
+        for n in [1usize, 7, 128, 300] {
+            let mut list = PostingList::new("sizes".to_string());
+            for i in 0..n {
+                list.add_posting(Posting::with_frequency(i as u64 * 3, (i % 5) as u32 + 1));
+            }
+
+            let encode_to = |path: &str, v3: bool| -> u64 {
+                let output = storage.create_output(path).unwrap();
+                let mut writer = StructWriter::new(output);
+                if v3 {
+                    list.encode_v3(&mut writer).unwrap();
+                } else {
+                    list.encode_v2(&mut writer).unwrap();
+                }
+                let len = writer.position();
+                writer.close().unwrap();
+                len
+            };
+
+            let len_v2 = encode_to(&format!("v2_{n}.bin"), false);
+            let len_v3 = encode_to(&format!("v3_{n}.bin"), true);
+
+            assert_eq!(
+                len_v2 - len_v3,
+                (4 * n - 1) as u64,
+                "n={n}: expected v3 to save exactly 4N-1 bytes (v2={len_v2}, v3={len_v3})"
+            );
+        }
+    }
+
+    /// #553 — the ordinary case: every weight is the 1.0 default, so
+    /// Section 3 is absent on disk and the decoder leaves `weights`
+    /// empty rather than materialising N copies of 1.0.
+    ///
+    /// The AoS view must still report 1.0 for every posting, which is
+    /// what proves the empty vec is a representation of all-1.0 and not
+    /// a dropped section.
+    #[test]
+    fn v3_round_trip_without_weights_reports_all_ones() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let n: usize = 260;
+        let mut original = PostingList::new("plain".to_string());
+        for i in 0..n {
+            original.add_posting(Posting::with_frequency(i as u64 * 2, (i % 7) as u32 + 1));
+        }
+
+        let path = "v3_plain.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            original.encode_v3(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let decoded = PostingList::decode_soa_v3(&mut reader).unwrap();
+
+        assert_eq!(decoded.len(), n);
+        assert!(
+            decoded.weights.is_empty(),
+            "Section 3 must be absent, leaving weights empty; got {} entries",
+            decoded.weights.len()
+        );
+        for (i, posting) in original.postings.iter().enumerate() {
+            assert_eq!(decoded.doc_ids[i], posting.doc_id as u32, "doc at {i}");
+            assert_eq!(decoded.frequencies[i], posting.frequency, "freq at {i}");
+        }
+
+        // The AoS reassembly expands the empty vec back to 1.0 — this is
+        // the assertion that would fail on a naive `.zip(self.weights)`,
+        // which truncates to zero postings.
+        let aos = decoded.into_posting_list();
+        assert_eq!(aos.postings.len(), n, "empty weights must not truncate");
+        assert!(aos.postings.iter().all(|p| p.weight == 1.0));
+    }
+
+    /// #553 — the saving must not be bought with silent data loss. One
+    /// non-1.0 weight flips `any_weights`, brings Section 3 back, and
+    /// every value must round-trip bit-exactly.
+    #[test]
+    fn v3_round_trip_preserves_non_default_weights_exactly() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        // Past the 128-posting bit-packed block boundary, so Section 3
+        // is exercised alongside a full block plus a varint tail rather
+        // than only in the small-list path.
+        let n: usize = 300;
+        let mut original = PostingList::new("weighted".to_string());
+        for i in 0..n {
+            original.add_posting(Posting::with_frequency(i as u64, 1).with_weight(match i {
+                17 => 0.25,
+                200 => 2.5,
+                _ => 1.0,
+            }));
+        }
+
+        let path = "v3_weighted.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            original.encode_v3(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let decoded = PostingList::decode_soa_v3(&mut reader).unwrap();
+
+        assert_eq!(
+            decoded.weights.len(),
+            n,
+            "a single non-1.0 weight must bring Section 3 back"
+        );
+        for (i, posting) in original.postings.iter().enumerate() {
+            assert_eq!(decoded.weights[i], posting.weight, "weight at {i}");
+        }
+        assert_eq!(decoded.weights[17], 0.25);
+        assert_eq!(decoded.weights[200], 2.5);
+
+        // The AoS wrapper is a separate code path from the SoA decode
+        // above and must carry the same values through.
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let aos = PostingList::decode_v3(&mut reader).unwrap();
+        assert_eq!(aos.postings.len(), n);
+        for (got, want) in aos.postings.iter().zip(original.postings.iter()) {
+            assert_eq!(got.doc_id, want.doc_id);
+            assert_eq!(got.frequency, want.frequency);
+            assert_eq!(got.weight, want.weight);
+        }
+    }
+
+    /// #553 — an empty `weights` on a non-empty `DecodedPostingList`
+    /// must expand to all-1.0 rather than truncating the result. Pins
+    /// the convention directly, independent of any encoder.
+    #[test]
+    fn into_posting_list_treats_empty_weights_as_all_ones() {
+        let decoded = DecodedPostingList {
+            term: "convention".to_string(),
+            doc_ids: vec![1, 4, 9],
+            frequencies: vec![2, 1, 3],
+            weights: Vec::new(),
+            positions: None,
+            skip_levels: Vec::new(),
+            total_frequency: 6,
+            doc_frequency: 3,
+        };
+
+        let list = decoded.into_posting_list();
+        assert_eq!(list.postings.len(), 3, "empty weights must not truncate");
+        assert!(list.postings.iter().all(|p| p.weight == 1.0));
+        assert_eq!(
+            list.postings.iter().map(|p| p.doc_id).collect::<Vec<_>>(),
+            vec![1, 4, 9]
+        );
+    }
+
+    /// #553 — a v2 payload must keep decoding as v2 after v3 exists,
+    /// **and the two formats must be genuinely distinct**.
+    ///
+    /// A plain `encode_v2` → `decode_soa_v2` round trip would prove
+    /// neither: both sides could drift together and it would stay green.
+    /// So this also feeds the same v2 bytes to the *v3* decoder and
+    /// requires that to fail or disagree. That is precisely the hazard
+    /// the exact-match dispatch guards — an ordered comparison would
+    /// hand a payload to the wrong decoder, and if the two formats were
+    /// somehow interchangeable this test would be worthless.
+    #[test]
+    fn v2_payload_decodes_as_v2_and_not_as_v3() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let n: usize = 200;
+        let mut original = PostingList::new("v2_pin".to_string());
+        for i in 0..n {
+            original.add_posting(Posting::with_frequency(i as u64 * 5, (i % 3) as u32 + 1));
+        }
+
+        let path = "v2_pin.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            original.encode_v2(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+
+        // Correct decoder: full fidelity, Section 3 present.
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let decoded = PostingList::decode_soa_v2(&mut reader).unwrap();
+
+        assert_eq!(decoded.len(), n);
+        assert_eq!(
+            decoded.weights.len(),
+            n,
+            "v2 always carries Section 3, regardless of the values"
+        );
+        assert!(decoded.weights.iter().all(|&w| w == 1.0));
+        for (i, posting) in original.postings.iter().enumerate() {
+            assert_eq!(decoded.doc_ids[i], posting.doc_id as u32, "doc at {i}");
+            assert_eq!(decoded.frequencies[i], posting.frequency, "freq at {i}");
+        }
+
+        // Wrong decoder: v3 reads an `any_weights` byte that v2 never
+        // wrote, so every field after the header shifts. It must not
+        // quietly reproduce the correct list.
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        match PostingList::decode_soa_v3(&mut reader) {
+            Err(_) => {}
+            Ok(mis) => {
+                assert!(
+                    mis.doc_ids != decoded.doc_ids || mis.frequencies != decoded.frequencies,
+                    "v2 and v3 payloads must not be interchangeable, or the \
+                     version dispatch guards nothing"
+                );
+            }
+        }
+    }
+
+    /// #553 — `TermPostingIndex` must dispatch on the exact version.
+    ///
+    /// A hand-synthesized v2 container and the v3 container the writer
+    /// now emits must both load. An ordered `>=` dispatch would send the
+    /// v3 bytes to the v2 decoder, which reads the `any_weights` byte as
+    /// the skip-level count and corrupts the list without erroring —
+    /// so this asserts on decoded content, not merely on success.
+    #[test]
+    fn term_posting_index_dispatches_v2_and_v3_exactly() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+        let mut original = TermPostingIndex::new();
+        original.add_document(
+            1,
+            vec![
+                ("hello".to_string(), 2, Some(vec![0, 5])),
+                ("world".to_string(), 1, Some(vec![1])),
+            ],
+        );
+        original.add_document(
+            2,
+            vec![
+                ("hello".to_string(), 1, Some(vec![2])),
+                ("rust".to_string(), 3, Some(vec![0, 3, 6])),
+            ],
+        );
+
+        let check = |loaded: &TermPostingIndex, label: &str| {
+            assert_eq!(loaded.doc_count(), original.doc_count(), "{label}");
+            assert_eq!(loaded.term_count(), original.term_count(), "{label}");
+            for term in ["hello", "world", "rust"] {
+                let want = original.get_posting_list(term).expect("term exists");
+                let got = loaded
+                    .get_posting_list(term)
+                    .unwrap_or_else(|| panic!("{label}: term {term} missing"));
+                assert_eq!(got.postings.len(), want.postings.len(), "{label} {term}");
+                for (g, w) in got.postings.iter().zip(want.postings.iter()) {
+                    assert_eq!(g.doc_id, w.doc_id, "{label} {term}");
+                    assert_eq!(g.frequency, w.frequency, "{label} {term}");
+                    assert_eq!(g.weight, w.weight, "{label} {term}");
+                    assert_eq!(g.positions, w.positions, "{label} {term}");
+                }
+            }
+        };
+
+        // Hand-written v2 container (write_to_storage now emits v3).
+        let v2_path = "tpi_v2.bin";
+        {
+            let output = storage.create_output(v2_path).unwrap();
+            let mut writer = StructWriter::new(output);
+            writer.write_u32(0x494E5658).unwrap(); // "INVX"
+            writer.write_u32(2).unwrap();
+            writer.write_varint(original.doc_count()).unwrap();
+            writer.write_varint(original.term_count()).unwrap();
+            writer.write_varint(3).unwrap();
+            let mut terms: Vec<_> = original.terms.iter().collect();
+            terms.sort_by_key(|(t, _)| *t);
+            for (_, posting_list) in terms {
+                posting_list.encode_v2(&mut writer).unwrap();
+            }
+            writer.close().unwrap();
+        }
+        let input = storage.open_input(v2_path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        check(
+            &TermPostingIndex::read_from_storage(&mut reader).unwrap(),
+            "v2",
+        );
+
+        // v3 container, straight from the current writer.
+        let v3_path = "tpi_v3.bin";
+        {
+            let output = storage.create_output(v3_path).unwrap();
+            let mut writer = StructWriter::new(output);
+            original.write_to_storage(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input(v3_path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        check(
+            &TermPostingIndex::read_from_storage(&mut reader).unwrap(),
+            "v3",
+        );
+    }
+
+    /// #553 — an unknown future version must be rejected, not guessed
+    /// at. This is what keeps the exact-match dispatch honest.
+    #[test]
+    fn term_posting_index_rejects_unknown_version() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let path = "tpi_v99.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            writer.write_u32(0x494E5658).unwrap();
+            writer.write_u32(99).unwrap();
+            writer.write_varint(0u64).unwrap();
+            writer.write_varint(0u64).unwrap();
+            writer.write_varint(0u64).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let err = TermPostingIndex::read_from_storage(&mut reader).unwrap_err();
+        assert!(
+            err.to_string().contains("Unsupported index version: 99"),
+            "unexpected error: {err}"
+        );
     }
 
     /// Encoding a doc_id beyond `u32::MAX` must fail with a clear error so we

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -1152,20 +1152,26 @@ impl SegmentReader {
             // Decode the posting list in SoA-native form to skip the
             // intermediate `Vec<Posting>` reassembly and keep the iterator
             // backed by parallel `Vec<u32>` slices. Dispatch by on-disk
-            // posting format version (#503): v2 segments carry the
-            // multi-level skip table inline; v1 segments rebuild it from
-            // `doc_ids` at load time inside `decode_soa`.
+            // posting format version: v2 segments carry the multi-level
+            // skip table inline (#503) while v1 segments rebuild it from
+            // `doc_ids` at load time inside `decode_soa`; v3 additionally
+            // gates the weights section on a header byte (#553).
+            //
+            // Matched exactly rather than with an ordered comparison. A
+            // `>=` would route a newer payload into an older decoder,
+            // which reads the added header byte as the next field and
+            // corrupts the list silently instead of failing.
             let posting_format = self
                 .term_dictionary
                 .read()
                 .unwrap()
                 .as_ref()
                 .map(|dict| dict.posting_format_version())
-                .unwrap_or(2);
-            let decoded = if posting_format >= 2 {
-                PostingList::decode_soa_v2(&mut reader)?
-            } else {
-                PostingList::decode_soa(&mut reader)?
+                .unwrap_or(3);
+            let decoded = match posting_format {
+                1 => PostingList::decode_soa(&mut reader)?,
+                2 => PostingList::decode_soa_v2(&mut reader)?,
+                _ => PostingList::decode_soa_v3(&mut reader)?,
             };
             let filtered = self.filter_deleted_soa(decoded)?;
 
@@ -2439,6 +2445,101 @@ impl crate::lexical::reader::PostingIterator for MergedPostingIterator {
 mod tests {
     use super::*;
     use crate::lexical::reader::PostingIterator;
+
+    /// #553 — the production decoder selector, end to end.
+    ///
+    /// `SegmentReader::postings` is the only place that chooses a
+    /// posting decoder for a real segment, and it had **no test at all**
+    /// before this change — which is how the `posting_format >= 2`
+    /// ordered comparison could have survived a format bump and silently
+    /// misparsed v3 payloads.
+    ///
+    /// This drives the whole production path: `InvertedIndexWriter`
+    /// writes a real segment (v3 postings + a v3 dictionary), and the
+    /// reader dispatches on the dictionary version to decode it back.
+    /// The unit tests around `encode_v3` / `decode_soa_v3` never touch
+    /// this wiring.
+    #[test]
+    fn segment_reader_decodes_postings_written_by_the_writer() {
+        use crate::lexical::index::inverted::writer::{
+            InvertedIndexWriter, InvertedIndexWriterConfig,
+        };
+        use crate::lexical::writer::LexicalIndexWriter;
+        use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut writer =
+            InvertedIndexWriter::new(storage, InvertedIndexWriterConfig::default()).unwrap();
+
+        // Enough documents to push the term past the bit-packed block
+        // boundary, so the decode exercises full blocks plus a tail.
+        let doc_count = 200u64;
+        for i in 0..doc_count {
+            writer
+                .add_document(
+                    crate::Document::builder()
+                        .add_text("body", if i % 2 == 0 { "alpha beta" } else { "alpha" })
+                        .build(),
+                )
+                .unwrap();
+        }
+        writer.commit().unwrap();
+
+        let reader = writer.build_reader().unwrap();
+        let inverted = reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .unwrap();
+        let segment = inverted.segment_readers()[0].clone();
+        let segment = segment.read().unwrap();
+
+        // The segment the writer just produced must be stamped v3, or
+        // the dispatch below is not testing what it claims to.
+        let dict = segment
+            .term_dictionary()
+            .unwrap()
+            .expect("segment must have a term dictionary");
+        assert_eq!(
+            dict.posting_format_version(),
+            3,
+            "the writer must produce v3 segments"
+        );
+
+        // "alpha" is in every document; "beta" in the even ones.
+        let mut iter = segment
+            .postings("body", "alpha")
+            .unwrap()
+            .expect("alpha must have postings");
+        // `doc_id()` is only valid after a `next()` that returned true,
+        // so the iterator starts positioned before the first posting.
+        let mut seen = Vec::new();
+        while iter.next().unwrap() {
+            seen.push(iter.doc_id());
+        }
+        assert_eq!(
+            seen.len(),
+            doc_count as usize,
+            "every document contains 'alpha'"
+        );
+        assert!(
+            seen.windows(2).all(|w| w[0] < w[1]),
+            "doc ids must come back strictly ascending"
+        );
+
+        let mut iter = segment
+            .postings("body", "beta")
+            .unwrap()
+            .expect("beta must have postings");
+        let mut even = Vec::new();
+        while iter.next().unwrap() {
+            even.push(iter.doc_id());
+        }
+        assert_eq!(
+            even.len(),
+            (doc_count / 2) as usize,
+            "'beta' is only in the even documents"
+        );
+    }
 
     #[test]
     fn test_advanced_posting_iterator() {

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -900,9 +900,12 @@ impl InvertedIndexWriter {
             if let Some(posting_list) = self.inverted_index.get_posting_list(term) {
                 let start_offset = posting_writer.position();
 
-                // Write posting list (v2: includes on-disk multi-level
-                // skip table for O(log_8 N) `skip_to`, #503).
-                posting_list.encode_v2(&mut posting_writer)?;
+                // Write posting list (v3: on-disk multi-level skip table
+                // for O(log_8 N) `skip_to` (#503), and a weights section
+                // emitted only when some posting deviates from the 1.0
+                // default — which nothing in this writer does, so it is
+                // always omitted (#553)).
+                posting_list.encode_v3(&mut posting_writer)?;
 
                 let end_offset = posting_writer.position();
                 let length = end_offset - start_offset;

--- a/laurus/src/lexical/index/structures/dictionary.rs
+++ b/laurus/src/lexical/index/structures/dictionary.rs
@@ -226,7 +226,14 @@ pub struct BlockTermDictionary {
     /// the posting lists, but it is the only segment-level file with a
     /// magic + version, so its version implies the format used by the
     /// sibling `.post` file. `1` = legacy (no on-disk skip levels);
-    /// `2` = multi-level skip table embedded per posting list.
+    /// `2` = multi-level skip table embedded per posting list (#503);
+    /// `3` = the weights section is gated by an `any_weights` header
+    /// byte and omitted when every weight is `1.0` (#553).
+    ///
+    /// Because this drives which decoder `SegmentReader::postings`
+    /// selects, bumping the posting format **requires** bumping this
+    /// version in the same change — otherwise new payloads are handed to
+    /// an old decoder and misparse without erroring.
     posting_format_version: u32,
 }
 
@@ -356,11 +363,11 @@ impl BlockTermDictionary {
 
     /// Read the dictionary from storage.
     ///
-    /// Format (v1 `LTDD` layout):
+    /// Format (`LTDD` layout):
     ///
     /// ```text
     /// [magic:              u32 = 0x4C544444 "LTDD"]
-    /// [version:            u32 = 1]
+    /// [version:            u32 = 1 | 2 | 3]
     /// [fst_bytes_len:      u32]
     /// [fst_bytes:          u8 × fst_bytes_len]
     /// [block_section_len:  u32]
@@ -389,7 +396,7 @@ impl BlockTermDictionary {
         }
 
         let version = reader.read_u32()?;
-        if version != 1 && version != 2 {
+        if !matches!(version, 1..=3) {
             return Err(LaurusError::index(format!(
                 "Unsupported BlockTermDictionary version: {version}"
             )));
@@ -436,14 +443,20 @@ impl BlockTermDictionary {
         self.posting_format_version
     }
 
-    /// Write the dictionary to storage in the v2 `LTDD` layout.
+    /// Write the dictionary to storage in the v3 `LTDD` layout.
     /// See [`Self::read_from_storage`] for the byte layout.
     pub fn write_to_storage<W: StorageOutput>(&self, writer: &mut StructWriter<W>) -> Result<()> {
         writer.write_u32(MAGIC_LTDD)?;
-        // v2 (#503): every sibling `.post` file uses the v2 posting list
-        // format with an on-disk multi-level skip table. v1 dictionaries
-        // remain readable for backward compat via `read_from_storage`.
-        writer.write_u32(2)?; // version
+        // Stamp the version this dictionary actually carries rather than
+        // a literal. Fresh builds set it to the current format in
+        // `build()`; a dictionary loaded from disk keeps whatever its
+        // segment was written with, so re-serialising one can never
+        // claim a newer format than its sibling `.post` file holds
+        // (#553).
+        //
+        // v1 = no on-disk skip levels; v2 = skip table per posting list
+        // (#503); v3 = weights section gated by `any_weights` (#553).
+        writer.write_u32(self.posting_format_version)?;
 
         let fst_bytes = self.fst.as_fst().as_inner();
         writer.write_u32(
@@ -549,7 +562,7 @@ impl TermDictionaryBuilder {
                 total_term_count: 0,
                 block_count: 0,
                 // Fresh builds always emit the latest format (#503).
-                posting_format_version: 2,
+                posting_format_version: 3,
             });
         }
 
@@ -625,7 +638,7 @@ impl TermDictionaryBuilder {
             total_term_count,
             block_count,
             // Fresh builds always emit the latest format (#503).
-            posting_format_version: 2,
+            posting_format_version: 3,
         })
     }
 
@@ -712,6 +725,170 @@ mod tests {
         let dict = builder.build().unwrap();
         assert_eq!(dict.len(), 1);
         assert!(dict.get("test").is_some());
+    }
+
+    // ----- Posting format version (#553) -----
+
+    /// Copy a dictionary file, overwriting only its `version` header
+    /// field.
+    ///
+    /// Everything after the header is version-independent, so a body
+    /// written by the current code with an older stamp is byte-identical
+    /// to what that older release produced — which is what makes this a
+    /// genuine backward-compatibility fixture rather than a re-encoding.
+    /// The trailing CRC is not recomputed because `read_from_storage`
+    /// does not verify it (checksum validation is opt-in via
+    /// `StructReader::verify_checksum`).
+    ///
+    /// # Arguments
+    ///
+    /// * `storage` - Storage holding both files.
+    /// * `src` - Path of the file to copy.
+    /// * `dst` - Path to write the restamped copy to.
+    /// * `version` - Version number to stamp.
+    fn stamp_version(storage: &Arc<MemoryStorage>, src: &str, dst: &str, version: u32) {
+        use std::io::{Read, Write};
+
+        let mut bytes = Vec::new();
+        {
+            let mut input = storage.open_input(src).unwrap();
+            input.read_to_end(&mut bytes).unwrap();
+        }
+        // [magic: u32][version: u32], little-endian per `StructWriter`.
+        bytes[4..8].copy_from_slice(&version.to_le_bytes());
+        {
+            let mut output = storage.create_output(dst).unwrap();
+            output.write_all(&bytes).unwrap();
+            output.flush_and_sync().unwrap();
+            output.close().unwrap();
+        }
+    }
+
+    /// #553 — the `.dict` header version is what tells the reader which
+    /// `.post` decoder to use, so a fresh build must stamp the current
+    /// version and a round trip must carry it back unchanged.
+    ///
+    /// Nothing asserted this value before, which is how the two version
+    /// gates could have drifted apart unnoticed.
+    #[test]
+    fn fresh_dictionary_stamps_and_round_trips_posting_format_v3() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut builder = TermDictionaryBuilder::new();
+        builder.add_term("alpha".to_string(), create_test_term_info(0));
+        builder.add_term("beta".to_string(), create_test_term_info(100));
+        let dict = builder.build().unwrap();
+
+        assert_eq!(
+            dict.posting_format_version(),
+            3,
+            "fresh builds must emit the current posting format"
+        );
+
+        let path = "dict_v3.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            dict.write_to_storage(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input(path).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let loaded = BlockTermDictionary::read_from_storage(&mut reader).unwrap();
+
+        assert_eq!(loaded.posting_format_version(), 3);
+        assert!(loaded.get("alpha").is_some());
+        assert!(loaded.get("beta").is_some());
+    }
+
+    /// #553 — an existing v2 dictionary must keep loading and must keep
+    /// reporting **2**, so its sibling `.post` file is decoded with the
+    /// v2 decoder rather than the v3 one.
+    ///
+    /// This is the backward-compatibility guarantee for every index
+    /// written before this change. `index-interop` CI cannot cover it —
+    /// both of its jobs build the same commit, so it tests platforms,
+    /// not versions.
+    #[test]
+    fn v2_dictionary_still_loads_and_reports_v2() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut builder = TermDictionaryBuilder::new();
+        builder.add_term("gamma".to_string(), create_test_term_info(0));
+        let dict = builder.build().unwrap();
+
+        // Rewrite the version field in place: everything after the
+        // header is version-independent, so a v3 body with a v2 stamp is
+        // byte-identical to what the previous release produced.
+        let path = "dict_v2.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            dict.write_to_storage(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let patched = "dict_v2_patched.bin";
+        stamp_version(&storage, path, patched, 2);
+
+        let input = storage.open_input(patched).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let loaded = BlockTermDictionary::read_from_storage(&mut reader).unwrap();
+
+        assert_eq!(
+            loaded.posting_format_version(),
+            2,
+            "a v2 dictionary must not be silently promoted to v3"
+        );
+        assert!(loaded.get("gamma").is_some());
+
+        // Re-serialising it must keep the v2 stamp. Writing a literal
+        // here instead of the carried version would tell the reader to
+        // use the v3 posting decoder on a sibling `.post` file that is
+        // still v2 — a silent misparse, and the reason
+        // `write_to_storage` stamps `self.posting_format_version`.
+        let rewritten = "dict_v2_rewritten.bin";
+        {
+            let output = storage.create_output(rewritten).unwrap();
+            let mut writer = StructWriter::new(output);
+            loaded.write_to_storage(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let input = storage.open_input(rewritten).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let again = BlockTermDictionary::read_from_storage(&mut reader).unwrap();
+        assert_eq!(
+            again.posting_format_version(),
+            2,
+            "re-serialising a v2 dictionary must not promote it to v3"
+        );
+    }
+
+    /// #553 — an unknown version must be rejected rather than assumed
+    /// compatible, which is what keeps the exact-match dispatch in
+    /// `SegmentReader::postings` sound.
+    #[test]
+    fn unknown_dictionary_version_is_rejected() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut builder = TermDictionaryBuilder::new();
+        builder.add_term("delta".to_string(), create_test_term_info(0));
+        let dict = builder.build().unwrap();
+
+        let path = "dict_v99_src.bin";
+        {
+            let output = storage.create_output(path).unwrap();
+            let mut writer = StructWriter::new(output);
+            dict.write_to_storage(&mut writer).unwrap();
+            writer.close().unwrap();
+        }
+        let patched = "dict_v99.bin";
+        stamp_version(&storage, path, patched, 99);
+
+        let input = storage.open_input(patched).unwrap();
+        let mut reader = StructReader::new(input).unwrap();
+        let err = BlockTermDictionary::read_from_storage(&mut reader).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("Unsupported BlockTermDictionary version"),
+            "unexpected error: {err}"
+        );
     }
 
     // ----- BlockTermDictionary tests (#487 PR1) -----


### PR DESCRIPTION
Closes #553

Every posting carried an `f32` weight on disk. Every posting Laurus writes has weight `1.0`, and the read side does not even consume the value — `reader.rs:848` left `weights` empty with the comment *"weights are not consumed by the iterator API"*. So the bytes were written, decoded, and discarded. At a billion postings that is **4 GB of guaranteed-`1.0`**.

## Format v3

```text
[term][total_frequency][doc_frequency][posting_count N]
[any_positions: u8]
[any_weights: u8]                 <- new in v3
[skip levels ...]                 (v2 onward)
Section 1: doc_ids
Section 2: frequencies
Section 3: weights                <- only when any_weights == 1
Section 4: positions              <- only when any_positions == 1
```

`any_weights` mirrors the `any_positions` byte that has always gated Section 4 — the pattern was already in this format, so nothing new had to be invented. One byte per posting *list* buys four bytes per *posting*.

The saving is not bought with a lossy format: a single weight other than `1.0` sets the flag, restores Section 3, and every value round-trips exactly.

Internally the `with_skip_levels: bool` parameter became `enum PostingFormat { V1, V2, V3 }` with `has_skip_levels()` / `has_weight_flag()`, because the versions now differ on two independent axes and two parallel booleans would say less.

## The version gate was not where it looked

`TermPostingIndex::ON_DISK_VERSION` is the obvious candidate, but its `INVX` container **has no production caller** — `write_to_storage` / `read_from_storage` are exercised only by unit tests. What actually drives production reads is the sibling **`.dict` header version**, which is also how the v1 → v2 bump shipped (#503 / PR #509): the dictionary is the only segment-level file carrying a magic and a version.

Both are bumped here. More importantly, **both dispatches now match the version exactly instead of comparing with `>=`**:

```rust
// before — reader.rs
let decoded = if posting_format >= 2 { decode_soa_v2 } else { decode_soa };
```

A v3 dictionary satisfies `>= 2`, so that would have handed a v3 payload to the v2 decoder, which reads the new `any_weights` byte **as the skip-level count** — no error, just a corrupted list. Ordered comparisons are what make a format bump fail quietly instead of loudly. `posting.rs`'s `if version == 1 { .. } else { decode_v2 }` had the same shape.

`write_to_storage` now also stamps `self.posting_format_version` rather than a literal, so re-serialising a loaded v2 dictionary can never claim a newer format than its sibling `.post` file holds.

## A second, unplanned win: one fewer allocation on read

Filling `weights` with `vec![1.0; n]` when the section is absent would **add** an N-element allocation to represent exactly the information the format just finished not storing. Instead `weights` stays empty — empty means all-`1.0` — and `into_posting_list` expands it on demand, mirroring how `positions: None` already becomes `repeat_with(|| None).take(n)`.

That method did `.zip(self.weights)`, which truncates to zero postings on an empty vec. It is not reachable on main (all three callers always receive `n` weights), but `decode_v3` becomes a fourth caller that legitimately passes empty, so it is fixed here and pinned by a test.

## Effect: proven in bytes, not in a benchmark

`v3_omits_weight_section_saving_exactly_four_bytes_per_posting` asserts that a v3 payload is **exactly `4N - 1` bytes** smaller than its v2 equivalent, for `N = 1, 7, 128, 300`. An exact figure rather than "v3 is smaller", so it fails loudly if a header or section silently changes size.

`N = 0` is asserted too, as the one case where v3 is **1 byte larger** — no weights to drop, but the flag byte is still written so the header stays fixed-width.

This is deliberately a byte gate. Timing benchmarks on the development host are noise-dominated (#944 Phase B could not resolve a delta across three rounds of increasingly strict methodology), so this change was selected precisely because its effect is provable without a stopwatch.

## Tests (11 new)

The repo's cross-version coverage was thinner than it looked, and this closes the gaps:

- **`SegmentReader::postings` had no test at all.** It is the only place that selects a posting decoder for a real segment — the very code that carried the `>= 2` comparison. A new end-to-end test writes a real segment through `InvertedIndexWriter` and reads it back, asserting the writer produces v3 and that both terms decode correctly across the bit-packed block boundary.
- **There was no v2 pinning test.** The existing v2 tests are symmetric `encode_v2` → `decode_soa_v2` round trips, which stay green if both sides drift together. The new one additionally feeds the same v2 bytes to the *v3* decoder and requires that to fail or disagree — if the formats were interchangeable, the version dispatch would be guarding nothing.
- Dictionary: fresh builds stamp v3; a v2 dictionary loads, reports 2, **and still reports 2 after re-serialisation**; unknown versions are rejected. None of these values were asserted anywhere before.
- Format: v3 round trip with weights absent (and the AoS view reporting 1.0), with a non-default weight present past the 128-posting block boundary, through both the SoA and AoS decoders; the empty-weights convention pinned directly; unknown container versions rejected.

Note that `index-interop` CI cannot cover any of this: both of its jobs check out the same SHA, so it verifies **cross-platform**, not **cross-version**. The pinning tests carry that guarantee instead.

## Compatibility

v1 and v2 segments keep loading; no migration is performed and no migration tool is added, matching how #503 shipped. Nothing outside the core crate is affected — no binding, CLI, server or MCP surface references postings or format versions, and there are no checked-in index fixtures.

`cargo test --workspace` **1906 passed / 0 failed**; `cargo clippy --all-targets --features embeddings-all -- -D warnings` and `cargo fmt --all --check` clean on Rust 1.98; `markdownlint-cli2` clean.

Docs updated in both trees. The Japanese page was missing the On-Disk Posting Layout section entirely — pre-existing drift, written here — and four places across the two trees described `.dict` as v1, which had been wrong since #503.
