### PR TITLE
test(lexical): reproduce pre-commit search visibility of flushed segments

### DIFF
--- a/laurus/tests/uncommitted_search_visibility_test.rs
+++ b/laurus/tests/uncommitted_search_visibility_test.rs
@@ -1,0 +1,260 @@
+//! Reproduction for #1017: whether a flushed-but-uncommitted segment is
+//! visible to `search()` is currently accidental.
+//!
+//! `InvertedIndex::load_segments` discovers segments by listing storage for
+//! `segment_*.meta`, consulting no commit marker, while `flush_segment` fires
+//! automatically at `max_buffered_docs` and writes that `.meta` on the spot.
+//! So whether a user sees uncommitted documents depends only on whether the
+//! searcher cache happened to be cold — and the repository documents the
+//! opposite in roughly twenty-five places ("documents become searchable only
+//! after `commit()`").
+//!
+//! It is worse than early visibility. `segment_info_for` hard-codes
+//! `has_deletions: false`, and deletions have been group-committed since
+//! #875, so the flag and the `.delmap` only reach storage at commit.
+//! `SegmentReader` short-circuits on that flag in `load_deletion_bitmap`,
+//! `is_deleted` and `filter_deleted_soa` alike — meaning a searcher that can
+//! see such a segment cannot filter its deletions or its superseded upsert
+//! versions at all.
+//!
+//! These tests are `#[ignore]`d: they are the RED for the fix, kept green in
+//! CI so the reproduction stays a reviewable artifact rather than a claim.
+//! Run them with `cargo test -p laurus --test uncommitted_search_visibility_test -- --ignored`.
+
+use std::sync::Arc;
+
+use laurus::lexical::{TermQuery, TextOption};
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document, Engine, FieldOption, Schema};
+use laurus::{LexicalSearchQuery, SearchRequestBuilder};
+
+/// `InvertedIndexWriterConfig::default().max_buffered_docs`, the point at
+/// which the writer flushes a segment on its own.
+const MAX_BUFFERED_DOCS: usize = 10_000;
+
+/// Documents written past the flush boundary, so the flush is comfortably
+/// behind us while some documents remain buffered.
+const TOTAL_DOCS: usize = MAX_BUFFERED_DOCS + 50;
+
+/// A schema with a single `body` text field.
+fn body_schema() -> Schema {
+    Schema::builder()
+        .add_field("body", FieldOption::Text(TextOption::default()))
+        .build()
+}
+
+/// Build a `(id, doc)` entry. Document 0 gets a distinctive term so a query
+/// can single it out.
+fn entry(i: usize) -> (String, Document) {
+    let body = if i == 0 { "zebra" } else { "alpha" };
+    let doc = Document::builder()
+        .add_field("body", DataValue::Text(body.into()))
+        .build();
+    (format!("id{i:06}"), doc)
+}
+
+/// Write past the automatic flush boundary **without committing**, and prove
+/// the flush actually fired.
+///
+/// `add_documents` is deliberate: `Engine::index_internal` skips
+/// `delete_documents_internal` for chunked adds, so nothing warms the
+/// searcher cache during ingest. That leaves the cache cold, which is the
+/// state the following tests vary.
+async fn engine_past_auto_flush() -> laurus::Result<(Engine, Arc<dyn Storage>)> {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let engine = Engine::new(storage.clone(), body_schema()).await?;
+
+    engine
+        .add_documents((0..TOTAL_DOCS).map(entry).collect())
+        .await?;
+
+    // Without this the tests could pass by failing to set up their own
+    // premise: no flush, no flushed segment, nothing to be visible.
+    let flushed = storage
+        .list_files()?
+        .iter()
+        .any(|f| f.contains("segment_") && f.ends_with(".meta"));
+    assert!(
+        flushed,
+        "automatic flush_segment must fire at max_buffered_docs"
+    );
+
+    Ok((engine, storage))
+}
+
+/// Search for the term carried only by document 0.
+async fn search_zebra(engine: &Engine) -> laurus::Result<Vec<laurus::SearchResult>> {
+    let request = SearchRequestBuilder::new()
+        .lexical_query(LexicalSearchQuery::Obj(Box::new(TermQuery::new(
+            "body", "zebra",
+        ))))
+        .limit(10)
+        .build();
+    engine.search(request).await
+}
+
+/// Search for the term every other document carries.
+async fn search_alpha(engine: &Engine) -> laurus::Result<Vec<laurus::SearchResult>> {
+    let request = SearchRequestBuilder::new()
+        .lexical_query(LexicalSearchQuery::Obj(Box::new(TermQuery::new(
+            "body", "alpha",
+        ))))
+        .limit(10)
+        .build();
+    engine.search(request).await
+}
+
+/// A document written before the automatic flush must not be searchable
+/// until commit — with a **cold** searcher cache.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "RED for #1017; un-ignored by the fix"]
+async fn uncommitted_documents_are_invisible_to_search_cold_cache() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    let hits = search_zebra(&engine).await?;
+    assert!(
+        hits.is_empty(),
+        "an uncommitted document must not be searchable, got {} hit(s)",
+        hits.len()
+    );
+
+    // And after the commit it must be, so the test is not passing because the
+    // document was never indexed.
+    engine.commit().await?;
+    assert_eq!(
+        search_zebra(&engine).await?.len(),
+        1,
+        "the document must be searchable once committed"
+    );
+
+    Ok(())
+}
+
+/// The same, but with the searcher cache **warmed after the flush**.
+///
+/// This is the route a real user hits: `get_documents` resolves through
+/// `find_doc_ids_by_term`, which runs a search and populates the cache. In an
+/// `add_documents` workload nothing warms it during ingest, so the first
+/// read-your-writes call after the flush builds a searcher over the flushed
+/// segment — and every subsequent search uses it.
+///
+/// A single-state test would prove nothing here, since the whole defect is
+/// that the answer depends on cache state.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "RED for #1017; un-ignored by the fix"]
+async fn uncommitted_documents_are_invisible_to_search_warm_cache() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    // Warm the cache over the flushed segment.
+    let resolved = engine.get_documents("id000000").await?;
+    assert_eq!(
+        resolved.len(),
+        1,
+        "NRT `_id` resolution must still work before commit (#1016)"
+    );
+
+    let hits = search_zebra(&engine).await?;
+    assert!(
+        hits.is_empty(),
+        "an uncommitted document must not be searchable, got {} hit(s)",
+        hits.len()
+    );
+
+    Ok(())
+}
+
+/// A deletion made before commit must not leave the deleted document
+/// searchable.
+///
+/// The delete lands only in the in-memory `DeletionManager`; the segment's
+/// `.meta` still says `has_deletions: false` and its `.delmap` does not
+/// exist, so a searcher that can see the segment cannot filter it.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "RED for #1017; un-ignored by the fix"]
+async fn uncommitted_deletion_does_not_leave_a_live_hit() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    engine.delete_documents("id000000").await?;
+
+    let hits = search_zebra(&engine).await?;
+    assert!(
+        hits.is_empty(),
+        "a deleted document must not surface as a live hit, got {} hit(s)",
+        hits.len()
+    );
+
+    engine.commit().await?;
+    assert!(
+        search_zebra(&engine).await?.is_empty(),
+        "and it must stay gone after the commit"
+    );
+
+    Ok(())
+}
+
+/// An upsert made before commit must not leave both versions searchable.
+///
+/// This is the sharpest symptom: two hits carrying the same external `_id`,
+/// one of them holding superseded field values.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "RED for #1017; un-ignored by the fix"]
+async fn uncommitted_upsert_does_not_duplicate_the_document() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    // Supersede document 0: "zebra" becomes "alpha".
+    let replacement = Document::builder()
+        .add_field("body", DataValue::Text("alpha".into()))
+        .build();
+    engine.put_document("id000000", replacement).await?;
+
+    let hits = search_zebra(&engine).await?;
+    assert!(
+        hits.is_empty(),
+        "the superseded version must not remain searchable, got {} hit(s)",
+        hits.len()
+    );
+
+    engine.commit().await?;
+
+    let alpha = search_alpha(&engine).await?;
+    let dupes = alpha.iter().filter(|h| h.id == "id000000").count();
+    assert_eq!(
+        dupes, 1,
+        "exactly one live copy of an `_id` may exist, found {dupes}"
+    );
+
+    Ok(())
+}
+
+/// `count()` and filter-only queries take different code paths from `search`
+/// — `count` has an O(1) `term_doc_freq` shortcut with no documents to
+/// inspect — so the contract has to hold for them independently.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "RED for #1017; un-ignored by the fix"]
+async fn uncommitted_documents_are_invisible_to_count() -> laurus::Result<()> {
+    let (engine, _storage) = engine_past_auto_flush().await?;
+
+    // `total_hits` is produced inside the collector, not derived from the
+    // returned hits, so it is a genuinely separate assertion.
+    let request = SearchRequestBuilder::new()
+        .lexical_query(LexicalSearchQuery::Obj(Box::new(TermQuery::new(
+            "body", "alpha",
+        ))))
+        .limit(10)
+        .build();
+    let hits = engine.search(request).await?;
+    assert!(
+        hits.is_empty(),
+        "uncommitted documents must not be counted either, got {} hit(s)",
+        hits.len()
+    );
+
+    engine.commit().await?;
+    assert!(
+        !search_alpha(&engine).await?.is_empty(),
+        "committed documents must be searchable"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Refs #1017

This lands the **reproduction**, not the fix. #1017's hazard had been traced through the code but never executed — the investigating agents were explicit that their conclusion was a prediction — so this closes that gap before any fix gets written. If it had not reproduced, the justification would have been revisited rather than the fix written.

## What was reproduced

Five cases in `laurus/tests/uncommitted_search_visibility_test.rs`, all over the public `Engine` API:

| case | observed | expected |
|---|---|---|
| uncommitted document searchable, **cold** cache | **1 hit** | 0 |
| uncommitted document searchable, **warm** cache | **1 hit** | 0 |
| **uncommitted deletion leaves a live hit** | **FAILED** | 0 |
| uncommitted upsert leaves the superseded version | **1 hit** | 0 |
| uncommitted documents counted | **10 hits** | 0 |

## Why the deletion case matters most

It shows this is not merely *early* visibility but *wrong results*: a document that has been deleted comes back as a live search hit.

`segment_info_for` hard-codes `has_deletions: false` (`writer.rs:1455`), and deletions have been group-committed since #875 — the `.delmap` and the flag flip only reach storage at commit. `SegmentReader` then short-circuits on that flag in all three of `load_deletion_bitmap` (`reader.rs:753`), `is_deleted` (`:777`) and `filter_deleted_soa` (`:804`). So a searcher that can see such a segment cannot filter its deletions or its superseded upsert versions at all.

## The warm-cache case corrects the investigation

The investigation reasoned that the ordinary `put_documents` path warms the searcher cache at document 0 and therefore hides the flushed segment. That much holds — but `add_documents` followed by `get_documents` warms it **after** the flush instead, so nothing is hidden. That is plain read-your-writes usage through the shipped CLI and server, not an exotic route, and it makes the defect considerably more reachable than first assessed.

`add_documents` is used deliberately in the fixture: `Engine::index_internal` skips `delete_documents_internal` for chunked adds (`engine.rs:786-788`), so nothing warms the cache during ingest — which is what lets the tests vary cache state as the independent variable. A single-state test would prove nothing here, since the whole defect is that the answer depends on that state.

Every case first asserts the automatic flush actually fired (a `segment_*.meta` exists with nothing committed), so a test cannot pass by failing to set up its own premise.

## CI stays green

All five carry `#[ignore = "RED for #1017; un-ignored by the fix"]`:

- normal run — 5 ignored, green
- `cargo test -p laurus --test uncommitted_search_visibility_test -- --ignored` — 5 failed, reproducing

The reproduction lands as a reviewable artifact rather than a claim in an issue comment, and the fix un-ignores it.

`cargo test --workspace` **1914 passed / 0 failed / 29 ignored**; `cargo clippy --all-targets --features embeddings-all -- -D warnings` and `cargo fmt --all --check` clean on Rust 1.98. No existing test is touched.

## What comes next

The fix, per the [plan on the issue](https://github.com/mosuka/laurus/issues/1017#issuecomment-5380663163): a `committed: bool` on `SegmentInfo` with `#[serde(default = true)]`, filtered at `load_segments` and set by `commit()` — roughly 40 lines across three files.

A manifest (mirroring the vector side's `segments.json`) was designed in parallel and deliberately **not** chosen: keeping `<seg>.meta` written at flush time makes every cost of deferral disappear — segment numbering, recovery, merge ordering, orphan sweeping, and the one existing test that would otherwise break. What a manifest additionally buys is robustness and performance, not this issue's correctness, so it is filed as a follow-up. The flag is not wasted either: once a manifest replaces `load_segments`' file scan, `committed` is dead and deletes in one commit.
