### PR TITLE
fix(lexical): keep documents resolvable by _id across an automatic flush

### DIFF
--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -18,6 +18,7 @@ use crate::lexical::core::document::Document;
 use crate::lexical::core::field::FieldOption;
 use crate::lexical::index::inverted::IndexMetadata;
 use crate::lexical::index::inverted::core::posting::{Posting, TermPostingIndex};
+use crate::lexical::index::inverted::reader::SegmentReader;
 use crate::lexical::index::inverted::segment::SegmentInfo;
 use crate::lexical::index::structures::bkd_tree::BKDWriter;
 use crate::lexical::index::structures::dictionary::{TermDictionaryBuilder, TermInfo};
@@ -167,6 +168,25 @@ pub struct InvertedIndexWriter {
     /// Pending deletions that are not yet reflected in the reader (NRT).
     pending_deletions: std::collections::HashSet<u64>,
 
+    /// Readers for the segments this writer has flushed but not yet
+    /// committed (#1016).
+    ///
+    /// `flush_segment` empties the in-memory buffer, which is the only
+    /// thing [`Self::find_doc_ids_by_term`] used to search — so a
+    /// document written before an automatic flush stopped resolving by
+    /// `_id` until the next commit, silently breaking `get` and `delete`
+    /// for it. Keeping a reader per flushed segment lets the NRT lookup
+    /// follow the documents out of the buffer.
+    ///
+    /// This is deliberately **not** every persisted segment, only the
+    /// ones this writer produced since its last commit — normally none.
+    /// That is what makes probing them affordable on a path that runs
+    /// once per written document.
+    ///
+    /// [`SegmentReader::open`] is fully lazy, so registering one costs no
+    /// I/O; the files are opened only if a lookup actually reaches them.
+    flushed_segments: Vec<SegmentReader>,
+
     /// Cached `(segment_id, min_doc_id, max_doc_id)` for every committed
     /// segment, mirroring the `*.meta` files on storage (Issue #559 / #864).
     ///
@@ -290,6 +310,7 @@ impl InvertedIndexWriter {
             last_wal_seq: base_metadata.last_wal_seq,
             base_metadata,
             pending_deletions: std::collections::HashSet::new(),
+            flushed_segments: Vec::new(),
             segment_ranges,
             max_committed_doc_id,
             deletion_manager: None,
@@ -463,29 +484,64 @@ impl InvertedIndexWriter {
 
     /// Find all internal document IDs for a given term (field:value).
     ///
-    /// This searches both the in-memory buffer (uncommitted) and, in the future,
-    /// persisted segments (committed).
+    /// Searches everything this writer is responsible for that a shared
+    /// searcher cannot yet see: the in-memory buffer, and the segments
+    /// flushed since the last commit.
+    ///
+    /// The second half matters because `flush_segment` fires automatically
+    /// at `max_buffered_docs` and empties the buffer. Without it a document
+    /// written earlier in an uncommitted batch stopped resolving by `_id`,
+    /// which silently broke `get` and `delete` for it and let a later
+    /// document with the same `_id` fail to supersede it (#1016).
+    ///
+    /// # Arguments
+    ///
+    /// * `field` - Field to look the term up in.
+    /// * `term` - Term to look up.
+    ///
+    /// # Returns
+    ///
+    /// The matching document ids, or `None` when there are none.
     fn find_doc_ids_by_term(&self, field: &str, term: &str) -> Result<Option<Vec<u64>>> {
         let full_term = format!("{field}:{term}");
+        let mut seen = AHashSet::new();
+        let mut ids: Vec<u64> = Vec::new();
 
-        // 1. Check in-memory inverted index. The index may hold stale postings
-        // for docs removed since the last rebuild (deferred under #828), so keep
-        // only ids still in the live buffer; a same-id re-upsert can also leave
+        // 1. In-memory buffer. The index may hold stale postings for docs
+        // removed since the last rebuild (deferred under #828), so keep only
+        // ids still in the live buffer; a same-id re-upsert can also leave
         // two postings for one id, so dedup.
         if let Some(posting_list) = self.inverted_index.get_posting_list(&full_term) {
-            let mut seen = AHashSet::new();
-            let ids: Vec<u64> = posting_list
-                .postings
-                .iter()
-                .map(|p| p.doc_id)
-                .filter(|id| self.buffered_doc_ids.contains(id) && seen.insert(*id))
-                .collect();
-            if !ids.is_empty() {
-                return Ok(Some(ids));
+            ids.extend(
+                posting_list
+                    .postings
+                    .iter()
+                    .map(|p| p.doc_id)
+                    .filter(|id| self.buffered_doc_ids.contains(id) && seen.insert(*id)),
+            );
+        }
+
+        // 2. Segments flushed but not yet committed. Usually empty, in
+        // which case this loop costs nothing. Ids whose persisted copy has
+        // since been superseded are skipped — that is exactly what
+        // `pending_deletions` records.
+        for segment in &self.flushed_segments {
+            let Some(mut postings) = segment.postings(field, term)? else {
+                continue;
+            };
+            while postings.next()? {
+                let doc_id = postings.doc_id();
+                if !self.pending_deletions.contains(&doc_id) && seen.insert(doc_id) {
+                    ids.push(doc_id);
+                }
             }
         }
 
-        Ok(None)
+        if ids.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(ids))
+        }
     }
 
     /// Analyze a document into terms.
@@ -781,6 +837,15 @@ impl InvertedIndexWriter {
         // (Issue #559 / #864) so an overwrite of one of these docs later in
         // this writer's life resolves without rescanning storage.
         self.extend_segment_cache(&segment_name);
+
+        // Keep a reader over the segment just written so `_id` lookups
+        // survive the buffer being emptied below (#1016). Built from the
+        // same `SegmentInfo` the `.meta` was serialised from, and before
+        // the buffers that description is computed from are cleared.
+        self.flushed_segments.push(SegmentReader::open(
+            self.segment_info_for(&segment_name),
+            self.storage.clone(),
+        )?);
 
         // Clear buffers
         self.buffered_docs.clear();
@@ -1360,12 +1425,28 @@ impl InvertedIndexWriter {
             .push((segment_name.to_string(), min_id, max_id));
     }
 
-    /// Write segment metadata.
-    fn write_segment_metadata(&self, segment_name: &str) -> Result<()> {
+    /// Describe the segment about to be written from the current buffer.
+    ///
+    /// Shared by [`Self::write_segment_metadata`], which serialises it to
+    /// `<segment>.meta`, and [`Self::flush_segment`], which opens a
+    /// [`SegmentReader`] over the same description so NRT `_id` lookups
+    /// keep working after the buffer is cleared (#1016). Building it in
+    /// one place keeps the on-storage `.meta` and the in-memory reader
+    /// from describing the same segment differently — the same reason
+    /// [`Self::buffered_doc_id_range`] exists.
+    ///
+    /// Must be called **before** the buffers it summarises are cleared.
+    ///
+    /// # Arguments
+    ///
+    /// * `segment_name` - Name the segment's files are written under.
+    ///
+    /// # Returns
+    ///
+    /// The segment's metadata.
+    fn segment_info_for(&self, segment_name: &str) -> SegmentInfo {
         let (min_id, max_id) = self.buffered_doc_id_range();
-
-        // Create SegmentInfo
-        let info = SegmentInfo {
+        SegmentInfo {
             segment_id: segment_name.to_string(),
             doc_count: self.buffered_docs.len() as u64,
             min_doc_id: min_id,
@@ -1373,7 +1454,12 @@ impl InvertedIndexWriter {
             generation: self.current_segment as u64,
             has_deletions: false, // New segments initially have no deletions
             shard_id: self.config.shard_id,
-        };
+        }
+    }
+
+    /// Write segment metadata.
+    fn write_segment_metadata(&self, segment_name: &str) -> Result<()> {
+        let info = self.segment_info_for(segment_name);
 
         // Write as JSON for compatibility with InvertedIndex::load_segments()
         let meta_file = format!("{segment_name}.meta");
@@ -1409,6 +1495,12 @@ impl InvertedIndexWriter {
         // Write index metadata
         self.write_index_metadata()?;
         self.write_metadata_json()?;
+
+        // The committed searcher can serve these segments now, so stop
+        // carrying our own readers for them (#1016). `LexicalStore::commit`
+        // drops the cached searcher right after this, so the next one is
+        // rebuilt over the full committed set.
+        self.flushed_segments.clear();
 
         Ok(())
     }
@@ -1612,10 +1704,17 @@ impl InvertedIndexWriter {
             }
             // Track globally
             self.stats.deleted_count += deleted;
-        }
 
-        // Add to pending deletions for NRT visibility
-        self.pending_deletions.insert(doc_id);
+            // Record that this id's *persisted* copy is superseded, so an
+            // NRT `_id` lookup does not hand back the stale version.
+            //
+            // Scoped to the branch that actually deleted something. It used
+            // to run unconditionally, which flagged every freshly inserted
+            // document with its own id — nothing had been deleted, and the
+            // set is never cleared, so after an automatic flush the lookup
+            // discarded the document it was looking for (#1016).
+            self.pending_deletions.insert(doc_id);
+        }
 
         Ok(())
     }
@@ -1700,6 +1799,11 @@ impl InvertedIndexWriter {
         // `.meta` files for merged-away segments.
         self.deletion_manager = None;
         self.pending_meta_deletions.clear();
+        // The force-merge that prompted this replaced the files these
+        // readers were opened over, so they describe segments that no
+        // longer exist (#1016). `LexicalStore::optimize` drops the cached
+        // searcher at the same time, so the merged result stays reachable.
+        self.flushed_segments.clear();
         Ok(())
     }
 

--- a/laurus/src/lexical/store.rs
+++ b/laurus/src/lexical/store.rs
@@ -828,6 +828,108 @@ mod tests {
             .build()
     }
 
+    /// #1016 — a document written before the writer's automatic
+    /// `flush_segment` must still resolve by `_id` before commit.
+    ///
+    /// The flush empties the in-memory buffer, which used to be the only
+    /// thing the NRT lookup searched, so the document silently stopped
+    /// being findable — which is what made `get` return nothing and
+    /// `delete` do nothing for it.
+    #[test]
+    fn doc_written_before_auto_flush_still_resolves_by_id() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let store = LexicalStore::new(storage, LexicalIndexConfig::default()).unwrap();
+
+        // Past `max_buffered_docs` (10_000) so the writer auto-flushes.
+        //
+        // Resolve before every write, exactly as the ingest path does —
+        // `Engine::index_internal` runs `delete_documents_internal`, and so
+        // `find_doc_ids_by_term`, on every put (engine.rs:787). That warms
+        // the searcher cache well before the flush, which is the state the
+        // bug actually occurs in; a test that only resolves at the end gets
+        // a cold cache and a freshly built searcher, and would pass without
+        // the fix.
+        let total = 10_050u64;
+        for i in 0..total {
+            let id = format!("id{i:06}");
+            let _ = store.find_doc_ids_by_term("_id", &id).unwrap();
+            let doc = Document::builder()
+                .add_text("_id", &id)
+                .add_text("body", "alpha")
+                .build();
+            store.upsert_document(i + 1, doc).unwrap();
+        }
+
+        // No commit at any point.
+        let buffered = store.find_doc_ids_by_term("_id", "id010040").unwrap();
+        assert_eq!(buffered.len(), 1, "a buffered doc must resolve");
+
+        let flushed = store.find_doc_ids_by_term("_id", "id000000").unwrap();
+        assert_eq!(
+            flushed,
+            vec![1u64],
+            "a doc written before the automatic flush must still resolve"
+        );
+    }
+
+    /// #1016 — after an automatic flush, `_id` resolution must still
+    /// surface the flushed copy so a later upsert can supersede it.
+    ///
+    /// This is the mechanism behind the duplicate-document symptom.
+    /// `Engine::index_internal` implements upsert as "resolve the `_id` to
+    /// its existing internal ids, delete those, then write the new
+    /// version" (engine.rs:1065). When resolution silently returned
+    /// nothing, step one found no old version, nothing was deleted, and
+    /// the batch ended with two live copies of the same `_id`.
+    ///
+    /// `docs/src/laurus/deletions.md` states that "upsert deduplication
+    /// within an uncommitted batch is handled separately and is always
+    /// correct"; this pins that sentence.
+    #[test]
+    fn upsert_across_auto_flush_supersedes_the_flushed_version() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let store = LexicalStore::new(storage, LexicalIndexConfig::default()).unwrap();
+
+        // Resolve before every write, warming the searcher cache the way
+        // the real ingest path does (see the sibling test).
+        for i in 0..10_050u64 {
+            let id = format!("id{i:06}");
+            let _ = store.find_doc_ids_by_term("_id", &id).unwrap();
+            let doc = Document::builder()
+                .add_text("_id", &id)
+                .add_text("body", "alpha")
+                .build();
+            store.upsert_document(i + 1, doc).unwrap();
+        }
+
+        // Step 1 of the engine's upsert: resolve the existing copies. This
+        // is what used to come back empty.
+        let existing = store.find_doc_ids_by_term("_id", "id000000").unwrap();
+        assert_eq!(
+            existing,
+            vec![1u64],
+            "the flushed copy must be visible to the upsert that supersedes it"
+        );
+
+        // Steps 2 and 3: delete what was found, then write the new version
+        // under a fresh internal id.
+        for doc_id in &existing {
+            store.delete_document_by_internal_id(*doc_id).unwrap();
+        }
+        let replacement = Document::builder()
+            .add_text("_id", "id000000")
+            .add_text("body", "beta")
+            .build();
+        store.upsert_document(90_001, replacement).unwrap();
+
+        let after = store.find_doc_ids_by_term("_id", "id000000").unwrap();
+        assert_eq!(
+            after,
+            vec![90_001u64],
+            "only the new version may remain — no duplicate"
+        );
+    }
+
     #[test]
     fn test_search_engine_creation() {
         let temp_dir = TempDir::new().unwrap();

--- a/laurus/tests/uncommitted_autoflush_visibility_test.rs
+++ b/laurus/tests/uncommitted_autoflush_visibility_test.rs
@@ -1,0 +1,142 @@
+//! End-to-end tests for #1016: documents written before the writer's
+//! automatic `flush_segment` must stay reachable by `_id` before a commit.
+//!
+//! `InvertedIndexWriter` flushes a segment automatically once
+//! `max_buffered_docs` (10 000) documents are buffered, which empties the
+//! in-memory buffer the NRT `_id` lookup used to be limited to. Under the
+//! default `CommitPolicy::Manual` that made every document written earlier
+//! in an uncommitted batch silently unreachable: `get_documents` returned
+//! nothing and `delete_documents` did nothing, with no error either way.
+//!
+//! These tests drive the public `Engine` API, so they pin the symptom a
+//! user would actually hit rather than the internals that cause it.
+
+use std::sync::Arc;
+
+use laurus::lexical::TextOption;
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document, Engine, FieldOption, Schema};
+
+/// `InvertedIndexWriterConfig::default().max_buffered_docs`.
+const MAX_BUFFERED_DOCS: usize = 10_000;
+
+/// A schema with a single `title` text field.
+fn title_schema() -> Schema {
+    Schema::builder()
+        .add_field("title", FieldOption::Text(TextOption::default()))
+        .build()
+}
+
+/// Build a `(id, doc)` batch entry.
+fn entry(i: usize, title: &str) -> (String, Document) {
+    let doc = Document::builder()
+        .add_field("title", DataValue::Text(title.into()))
+        .build();
+    (format!("id{i:06}"), doc)
+}
+
+/// Write past the automatic flush boundary and confirm it actually fired,
+/// returning the engine and its storage.
+async fn engine_past_auto_flush() -> laurus::Result<(Engine, Arc<dyn Storage>)> {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let engine = Engine::new(storage.clone(), title_schema()).await?;
+
+    let docs: Vec<_> = (0..MAX_BUFFERED_DOCS + 50)
+        .map(|i| entry(i, "alpha"))
+        .collect();
+    engine.put_documents(docs).await?;
+
+    // The flush must really have happened, or these tests prove nothing:
+    // a segment `.meta` exists even though nothing has been committed.
+    let flushed = storage
+        .list_files()?
+        .iter()
+        .any(|f| f.contains("segment_") && f.ends_with(".meta"));
+    assert!(
+        flushed,
+        "automatic flush_segment must fire at max_buffered_docs"
+    );
+
+    Ok((engine, storage))
+}
+
+/// A document written before the automatic flush must still be readable
+/// before commit — the core symptom of #1016.
+#[tokio::test(flavor = "multi_thread")]
+async fn get_document_written_before_auto_flush_is_readable() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    // Control: a document still sitting in the in-memory buffer.
+    let late = engine
+        .get_documents(&format!("id{:06}", MAX_BUFFERED_DOCS + 10))
+        .await?;
+    assert_eq!(late.len(), 1, "a buffered document must be readable");
+
+    // Subject: a document written before the flush emptied the buffer.
+    let early = engine.get_documents("id000000").await?;
+    assert_eq!(
+        early.len(),
+        1,
+        "a document written before the automatic flush must be readable before commit"
+    );
+
+    Ok(())
+}
+
+/// Deleting such a document must actually remove it rather than silently
+/// doing nothing.
+#[tokio::test(flavor = "multi_thread")]
+async fn delete_document_written_before_auto_flush_removes_it() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    engine.delete_documents("id000000").await?;
+    engine.commit().await?;
+
+    let after_delete = engine.get_documents("id000000").await?;
+    assert!(
+        after_delete.is_empty(),
+        "deleting a pre-flush document must remove it, got {} hit(s)",
+        after_delete.len()
+    );
+    // Counts are only comparable on the same side of a commit, so assert
+    // the absolute figure: everything written, less the one deleted.
+    assert_eq!(
+        engine.stats()?.document_count,
+        (MAX_BUFFERED_DOCS + 50 - 1) as u64,
+        "the delete must be reflected in the document count, not silently dropped"
+    );
+
+    Ok(())
+}
+
+/// Re-putting an `_id` written before the automatic flush must supersede
+/// the earlier version instead of leaving a duplicate behind.
+///
+/// `docs/src/laurus/deletions.md` states that "upsert deduplication within
+/// an uncommitted batch is handled separately and is always correct". When
+/// `_id` resolution came back empty, the upsert found no previous version
+/// to delete and the batch ended with two live copies.
+#[tokio::test(flavor = "multi_thread")]
+async fn upsert_across_auto_flush_leaves_no_duplicate() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    // Overwrite a document from before the flush, still without committing.
+    let (id, doc) = entry(0, "beta");
+    engine.put_document(&id, doc).await?;
+    engine.commit().await?;
+
+    let hits = engine.get_documents("id000000").await?;
+    assert_eq!(
+        hits.len(),
+        1,
+        "the re-put must supersede the earlier version, not duplicate it"
+    );
+    assert_eq!(
+        engine.stats()?.document_count,
+        (MAX_BUFFERED_DOCS + 50) as u64,
+        "an overwrite must not increase the document count"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #1016

A document written before the writer's automatic `flush_segment` became unreachable by `_id` until the next commit. `get_documents` returned nothing, `delete_documents` did nothing — **both silently**, with no error either way. A re-put of the same `_id` then failed to supersede the earlier version, leaving duplicates in the committed index.

The default commit policy is `Manual` and the flush fires at `max_buffered_docs` = 10 000, so the exposed path is bulk ingestion (#551).

## Two stacked defects

`LexicalStore::find_doc_ids_by_term` resolves an `_id` in two steps: the writer's in-memory buffer, then a search over the persisted index. The automatic flush empties the buffer, so step 1 stops seeing the document — and **both halves of step 2 then fail it**.

**Defect 1.** `mark_persisted_doc_deleted` inserted a document's **own** id into `pending_deletions` unconditionally, *outside* the `if !segments.is_empty()` block that does the actual deleting. So every fresh insert flagged itself, and the set is never cleared — no `remove`, no `clear`, in `flush_segment`, `commit`, `rollback`, `flush_deletions` or `close`. Step 2 then discarded exactly the document it was looking for.

**Defect 2.** The NRT lookup searched only the in-memory buffer, which the flush had just emptied.

Both are load-bearing — see the red proof below.

## The fix implements a promise the code already made

`laurus/src/lexical/writer.rs:170` documents this lookup as performing *"a near-real-time (NRT) lookup against **both the in-memory buffer and committed segments**"*, and the implementation carried a literal `// 2. TODO: Check persisted segments`, deferred because *"this requires opening readers for existing segments, which is expensive if done on every write."*

This fills that TODO, scoped to **only the segments this writer flushed since its last commit** — normally none. The cost objection does not apply at that scope: the added loop runs **zero times** when nothing has been flushed, and `k` in-memory dictionary lookups per put after `k` flushes. `SegmentReader::open` is fully lazy, so registering one costs no I/O.

Defect 1 is fixed by moving the insert inside the branch that actually deleted something, restoring the set's meaning to *"this id's persisted copy is superseded"*. That is sound because `flush_segment` already calls `extend_segment_cache`, so a later upsert of an id living in a just-flushed segment still finds it and flags it correctly.

Readers are released on `commit()` (the shared searcher takes over) and on `invalidate_segment_cache()` (optimize's force-merge replaces the files underneath), but **not** on `rollback()` — a flushed segment is on storage and cannot be taken back.

`store.rs` is unchanged. No searcher-cache invalidation is added. User-visible search behaviour does not change.

## Why search visibility was deliberately left alone

The cheap-looking fix — invalidate the searcher cache on flush — would have introduced a *new* correctness regression.

`docs/src/laurus/deletions.md` states:

> deletion **visibility is commit-scoped**: like newly added documents, a deletion becomes visible to searches after the next `commit()` (**upsert deduplication within an uncommitted batch is handled separately and is always correct**)

The project separates the two on purpose, and this bug violates the *second* declaration. Fixing it by moving the first would break the contract in the other direction — and worse: deletions have been group-committed since #875, so `.delmap` is written only at commit. A searcher able to see flushed-but-uncommitted segments applies only the **on-disk** bitmap, so a version superseded between flush and commit would surface as a live hit and inflate `total_hits`. Today that is latent non-determinism; that change would have made it reproducible.

The underlying non-determinism — a freshly built searcher sees flushed-but-uncommitted segments because `load_segments()` scans storage with no commit gate — is real and now tracked as **#1017**. Splitting it was confirmed with the owner.

## Tests, and a red proof for each defect

**The first version of these tests was inert** and it is worth recording why. The store-level tests passed with defect 2's fix disabled, because they resolved an `_id` only *after* all the writes — leaving the searcher cache cold, so a fresh searcher was built and happened to see the flushed segment. The real ingest path calls `find_doc_ids_by_term` on **every** put (`Engine::index_internal` → `delete_documents_internal`), so the cache is warm long before the flush. The tests now model that.

With that corrected, each fix was disabled in turn:

| state | store tests (2) | end-to-end tests (3) |
|---|---|---|
| defect 1 fix disabled | FAILED | 3/3 FAILED |
| defect 2 fix disabled | FAILED | 3/3 FAILED |
| both applied | pass | 3/3 pass |

New `laurus/tests/uncommitted_autoflush_visibility_test.rs` drives the public `Engine` API and pins the user-visible symptom: a pre-flush document is readable before commit; deleting it actually removes it and the document count reflects that; and a re-put of the same `_id` leaves no duplicate. Each first asserts that the automatic flush really fired (a `segment_*.meta` exists with nothing committed), so the tests cannot pass by failing to set up their own premise.

Two store-level tests cover the resolution itself, including the engine's upsert sequence — resolve, delete what was found, write the new version — ending with only the new id.

`cargo test --workspace` **1911 passed / 0 failed**; `cargo clippy --all-targets --features embeddings-all -- -D warnings` and `cargo fmt --all --check` clean on Rust 1.98.

## How it was found

While investigating the remaining scope of #541, `pending_deletions` turned out not to be a deletion set at all — it gains an entry per *written* document. That also means this fix shrinks it from "every document written since the writer was created" to "documents actually superseded", which is most of what #541 wanted from that field.
