### PR TITLE
perf(lexical/index): merge against the deletion bitmap instead of a hash set

### DIFF
--- a/laurus/src/lexical/index/inverted/maintenance/background_tasks.rs
+++ b/laurus/src/lexical/index/inverted/maintenance/background_tasks.rs
@@ -541,12 +541,9 @@ impl BackgroundScheduler {
                 Self::execute_merge_task(&segment_ids, segment_manager, merge_engine)
             }
 
-            TaskType::Compaction { segment_id, .. } => Self::execute_compaction_task(
-                &segment_id,
-                deletion_manager,
-                segment_manager,
-                merge_engine,
-            ),
+            TaskType::Compaction { segment_id, .. } => {
+                Self::execute_compaction_task(&segment_id, segment_manager, merge_engine)
+            }
 
             TaskType::Optimization {
                 target_segments,
@@ -668,7 +665,6 @@ impl BackgroundScheduler {
     /// Execute compaction task.
     fn execute_compaction_task(
         segment_id: &str,
-        deletion_manager: &DeletionManager,
         segment_manager: &SegmentManager,
         merge_engine: &MergeEngine,
     ) -> (TaskStatus, u64, u64, Option<String>) {
@@ -685,13 +681,12 @@ impl BackgroundScheduler {
             }
         };
 
-        // Create a merge task with just this segment
-        // The merge engine handles removal of deleted documents
-        // Reuse execute_merge_task logic by calling it directly?
-        // No, execute_merge_task takes a list of IDs.
-
-        let _deleted_count = deletion_manager.get_deleted_docs(segment_id).len() as u64;
-
+        // Compact by merging this segment with itself: the merge engine
+        // drops the deleted documents as it reconstructs.
+        //
+        // The deleted count used to be read here into a discarded binding,
+        // which built an entire `Vec<u64>` of ids — O(deletions) allocation
+        // for a value nothing looked at (#541).
         Self::execute_merge_task(&[segment_id.to_string()], segment_manager, merge_engine)
     }
 

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -2446,6 +2446,101 @@ mod tests {
     use super::*;
     use crate::lexical::reader::PostingIterator;
 
+    /// #541 — `SegmentReader::postings` must never yield a deleted
+    /// document, on either of its paths.
+    ///
+    /// The segment merge relies on this: its per-posting loop no longer
+    /// re-checks the deletion set, because doing so could not ever fire
+    /// and cost a membership test on the merge's innermost loop. That
+    /// makes this invariant load-bearing rather than incidental, so it is
+    /// pinned here — a test that fails when the invariant breaks is
+    /// stronger protection than a runtime check that cannot.
+    ///
+    /// Both paths are covered: the normal one through `filter_deleted_soa`,
+    /// and the `scan_documents_for_term` fallback taken when a segment has
+    /// no `.post` file.
+    #[test]
+    fn postings_never_yields_a_deleted_document() {
+        use crate::lexical::index::inverted::writer::{
+            InvertedIndexWriter, InvertedIndexWriterConfig,
+        };
+        use crate::lexical::writer::LexicalIndexWriter;
+        use crate::maintenance::deletion::{DeletionConfig, DeletionManager};
+        use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let mut writer =
+            InvertedIndexWriter::new(storage.clone(), InvertedIndexWriterConfig::default())
+                .unwrap();
+
+        let doc_count = 60u64;
+        for _ in 0..doc_count {
+            writer
+                .add_document(crate::Document::builder().add_text("body", "alpha").build())
+                .unwrap();
+        }
+        writer.commit().unwrap();
+
+        let reader = writer.build_reader().unwrap();
+        let inverted = reader
+            .as_any()
+            .downcast_ref::<InvertedIndexReader>()
+            .unwrap();
+        let info = inverted.segment_readers()[0]
+            .read()
+            .unwrap()
+            .segment_info()
+            .clone();
+
+        // Delete every third document straight into the segment's `.delmap`.
+        let manager = DeletionManager::new(
+            DeletionConfig {
+                enable_deletion_log: false,
+                ..Default::default()
+            },
+            storage.clone(),
+        )
+        .unwrap();
+        manager
+            .initialize_segment(&info.segment_id, info.min_doc_id, info.max_doc_id)
+            .unwrap();
+        let mut deleted_ids = Vec::new();
+        for doc_id in (info.min_doc_id..=info.max_doc_id).step_by(3) {
+            manager
+                .delete_document(&info.segment_id, doc_id, "test")
+                .unwrap();
+            deleted_ids.push(doc_id);
+        }
+        manager.flush().unwrap();
+        assert!(!deleted_ids.is_empty(), "the fixture must delete something");
+
+        // Re-open with `has_deletions` set, the state the merge sees.
+        let mut info_with_deletions = info.clone();
+        info_with_deletions.has_deletions = true;
+        let segment = SegmentReader::open(info_with_deletions, storage).unwrap();
+
+        let mut iter = segment
+            .postings("body", "alpha")
+            .unwrap()
+            .expect("term must have postings");
+        let mut seen = Vec::new();
+        while iter.next().unwrap() {
+            seen.push(iter.doc_id());
+        }
+
+        assert_eq!(
+            seen.len(),
+            (doc_count as usize) - deleted_ids.len(),
+            "postings must yield exactly the live documents"
+        );
+        for id in &deleted_ids {
+            assert!(
+                !seen.contains(id),
+                "postings yielded deleted doc {id}; the merge relies on it not doing so"
+            );
+        }
+    }
+
     /// #553 — the production decoder selector, end to end.
     ///
     /// `SegmentReader::postings` is the only place that chooses a

--- a/laurus/src/lexical/index/inverted/segment/merge_engine.rs
+++ b/laurus/src/lexical/index/inverted/segment/merge_engine.rs
@@ -5,7 +5,8 @@
 
 use std::sync::Arc;
 
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
+use roaring::RoaringTreemap;
 
 use crate::error::{LaurusError, Result};
 use crate::lexical::core::analyzed::{AnalyzedDocument, AnalyzedTerm};
@@ -297,7 +298,7 @@ impl MergeEngine {
                 &deleted,
                 &mut store_positions,
             )?;
-            stats.deleted_docs_removed += deleted.len() as u64;
+            stats.deleted_docs_removed += deleted.len();
             for (doc_id, analyzed) in reconstructed {
                 if docs.insert(doc_id, analyzed).is_none() {
                     order.push(doc_id);
@@ -370,10 +371,9 @@ impl MergeEngine {
     }
 
     /// Load the set of deleted doc_ids for a segment from its `.delmap`.
-    fn load_deleted_docs(&self, segment_info: &SegmentInfo) -> Result<AHashSet<u64>> {
-        let mut deleted = AHashSet::new();
+    fn load_deleted_docs(&self, segment_info: &SegmentInfo) -> Result<RoaringTreemap> {
         if !segment_info.has_deletions {
-            return Ok(deleted);
+            return Ok(RoaringTreemap::new());
         }
         let bitmap_file = format!("{}.delmap", segment_info.segment_id);
         if let Ok(input) = self.storage.open_input(&bitmap_file) {
@@ -383,12 +383,17 @@ impl MergeEngine {
             if let Ok(mut reader) = StructReader::new(input)
                 && let Ok(bitmap) = DeletionBitmap::read_from_storage(&mut reader)
             {
-                for doc_id in bitmap.get_deleted_docs() {
-                    deleted.insert(doc_id);
-                }
+                // The `.delmap` payload already *is* a Roaring bitmap, and
+                // the merge only ever asks it for a count and membership —
+                // both of which it answers directly. Expanding it into a
+                // `Vec` and then a hash set turned ~125 KB into tens of
+                // megabytes of transient allocation for a segment with a
+                // million deletions, and replaced a bit test with a hashed
+                // probe on the merge's innermost loops (#541).
+                return Ok(bitmap.into_deleted_docs());
             }
         }
-        Ok(deleted)
+        Ok(RoaringTreemap::new())
     }
 
     /// Load a segment reader for the given segment.
@@ -423,7 +428,7 @@ impl MergeEngine {
         &self,
         reader: &SegmentReader,
         segment_id: &str,
-        deleted: &AHashSet<u64>,
+        deleted: &RoaringTreemap,
         store_positions: &mut Option<bool>,
     ) -> Result<Vec<(u64, AnalyzedDocument)>> {
         // Pass 1: bucket postings into per-doc analyzed terms.
@@ -435,10 +440,21 @@ impl MergeEngine {
                 };
                 if let Some(mut iter) = reader.postings(field, term)? {
                     while iter.next()? {
+                        // No deletion check here: `SegmentReader::postings`
+                        // already excludes deleted documents on both of its
+                        // paths — `filter_deleted_soa` for the normal one and
+                        // `scan_documents_for_term` for the no-inverted-index
+                        // fallback — gating on the same `has_deletions` flag
+                        // and the same `.delmap` this merge reads.
+                        //
+                        // That invariant is pinned by
+                        // `postings_never_yields_a_deleted_document` in
+                        // reader.rs, which is stronger protection than a
+                        // second test that can never fire, on the innermost
+                        // loop of the merge. The BKD and stored-document
+                        // loops below get no such filtering and do check
+                        // (#541).
                         let doc_id = iter.doc_id();
-                        if deleted.contains(&doc_id) {
-                            continue;
-                        }
                         let positions = iter.positions()?;
                         let freq = iter.term_freq();
                         if store_positions.is_none() {
@@ -493,7 +509,9 @@ impl MergeEngine {
                 let mut visitor = CollectPointsVisitor::default();
                 tree.intersect(&mut visitor)?;
                 for (doc_id, point) in visitor.entries {
-                    if deleted.contains(&doc_id) {
+                    // Load-bearing: `get_bkd_tree` hands back the raw
+                    // `BKDReader`, which knows nothing about deletions.
+                    if deleted.contains(doc_id) {
                         continue;
                     }
                     points
@@ -509,7 +527,9 @@ impl MergeEngine {
         // Pass 2: assemble each live document.
         let mut out = Vec::new();
         for doc_id in reader.doc_ids()? {
-            if deleted.contains(&doc_id) {
+            // Load-bearing: `doc_ids()` returns every stored key, deleted
+            // ones included.
+            if deleted.contains(doc_id) {
                 continue;
             }
             let Some(stored) = reader.document(doc_id)? else {
@@ -602,6 +622,108 @@ mod tests {
 
     use crate::storage::memory::MemoryStorage;
     use crate::storage::memory::MemoryStorageConfig;
+
+    /// #541 — the deterministic gate.
+    ///
+    /// The merge used to expand the `.delmap`'s Roaring bitmap into a
+    /// `Vec<u64>` and then an `AHashSet<u64>`, both discarded when the
+    /// merge finished. This pins what that cost, without a stopwatch:
+    /// wall-clock benchmarks are noise-dominated on this host, and no
+    /// benchmark reaches `MergeEngine` at all.
+    ///
+    /// `serialized_size()` is the repository's own yardstick for this
+    /// comparison — `DeletionBitmap::memory_usage` is defined as exactly
+    /// that, and its doc comment records that it replaced "the previous
+    /// `AHashSet::capacity()` heuristic".
+    ///
+    /// The point asserted is structural rather than a single ratio: over a
+    /// dense run of deletions the bitmap's size **does not grow at all**
+    /// while the hash set grows with the deletion count. A ratio measured
+    /// at one size would have hidden that, and would also have been
+    /// measured at whichever container boundary happened to be worst.
+    ///
+    /// The hash-set figure, `capacity() * size_of::<u64>()`, deliberately
+    /// UNDERSTATES the old cost: it ignores hashbrown's one control byte
+    /// per bucket and its 8/7 over-allocation, and ignores the `Vec<u64>`
+    /// materialised alongside it. Every number here is a floor.
+    #[test]
+    fn roaring_deletion_set_is_far_smaller_than_the_hash_set_it_replaced() {
+        use ahash::AHashSet;
+        use roaring::RoaringTreemap;
+
+        let mut measured: Vec<(u64, usize, usize)> = Vec::new();
+
+        // Dense runs — the shape a segment accumulates over its life.
+        for deleted_count in [4_096u64, 16_384, 65_536] {
+            let mut bitmap = RoaringTreemap::new();
+            for doc_id in 0..deleted_count {
+                bitmap.insert(doc_id);
+            }
+
+            let old: AHashSet<u64> = bitmap.iter().collect();
+            assert_eq!(
+                old.len() as u64,
+                bitmap.len(),
+                "the substitution must be lossless at {deleted_count} deletions"
+            );
+
+            measured.push((
+                deleted_count,
+                bitmap.serialized_size(),
+                old.capacity() * std::mem::size_of::<u64>(),
+            ));
+        }
+
+        // The bitmap is flat across a 16x growth in deletions; the hash set
+        // is not. This is the mechanism, and it is what makes the saving
+        // scale with segment size rather than being a fixed discount.
+        let bitmap_sizes: Vec<usize> = measured.iter().map(|(_, b, _)| *b).collect();
+        assert!(
+            bitmap_sizes.iter().all(|b| *b == bitmap_sizes[0]),
+            "a dense run must stay one container regardless of length: {measured:?}"
+        );
+
+        let first = measured[0];
+        let last = measured[measured.len() - 1];
+        assert!(
+            last.2 >= first.2 * 8,
+            "the hash set must grow with the deletion count: {measured:?}"
+        );
+
+        // Even at the worst container boundary the hash set alone — before
+        // counting the transient Vec — is several times the bitmap.
+        for (count, roaring_bytes, hash_set_bytes) in &measured {
+            let discarded_vec_bytes = (*count as usize) * std::mem::size_of::<u64>();
+            assert!(
+                hash_set_bytes >= &(6 * roaring_bytes),
+                "at {count} deletions: hash set {hash_set_bytes} B vs bitmap {roaring_bytes} B, \
+                 plus a further {discarded_vec_bytes} B of transient Vec"
+            );
+        }
+    }
+
+    /// #541 — `into_deleted_docs` must hand over exactly what
+    /// `get_deleted_docs` used to collect, so switching the merge to the
+    /// bitmap changes what it allocates and nothing else.
+    #[test]
+    fn into_deleted_docs_matches_the_vec_it_replaces() {
+        use crate::maintenance::deletion::DeletionBitmap;
+
+        let bitmap = DeletionBitmap::new("seg_x".to_string(), 0, 999);
+        for doc_id in [3u64, 7, 42, 900, 999] {
+            bitmap.delete_document(doc_id).unwrap();
+        }
+
+        let as_vec = bitmap.get_deleted_docs();
+        let as_bitmap = bitmap.into_deleted_docs();
+
+        assert_eq!(as_bitmap.len(), as_vec.len() as u64);
+        assert_eq!(as_bitmap.iter().collect::<Vec<u64>>(), as_vec);
+        for doc_id in &as_vec {
+            assert!(as_bitmap.contains(*doc_id));
+        }
+        assert!(!as_bitmap.contains(4));
+    }
 
     #[allow(dead_code)]
     fn create_test_segment(id: &str, doc_count: u64) -> ManagedSegmentInfo {

--- a/laurus/src/maintenance/deletion.rs
+++ b/laurus/src/maintenance/deletion.rs
@@ -214,6 +214,25 @@ impl DeletionBitmap {
         docs.iter().collect()
     }
 
+    /// Consume this bitmap and hand over its deleted-id set directly.
+    ///
+    /// Unlike [`Self::get_deleted_docs`], which collects the ids into a
+    /// `Vec<u64>`, this moves the underlying `RoaringTreemap` out — no
+    /// clone, no intermediate allocation. Use it when the caller only
+    /// needs membership tests and a count, which the treemap answers
+    /// directly and far more compactly (#541).
+    ///
+    /// # Returns
+    ///
+    /// The owned set of deleted document IDs.
+    pub fn into_deleted_docs(self) -> RoaringTreemap {
+        // A poisoned lock still holds a valid bitmap — only a writer
+        // panicked — so recover rather than propagate.
+        self.deleted_docs
+            .into_inner()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     /// Get an approximate memory usage of this deletion tracker in bytes.
     ///
     /// The estimate includes the struct itself, the segment ID string buffer,


### PR DESCRIPTION
Closes #541

The segment merge read a `.delmap` — whose payload **already is a Roaring bitmap** — and then materialised the same set twice:

```rust
for doc_id in bitmap.get_deleted_docs() {   // Roaring -> Vec<u64>
    deleted.insert(doc_id);                 //          -> AHashSet<u64>
}
```

Both were discarded when the merge finished. At a million deletions that is roughly **8 MB of transient `Vec` plus 16–32 MB of hash set**, built from a bitmap of about 125 KB.

The merge only ever asks that set for a count and for membership, and a `RoaringTreemap` answers both directly. `load_deleted_docs` now hands the bitmap over through a new `DeletionBitmap::into_deleted_docs()` — no clone, no intermediate `Vec` — and the innermost loops trade a hashed probe for a bit test.

## The per-posting check, and why only that one

Removing a deletion filter from a path that **rewrites data** is how documents get silently resurrected, so the three `contains` sites were checked one at a time rather than as a group.

| site | upstream filtering | outcome |
|---|---|---|
| `:439` postings | filtered on **both** paths — `filter_deleted_soa` and the `scan_documents_for_term` fallback | removed |
| `:496` BKD entries | `get_bkd_tree()` returns the raw `BKDReader`, which knows nothing about deletions | **kept** |
| `:512` stored documents | `doc_ids()` returns every stored key, deleted ones included | **kept** |

For `:439`: both paths gate on the same `info.has_deletions` flag and read the same `.delmap` that `load_deleted_docs` reads; the merge opens its reader from the *same* `SegmentInfo`, with the posting cache at capacity 0, so there is no stale-cache path either. The two loaders do differ on a corrupt `.delmap` — `load_deletion_bitmap` propagates the error while `load_deleted_docs` swallows it — but that cannot produce a wrong result: the reader errors first and the merge aborts before reaching the check.

The invariant this removal depends on is now pinned by `postings_never_yields_a_deleted_document`, **with its RED proven**: the test fails when the deletion filter is disabled and passes when it is restored. A test that fails when the invariant breaks is better protection than a second runtime check that could never fire, on the merge's innermost loop.

## Effect: stated in bytes, not in time

**No timing improvement is claimed, because none was measured.** No benchmark reaches `MergeEngine` at all, and wall-clock on the development host is noise-dominated — a recent change (#944 Phase B) could not resolve a delta across three rounds of increasingly strict methodology.

The gate is deterministic instead. `serialized_size()` is this repository's own yardstick for exactly this comparison: `DeletionBitmap::memory_usage` is defined as that, and its doc comment records that it replaced *"the previous `AHashSet::capacity()` heuristic"*.

| deletions | Roaring | AHashSet |
|---|---|---|
| 4,096 | 8,220 B | 57,344 B |
| 16,384 | **8,220 B** | 229,376 B |
| 65,536 | **8,220 B** | 917,504 B |

The point asserted is structural rather than a single ratio: **the bitmap is flat across a 16× growth in deletions while the hash set grows with them**, so the saving scales with segment size instead of being a fixed discount. The first version of this gate asserted "hash set ≥ 8× bitmap" and failed — 4,096 is exactly Roaring's array-to-bitmap container boundary, the worst ratio at 6.98× — which is precisely why a single ratio was the wrong thing to pin.

The hash-set column is a floor, not an estimate: it ignores hashbrown's one control byte per bucket and its 8/7 over-allocation, and ignores the `Vec` materialised alongside it.

## Also

`background_tasks.rs` built a `Vec<u64>` of every deleted id to read its length into `_deleted_count`, which nothing ever read — an O(deletions) allocation for a discarded value. Removed, along with the parameter that stranded.

`hnsw.rs:438` also calls `get_deleted_docs()`, but genuinely iterates the ids during compaction, so it is left alone.

## Verification

`cargo test --workspace` **1914 passed / 0 failed**; `cargo clippy --all-targets --features embeddings-all -- -D warnings` and `cargo fmt --all --check` clean on Rust 1.98. No `docs/src` change — format, public behaviour and contracts are all unchanged.

## This closes #541

The on-disk half landed in #684 (PR #771) and the issue body's headline figure was already obsolete; the writer's `pending_deletions` was fixed as a side effect of #1018; this is the merge path, the last of the three.
