### PR TITLE
fix(storage): write metadata.json atomically and verify it on read

### DIFF
--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -31,6 +31,7 @@ use crate::lexical::writer::LexicalIndexWriter;
 use crate::storage::Storage;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::storage::file::{FileStorage, FileStorageConfig};
+use crate::storage::manifest as manifest_io;
 
 pub(crate) mod bmw;
 pub mod core;
@@ -204,29 +205,31 @@ impl InvertedIndex {
     }
 
     /// Write metadata to storage.
+    ///
+    /// Atomic and checksummed (#1023). This file is what `open` gates on, so
+    /// a torn write does not lose a counter — it stops the whole engine from
+    /// opening, vector and document data included, with nothing to recreate
+    /// it. Serialization happens under the lock and the write outside it,
+    /// because holding a `parking_lot::RwLock` across I/O would deadlock the
+    /// moment an error path formatted `self`.
     fn write_metadata(&self) -> Result<()> {
-        let metadata = self.metadata.read();
-        let metadata_json = serde_json::to_string_pretty(&*metadata)
-            .map_err(|e| LaurusError::index(format!("Failed to serialize metadata: {e}")))?;
-        drop(metadata);
+        let metadata_json = {
+            let metadata = self.metadata.read();
+            serde_json::to_vec(&*metadata)
+                .map_err(|e| LaurusError::index(format!("Failed to serialize metadata: {e}")))?
+        };
 
-        let mut output = self.storage.create_output("metadata.json")?;
-        std::io::Write::write_all(&mut output, metadata_json.as_bytes())?;
-        output.close()?;
-
-        Ok(())
+        manifest_io::save_checksummed(self.storage.as_ref(), "metadata.json", None, &metadata_json)
     }
 
     /// Read metadata from storage.
     pub(crate) fn read_metadata(storage: &dyn Storage) -> Result<IndexMetadata> {
-        let mut input = storage.open_input("metadata.json")?;
-        let mut metadata_json = String::new();
-        Read::read_to_string(&mut input, &mut metadata_json)?;
-
-        let metadata: IndexMetadata = serde_json::from_str(&metadata_json)
-            .map_err(|e| LaurusError::index(format!("Failed to deserialize metadata: {e}")))?;
-
-        Ok(metadata)
+        // Verifies the checksum and refuses a corrupted file rather than
+        // reading it as valid; pre-#1023 raw-JSON files still load (#1023).
+        match manifest_io::load_checksummed_json::<IndexMetadata>(storage, "metadata.json", None)? {
+            Some((metadata, _format)) => Ok(metadata),
+            None => Err(LaurusError::index("metadata.json is missing or empty")),
+        }
     }
 
     /// Update metadata and write to storage.

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -1578,13 +1578,14 @@ impl InvertedIndexWriter {
         meta.generation += 1; // Increment generation
         meta.last_wal_seq = self.last_wal_seq;
 
-        let metadata_json = serde_json::to_string_pretty(&meta)
-            .map_err(|e| LaurusError::index(format!("Failed to serialize metadata: {e}")))?;
-
-        let mut output = self.storage.create_output("metadata.json")?;
-        std::io::Write::write_all(&mut output, metadata_json.as_bytes())?;
-        output.close()?;
-        Ok(())
+        // Atomic and checksummed (#1023): a torn write here would leave the
+        // index unopenable, not merely lose a counter.
+        crate::storage::manifest::save_checksummed_json(
+            self.storage.as_ref(),
+            "metadata.json",
+            None,
+            &meta,
+        )
     }
 
     /// Rollback all pending changes.

--- a/laurus/src/vector/index/flat.rs
+++ b/laurus/src/vector/index/flat.rs
@@ -16,6 +16,7 @@ use parking_lot::RwLock;
 use crate::embedding::embedder::Embedder;
 use crate::error::{LaurusError, Result};
 use crate::storage::Storage;
+use crate::storage::manifest as manifest_io;
 use crate::vector::index::config::FlatIndexConfig;
 use crate::vector::index::flat::searcher::FlatVectorSearcher;
 use crate::vector::index::flat::writer::FlatIndexWriter;
@@ -151,24 +152,25 @@ impl FlatIndex {
 
     /// Write metadata to storage.
     fn write_metadata(&self) -> Result<()> {
-        let metadata = self.metadata.read();
-        let metadata_json = serde_json::to_string_pretty(&*metadata)
-            .map_err(|e| LaurusError::index(format!("Failed to serialize metadata: {e}")))?;
-        drop(metadata);
+        // Atomic and checksummed, matching the HNSW path (#1023). Serialize
+        // under the lock, write outside it — holding a `parking_lot::RwLock`
+        // across I/O deadlocks as soon as an error path formats `self`.
+        let metadata_json = {
+            let metadata = self.metadata.read();
+            serde_json::to_vec(&*metadata)
+                .map_err(|e| LaurusError::index(format!("Failed to serialize metadata: {e}")))?
+        };
 
-        let mut output = self.storage.create_output("metadata.json")?;
-        std::io::Write::write_all(&mut output, metadata_json.as_bytes())?;
-        output.close()?;
-
-        Ok(())
+        manifest_io::save_checksummed(self.storage.as_ref(), "metadata.json", None, &metadata_json)
     }
 
     /// Read metadata from storage.
     fn read_metadata(storage: &dyn Storage, _: &str) -> Result<IndexMetadata> {
-        let input = storage.open_input("metadata.json")?;
-        let metadata: IndexMetadata = serde_json::from_reader(input)
-            .map_err(|e| LaurusError::index(format!("Failed to deserialize metadata: {e}")))?;
-        Ok(metadata)
+        // Verifies the checksum; pre-#1023 raw-JSON files still load.
+        match manifest_io::load_checksummed_json::<IndexMetadata>(storage, "metadata.json", None)? {
+            Some((metadata, _format)) => Ok(metadata),
+            None => Err(LaurusError::index("metadata.json is missing or empty")),
+        }
     }
 
     /// Update metadata.

--- a/laurus/src/vector/index/ivf.rs
+++ b/laurus/src/vector/index/ivf.rs
@@ -18,6 +18,7 @@ use parking_lot::RwLock;
 use crate::embedding::embedder::Embedder;
 use crate::error::{LaurusError, Result};
 use crate::storage::Storage;
+use crate::storage::manifest as manifest_io;
 use crate::vector::index::config::IvfIndexConfig;
 use crate::vector::index::ivf::searcher::IvfSearcher;
 use crate::vector::index::ivf::writer::IvfIndexWriter;
@@ -153,24 +154,25 @@ impl IvfIndex {
 
     /// Write metadata to storage.
     fn write_metadata(&self) -> Result<()> {
-        let metadata = self.metadata.read();
-        let metadata_json = serde_json::to_string_pretty(&*metadata)
-            .map_err(|e| LaurusError::index(format!("Failed to serialize metadata: {e}")))?;
-        drop(metadata);
+        // Atomic and checksummed, matching the HNSW path (#1023). Serialize
+        // under the lock, write outside it — holding a `parking_lot::RwLock`
+        // across I/O deadlocks as soon as an error path formats `self`.
+        let metadata_json = {
+            let metadata = self.metadata.read();
+            serde_json::to_vec(&*metadata)
+                .map_err(|e| LaurusError::index(format!("Failed to serialize metadata: {e}")))?
+        };
 
-        let mut output = self.storage.create_output("metadata.json")?;
-        std::io::Write::write_all(&mut output, metadata_json.as_bytes())?;
-        output.close()?;
-
-        Ok(())
+        manifest_io::save_checksummed(self.storage.as_ref(), "metadata.json", None, &metadata_json)
     }
 
     /// Read metadata from storage.
     fn read_metadata(storage: &dyn Storage, _: &str) -> Result<IndexMetadata> {
-        let input = storage.open_input("metadata.json")?;
-        let metadata: IndexMetadata = serde_json::from_reader(input)
-            .map_err(|e| LaurusError::index(format!("Failed to deserialize metadata: {e}")))?;
-        Ok(metadata)
+        // Verifies the checksum; pre-#1023 raw-JSON files still load.
+        match manifest_io::load_checksummed_json::<IndexMetadata>(storage, "metadata.json", None)? {
+            Some((metadata, _format)) => Ok(metadata),
+            None => Err(LaurusError::index("metadata.json is missing or empty")),
+        }
     }
 
     /// Update metadata.

--- a/laurus/tests/lexical_deletion_group_commit_test.rs
+++ b/laurus/tests/lexical_deletion_group_commit_test.rs
@@ -216,7 +216,13 @@ fn commit_writes_delmap_before_metadata_checkpoint() {
 
     let created = recording.created.lock().unwrap().clone();
     let delmap_pos = created.iter().position(|f| f.ends_with(".delmap"));
-    let checkpoint_pos = created.iter().position(|f| f == "metadata.json");
+    // `metadata.json` is published atomically since #1023, so what the
+    // recorder sees created is the staging file. The ordering invariant this
+    // test exists for is unchanged — only the name of the file that carries
+    // the checkpoint into place.
+    let checkpoint_pos = created
+        .iter()
+        .position(|f| f == "metadata.json" || f == "metadata.json.tmp");
     assert!(
         delmap_pos.is_some(),
         "the deletion-flush commit must write a .delmap, got: {created:?}"

--- a/laurus/tests/metadata_atomic_write_test.rs
+++ b/laurus/tests/metadata_atomic_write_test.rs
@@ -1,0 +1,305 @@
+//! Durability of the `metadata.json` control files (#1023).
+//!
+//! Three subsystems wrote theirs with a plain `create_output`, which
+//! truncates in place. The payload is a few hundred bytes and the writer is
+//! buffered, so nothing reaches the OS until `close` — meaning the torn state
+//! is a **zero-byte file** for the whole window, not half-written JSON.
+//!
+//! The lexical one is the worst of the three: `InvertedIndex::open` requires
+//! it, so losing it takes the entire engine down — vector and document data
+//! included — with nothing to recreate it.
+//!
+//! These tests pin two properties per subsystem: a crash mid-write leaves the
+//! previous file intact and readable, and a corrupted file is refused rather
+//! than read as though it were valid.
+
+use std::io::{Read, Write};
+use std::sync::Arc;
+
+use laurus::Document;
+use laurus::lexical::{LexicalIndexConfig, LexicalStore};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::storage::{Storage, StorageInput, StorageOutput};
+use laurus::{LaurusError, Result as LaurusResult};
+
+/// Storage decorator that fails the next rename onto a named file.
+///
+/// The crash-injection harnesses already in this repository intercept
+/// creating operations but pass `rename_file` straight through — and the
+/// rename is precisely the step an atomic write turns on, so none of them can
+/// exercise it.
+#[derive(Debug)]
+struct FailingStorage {
+    inner: Arc<dyn Storage>,
+    /// Destination name whose next `rename_file` should fail.
+    fail_rename_to: parking_lot::Mutex<Option<String>>,
+}
+
+impl FailingStorage {
+    fn new(inner: Arc<dyn Storage>) -> Self {
+        Self {
+            inner,
+            fail_rename_to: parking_lot::Mutex::new(None),
+        }
+    }
+
+    /// Arm a one-shot failure for the next `rename_file` **onto** `name`.
+    ///
+    /// Targeted by destination rather than blanket: segment `.meta` files are
+    /// also published by rename, so a blanket failure would abort the commit
+    /// before it ever reached the metadata write — and the test would pass
+    /// without exercising anything.
+    fn fail_next_rename_to(&self, name: &str) {
+        *self.fail_rename_to.lock() = Some(name.to_string());
+    }
+}
+
+impl Storage for FailingStorage {
+    fn create_output(&self, name: &str) -> LaurusResult<Box<dyn StorageOutput>> {
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> LaurusResult<Box<dyn StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+
+    fn open_input(&self, name: &str) -> LaurusResult<Box<dyn StorageInput>> {
+        self.inner.open_input(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> LaurusResult<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> LaurusResult<()> {
+        let armed = {
+            let mut guard = self.fail_rename_to.lock();
+            if guard.as_deref() == Some(new_name) {
+                *guard = None;
+                true
+            } else {
+                false
+            }
+        };
+        if armed {
+            return Err(LaurusError::storage(format!(
+                "injected failure renaming {old_name} to {new_name}"
+            )));
+        }
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn list_files(&self) -> LaurusResult<Vec<String>> {
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> LaurusResult<u64> {
+        self.inner.file_size(name)
+    }
+
+    fn sync(&self) -> LaurusResult<()> {
+        self.inner.sync()
+    }
+
+    fn metadata(&self, name: &str) -> LaurusResult<laurus::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+
+    fn create_temp_output(&self, prefix: &str) -> LaurusResult<(String, Box<dyn StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn close(&mut self) -> LaurusResult<()> {
+        Ok(())
+    }
+}
+
+/// Read a file's bytes.
+fn read_bytes(storage: &Arc<dyn Storage>, name: &str) -> Vec<u8> {
+    let mut input = storage.open_input(name).unwrap();
+    let mut bytes = Vec::new();
+    input.read_to_end(&mut bytes).unwrap();
+    bytes
+}
+
+/// A document with one text field.
+fn doc(body: &str) -> Document {
+    Document::builder().add_text("body", body).build()
+}
+
+/// Build a committed lexical store over `storage`.
+fn seeded_lexical_store(storage: Arc<dyn Storage>) -> LexicalStore {
+    let store = LexicalStore::new(storage, LexicalIndexConfig::default()).unwrap();
+    store.upsert_document(1, doc("alpha")).unwrap();
+    store.commit().unwrap();
+    store
+}
+
+/// A crash while writing lexical `metadata.json` must leave the previous one
+/// intact, so the index still opens.
+///
+/// Without an atomic write the file is truncated at `create_output` and the
+/// contents never arrive, leaving zero bytes — and `InvertedIndex::open`
+/// hard-errors on that, taking the whole engine with it.
+#[test]
+fn lexical_metadata_survives_a_failed_write() {
+    let inner: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let failing = Arc::new(FailingStorage::new(inner));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let store = seeded_lexical_store(storage.clone());
+    let before = read_bytes(&storage, "metadata.json");
+    assert!(!before.is_empty(), "the seed commit must have written it");
+
+    // Fail the rename that publishes the next write. The previous file must
+    // be untouched.
+    failing.fail_next_rename_to("metadata.json");
+    store.upsert_document(2, doc("beta")).unwrap();
+    let _ = store.commit();
+
+    let after = read_bytes(&storage, "metadata.json");
+    assert_eq!(
+        after, before,
+        "a failed publish must leave the previous metadata byte-identical"
+    );
+
+    // And the index still opens over it.
+    drop(store);
+    LexicalStore::new(storage, LexicalIndexConfig::default())
+        .expect("the index must still open after a failed metadata write");
+}
+
+/// A corrupted lexical `metadata.json` must be refused, not read as valid.
+#[test]
+fn lexical_metadata_corruption_is_refused() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let store = seeded_lexical_store(storage.clone());
+    drop(store);
+
+    // Flip a byte inside the payload, leaving the framing intact.
+    let mut bytes = read_bytes(&storage, "metadata.json");
+    let mid = bytes.len() / 2;
+    bytes[mid] ^= 0xFF;
+    let mut output = storage.create_output("metadata.json").unwrap();
+    output.write_all(&bytes).unwrap();
+    output.close().unwrap();
+
+    let err = LexicalStore::new(storage, LexicalIndexConfig::default())
+        .expect_err("a corrupted metadata.json must not be accepted");
+    assert!(
+        err.to_string().contains("checksum"),
+        "corruption must be reported as such, got: {err}"
+    );
+}
+
+/// An index written before the checksummed framing existed must keep opening.
+///
+/// This is the compatibility guarantee: no existing index needs rewriting.
+#[test]
+fn lexical_legacy_metadata_still_opens() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let store = seeded_lexical_store(storage.clone());
+    drop(store);
+
+    // Rewrite it in the pre-framing form: bare JSON in place. The current
+    // file may already be raw (before this change) or framed (after), so
+    // derive the payload either way rather than assuming one.
+    let json = raw_json_payload(&read_bytes(&storage, "metadata.json"));
+    let mut output = storage.create_output("metadata.json").unwrap();
+    output.write_all(&json).unwrap();
+    output.close().unwrap();
+
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default())
+        .expect("a legacy raw-JSON metadata.json must still open");
+
+    // And the next commit upgrades it to the framed form.
+    store.upsert_document(2, doc("beta")).unwrap();
+    store.commit().unwrap();
+    let upgraded = read_bytes(&storage, "metadata.json");
+    assert_ne!(upgraded, json, "the next commit must rewrite it framed");
+    LexicalStore::new(storage, LexicalIndexConfig::default())
+        .expect("the upgraded file must open too");
+}
+
+/// Return the bare-JSON payload of `content`, whether it is already raw or
+/// wrapped in the `varint(len) || json || crc` framing.
+fn raw_json_payload(content: &[u8]) -> Vec<u8> {
+    if serde_json::from_slice::<serde_json::Value>(content).is_ok() {
+        return content.to_vec();
+    }
+
+    let mut len: u64 = 0;
+    let mut shift = 0;
+    let mut cursor = 0usize;
+    loop {
+        let byte = content[cursor];
+        cursor += 1;
+        len |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    content[cursor..cursor + len as usize].to_vec()
+}
+
+/// The index-side writer must be atomic too.
+///
+/// Two code paths write this file: the writer's, on every commit, and
+/// `InvertedIndex::write_metadata`, reached through `create` and through
+/// `optimize`. Covering only the first would leave the second free to
+/// truncate the file in place — so this drives `optimize()` specifically.
+#[test]
+fn index_side_metadata_write_is_atomic_too() {
+    let inner: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let failing = Arc::new(FailingStorage::new(inner));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    // Two committed segments so the force-merge has work to do.
+    for i in 0..2u64 {
+        store.upsert_document(i + 1, doc("alpha")).unwrap();
+        store.commit().unwrap();
+    }
+    let before = read_bytes(&storage, "metadata.json");
+
+    // `optimize` ends in `InvertedIndex::update_metadata`, i.e. the index-side
+    // write. Fail its publish and the previous file must survive.
+    failing.fail_next_rename_to("metadata.json");
+    let _ = store.optimize();
+
+    let after = read_bytes(&storage, "metadata.json");
+    assert_eq!(
+        after, before,
+        "a failed index-side publish must leave the previous metadata intact"
+    );
+
+    drop(store);
+    LexicalStore::new(storage, LexicalIndexConfig::default())
+        .expect("the index must still open after a failed index-side write");
+}
+
+/// A successful commit must not leave the staging file behind.
+#[test]
+fn no_temp_file_survives_a_commit() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let store = seeded_lexical_store(storage.clone());
+    store.upsert_document(2, doc("beta")).unwrap();
+    store.commit().unwrap();
+    drop(store);
+
+    let leftovers: Vec<String> = storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| f.ends_with(".tmp"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "staging files must not survive: {leftovers:?}"
+    );
+}


### PR DESCRIPTION
Refs #1023

Second of three stages. `Refs`, not `Closes` — this is the durability half; the data-loss bug #1023 was filed for is the ownership fix in the next PR.

## What was wrong

The lexical `metadata.json` is what `InvertedIndex::open` gates on, and it was written with a plain `create_output`, which truncates in place. The payload is a few hundred bytes behind a buffered writer, so **nothing reaches the OS until `close`** — the torn state is a **zero-byte file** for the entire window, not half-written JSON.

`file_exists` still returns true for that, so `open` proceeds and then hard-errors. The failure propagates out of `EngineBuilder::build`, so **the whole engine stops opening — vector and document data included** — and nothing recreates the file.

The vector `flat` and `ivf` metadata writers had the same shape. `hnsw` did not; it was fixed in #1027 along with the shared helper this builds on.

## What changed

Both lexical write paths — `InvertedIndex::write_metadata` and `InvertedIndexWriter::write_metadata_json` — plus vector flat and ivf now go through `storage::manifest`. Reads verify the CRC and **refuse** a corrupted file rather than accepting it; previously corruption surfaced, if at all, as a confusing `stream did not contain valid UTF-8`.

Pre-existing raw-JSON files still open and are upgraded to the framed form by the next write, so no index needs rewriting.

Serialization happens **under** the metadata lock and the write **outside** it. `parking_lot::RwLock` is not reentrant and the `Debug` impls of both `InvertedIndex` and `LexicalStore` read it, so holding it across I/O would deadlock the moment an error path formatted `self`.

## Two things the tests caught about the tests

**The first version passed for the wrong reason.** The injection decorator failed renames indiscriminately, so it hit the segment `.meta` publish added in #1025 and aborted the commit before it ever reached the metadata write — leaving `metadata.json` unchanged and the assertion satisfied. It now targets a rename by destination name.

**The tests only covered one of the two write paths.** Disabling the fix in `inverted.rs` left everything green, because the fixture only ever exercised the writer-side path. A test driving `optimize()` was added for the index-side one.

RED was then proven per path:

| disabled | failing tests |
|---|---|
| writer-side | 2 |
| index-side | 1 |
| neither | **5 pass** |

So a regression in either path alone is caught.

## Tests

New `laurus/tests/metadata_atomic_write_test.rs`:

- a failed publish leaves the previous `metadata.json` **byte-identical**, and the index still opens
- the same for the index-side path, via `optimize()`
- corruption is refused **as a checksum error**
- a legacy raw-JSON file still opens, and the next commit upgrades it
- no staging file survives a commit

The three crash-injection harnesses already in the repository all pass `rename_file` straight through — the very step an atomic write turns on — so the decorator here is new.

## One existing test updated

`commit_writes_delmap_before_metadata_checkpoint` matched the recorded `create_output` name with exact equality against `"metadata.json"` and now sees `"metadata.json.tmp"`. **The #875 ordering invariant it exists for is unchanged** — the `.delmap` still lands before the checkpoint; only the file carrying the checkpoint into place is renamed. All six tests in that file pass.

## Verification

`cargo test --workspace` **1934 passed / 0 failed / 24 ignored**; `cargo clippy --all-targets --features embeddings-all -- -D warnings` and `cargo fmt --all --check` clean on Rust 1.98.

## Next

The ownership fix. `LexicalStore::optimize` blind-writes stale metadata over a fresh commit, rolling back `last_wal_seq` and `doc_count` — reproduced, with no crash and no concurrency involved. There is also a third writer nobody knows about (the merge engine's, firing from `Drop`) inflating `doc_count`, and the two defects currently mask each other.
