### PR TITLE
fix(analysis): follow lindera 5.3.0 prefix dictionary API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,7 +127,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -138,7 +138,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -921,7 +921,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1084,6 +1084,12 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crawdad"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87fbd1ecd2ed790e11c8fbe034f9b3e7687404818d1bdfd8218d26ec645ec7c5"
 
 [[package]]
 name = "crc32fast"
@@ -1462,7 +1468,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1585,7 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2625,6 +2631,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3052,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "lindera"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0f5a0cbc3369929e1d6ed8fbe8f0426c654f0b8e39d5a99253647f8f24dd4f"
+checksum = "65015f4b12a1b869058a602e3cf7b39239ca1fbedd4b451bc9bb2fd2c9989eee"
 dependencies = [
  "anyhow",
  "lindera-cc-cedict",
@@ -3072,21 +3080,22 @@ dependencies = [
 
 [[package]]
 name = "lindera-cc-cedict"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b811b7b2ff575723be389eb7f6b9ee71bdd77a7b21ec3bfb7207e3c4b73888"
+checksum = "a37a0487f0adbbf4693439f1331d453abc5aa23ce647ca16c39b608211fb9be6"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-dictionary"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8779209c5d48d98b389b9100f654cca2bd2b2beda280075fc59d755cde803fe7"
+checksum = "647b3dd3102151b82d6995f5fafdb4fe512f8b65b5f92ccf6bfde2ba33596423"
 dependencies = [
  "anyhow",
  "byteorder",
+ "crawdad",
  "csv",
  "daachorse 4.0.0",
  "encoding_rs",
@@ -3112,18 +3121,18 @@ dependencies = [
 
 [[package]]
 name = "lindera-ipadic"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e32a93b680f8ffbce63b8cdf6f30568e169cb92d5df0cdd198b7b3cdc52bdd"
+checksum = "5d01d06a14be0253c6f11cd48e3acebb0698aee3b199715e8ffae0c6f3111eb8"
 dependencies = [
  "lindera-dictionary",
 ]
 
 [[package]]
 name = "lindera-ko-dic"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e782f7475858ede9c699af8cbcf7f0f45ba561df76c2280f41d342453dc055d"
+checksum = "2ba1a7fbc96a797201784c473c94d9d33f6b5d7990d5510967c42df514587b14"
 dependencies = [
  "lindera-dictionary",
 ]
@@ -3563,7 +3572,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3871,9 +3880,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -3881,9 +3890,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3891,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3904,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.8"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
 ]
@@ -4802,13 +4811,14 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8dddc5b1924b9a59fba420166160ca2c4663a4e01803e52eda33070f56d63c8"
+checksum = "1a15bc53261a9dc37e105df006e4656c598379a8f9581f8950debb130f27a7cf"
 dependencies = [
  "base64 0.23.1",
  "chrono",
  "futures",
+ "indexmap",
  "pastey 0.2.1",
  "pin-project-lite",
  "rmcp-macros",
@@ -4824,9 +4834,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
  "darling 0.24.0",
  "proc-macro2",
@@ -4867,7 +4877,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4926,7 +4936,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5344,7 +5354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5559,10 +5569,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6303,9 +6313,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6589,7 +6599,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -354,7 +354,7 @@ for (let i = 0; i < 10000; i++) {
 
 日本語の形態素解析を行う場合は、まず `JapaneseAnalyzer` を IPADIC の
 バイト列から構築し、`addAnalyzer()` で登録してください。
-[`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dictda--mode)
+[`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dicttrie--mode)
 と [`addAnalyzer`](#addanalyzername-analyzer) を参照。
 
 #### `addIntegerField(name, stored?, indexed?, multiValued?)`
@@ -431,7 +431,7 @@ IVF ベクトルインデックスフィールドを追加します。
 フィールドが `Named` 形式で analyzer を参照するときに、組込名や
 `schema.analyzers` 定義よりも先に解決されます。
 
-現状は [`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dictda--mode)
+現状は [`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dicttrie--mode)
 で構築した `JapaneseAnalyzer` のみ受け付けます。ブラウザ WASM では
 `{ "language": "japanese", "dict": ... }` プリセットがファイルシステム
 パスを解決できないため、ランタイムレジストリ経由が日本語 analyzer を
@@ -444,8 +444,8 @@ import { downloadDictionary, loadDictionaryFiles } from "laurus-wasm/opfs";
 await downloadDictionary("./dict/lindera-ipadic.zip", "ipadic");
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
 );
 
 const schema = new Schema();
@@ -523,10 +523,10 @@ Lindera 辞書のバイト列から構築する日本語形態素解析 analyzer
 `{ "language": "japanese", "dict": "/path/to/ipadic" }` プリセットは
 利用できません。代わりに Lindera 辞書アーカイブ（典型的には
 `lindera-ipadic-X.Y.Z.zip`）を取得して [OPFS ヘルパ](#opfs-ヘルパ) で
-OPFS に保存し、8 つのコンポーネントバイト配列を
+OPFS に保存し、9 つのコンポーネントバイト配列を
 `JapaneseAnalyzer.fromBytes` に渡してください。
 
-#### `JapaneseAnalyzer.fromBytes(metadata, dictDa, ..., mode?)`
+#### `JapaneseAnalyzer.fromBytes(metadata, dictTrie, ..., mode?)`
 
 IPADIC のバイト列から analyzer を構築する static ファクトリ。
 
@@ -535,7 +535,8 @@ IPADIC のバイト列から analyzer を構築する static ファクトリ。
 | 引数 | 対応するファイル |
 | ---- | ---- |
 | `metadata` | `metadata.json` |
-| `dictDa` | `dict.da`（Double-Array Trie） |
+| `dictTrie` | `dict.trie`（prefix trie） |
+| `dictValsIdx` | `dict.valsidx` |
 | `dictVals` | `dict.vals` |
 | `dictWordsIdx` | `dict.wordsidx` |
 | `dictWords` | `dict.words` |
@@ -553,8 +554,8 @@ import { loadDictionaryFiles } from "laurus-wasm/opfs";
 
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk,
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk,
   "normal",
 );
 ```
@@ -582,9 +583,9 @@ import {
 
 | 関数 | 説明 |
 | ---- | ---- |
-| `downloadDictionary(url, name, options?)` | `.zip` を fetch し、Web の `DecompressionStream` API で展開して、Lindera 8 ファイルを OPFS の `laurus/dictionaries/<name>/` 配下に保存します。`options.onProgress({ phase, loaded?, total? })` で進捗通知を受け取れます。`options.version` を渡すとファイルと並べてバージョンスタンプを保存します（下記参照）。 |
+| `downloadDictionary(url, name, options?)` | `.zip` を fetch し、Web の `DecompressionStream` API で展開して、Lindera 9 ファイルを OPFS の `laurus/dictionaries/<name>/` 配下に保存します。`options.onProgress({ phase, loaded?, total? })` で進捗通知を受け取れます。`options.version` を渡すとファイルと並べてバージョンスタンプを保存します（下記参照）。 |
 | `getDictionaryVersion(name)` | `downloadDictionary` が保存したバージョンスタンプを返します。辞書またはスタンプが存在しない場合は `null` を返します。 |
-| `loadDictionaryFiles(name)` | 8 ファイルを `{ metadata, dictDa, dictVals, dictWordsIdx, dictWords, matrixMtx, charDef, unk }` オブジェクトとして読み出し、`JapaneseAnalyzer.fromBytes` にそのまま渡せる形にします。 |
+| `loadDictionaryFiles(name)` | 9 ファイルを `{ metadata, dictTrie, dictValsIdx, dictVals, dictWordsIdx, dictWords, matrixMtx, charDef, unk }` オブジェクトとして読み出し、`JapaneseAnalyzer.fromBytes` にそのまま渡せる形にします。 |
 | `hasDictionary(name)` | 辞書ディレクトリが OPFS にあれば `true`。 |
 | `listDictionaries()` | 保存済み辞書名の配列を返します。 |
 | `removeDictionary(name)` | 辞書ディレクトリを削除します。 |

--- a/docs/ja/src/laurus-wasm/development.md
+++ b/docs/ja/src/laurus-wasm/development.md
@@ -78,7 +78,7 @@ laurus = { workspace = true, default-features = false }
 
 ### 日本語形態素解析
 
-ブラウザ WASM にはファイルシステムが無いため、`{ "language": "japanese", "dict": "/path/to/ipadic" }` の標準アナライザープリセットは利用できません。`laurus-wasm` は [`src/analysis.rs`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/src/analysis.rs) で `JapaneseAnalyzer.fromBytes(...)` を公開しており、Lindera IPADIC 辞書アーカイブを実行時に OPFS へ取得し、Lindera が必要とする 8 つの生バイト配列を読み出してアナライザーに渡せます：
+ブラウザ WASM にはファイルシステムが無いため、`{ "language": "japanese", "dict": "/path/to/ipadic" }` の標準アナライザープリセットは利用できません。`laurus-wasm` は [`src/analysis.rs`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/src/analysis.rs) で `JapaneseAnalyzer.fromBytes(...)` を公開しており、Lindera IPADIC 辞書アーカイブを実行時に OPFS へ取得し、Lindera が必要とする 9 つの生バイト配列を読み出してアナライザーに渡せます：
 
 ```javascript
 import { JapaneseAnalyzer, Schema } from "laurus-wasm";
@@ -87,8 +87,8 @@ import { downloadDictionary, loadDictionaryFiles } from "laurus-wasm/opfs";
 await downloadDictionary("./dict/lindera-ipadic.zip", "ipadic");
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
 );
 
 const schema = new Schema();

--- a/docs/ja/src/laurus-wasm/quickstart.md
+++ b/docs/ja/src/laurus-wasm/quickstart.md
@@ -95,11 +95,11 @@ if (
   });
 }
 
-// 2. 8 つのコンポーネントファイルを読み出して analyzer を構築する。
+// 2. 9 つのコンポーネントファイルを読み出して analyzer を構築する。
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk,
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk,
   "normal",
 );
 

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -350,7 +350,7 @@ or the name of a runtime analyzer registered via `addAnalyzer()`.
 
 For Japanese morphological analysis, build a `JapaneseAnalyzer` from
 raw IPADIC bytes and register it with `addAnalyzer()` first; see
-[`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dictda--mode)
+[`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dicttrie--mode)
 and [`addAnalyzer`](#addanalyzername-analyzer) below.
 
 #### `addIntegerField(name, stored?, indexed?, multiValued?)`
@@ -436,7 +436,7 @@ parameter-less built-in names and before `schema.analyzers` definitions
 when text fields reference an analyzer by name.
 
 Currently only `JapaneseAnalyzer` instances built via
-[`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dictda--mode)
+[`JapaneseAnalyzer.fromBytes`](#japaneseanalyzerfrombytesmetadata-dicttrie--mode)
 are accepted here. The runtime registry is the only practical way to use
 the Japanese analyzer in browser WASM, where the
 `{ "language": "japanese", "dict": ... }` preset cannot resolve a
@@ -449,8 +449,8 @@ import { downloadDictionary, loadDictionaryFiles } from "laurus-wasm/opfs";
 await downloadDictionary("./dict/lindera-ipadic.zip", "ipadic");
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
 );
 
 const schema = new Schema();
@@ -533,10 +533,10 @@ bytes. Browser WASM has no real filesystem, so the standard
 `{ "language": "japanese", "dict": "/path/to/ipadic" }` preset cannot
 be used. Instead, fetch a Lindera dictionary archive (typically
 `lindera-ipadic-X.Y.Z.zip`), store it in OPFS via the
-[OPFS helpers](#opfs-helpers), and pass the eight component byte
+[OPFS helpers](#opfs-helpers), and pass the nine component byte
 arrays to `JapaneseAnalyzer.fromBytes`.
 
-#### `JapaneseAnalyzer.fromBytes(metadata, dictDa, ..., mode?)`
+#### `JapaneseAnalyzer.fromBytes(metadata, dictTrie, ..., mode?)`
 
 Static factory that builds an analyzer from raw IPADIC bytes.
 
@@ -545,7 +545,8 @@ Arguments (all `Uint8Array` except `mode`):
 | Argument | Source file |
 | ---- | ---- |
 | `metadata` | `metadata.json` |
-| `dictDa` | `dict.da` (Double-Array Trie) |
+| `dictTrie` | `dict.trie` (prefix trie) |
+| `dictValsIdx` | `dict.valsidx` |
 | `dictVals` | `dict.vals` |
 | `dictWordsIdx` | `dict.wordsidx` |
 | `dictWords` | `dict.words` |
@@ -563,8 +564,8 @@ import { loadDictionaryFiles } from "laurus-wasm/opfs";
 
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk,
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk,
   "normal",
 );
 ```
@@ -593,9 +594,9 @@ import {
 
 | Function | Description |
 | ---- | ---- |
-| `downloadDictionary(url, name, options?)` | Fetch a `.zip`, decompress with the Web `DecompressionStream` API, and store the eight Lindera files under `laurus/dictionaries/<name>/` in OPFS. `options.onProgress({ phase, loaded?, total? })` reports progress. `options.version` stores a version stamp next to the files (see below). |
+| `downloadDictionary(url, name, options?)` | Fetch a `.zip`, decompress with the Web `DecompressionStream` API, and store the nine Lindera files under `laurus/dictionaries/<name>/` in OPFS. `options.onProgress({ phase, loaded?, total? })` reports progress. `options.version` stores a version stamp next to the files (see below). |
 | `getDictionaryVersion(name)` | Return the version stamp stored by `downloadDictionary`, or `null` if the dictionary or its stamp does not exist. |
-| `loadDictionaryFiles(name)` | Read the eight files back as a `{ metadata, dictDa, dictVals, dictWordsIdx, dictWords, matrixMtx, charDef, unk }` object suitable for `JapaneseAnalyzer.fromBytes`. |
+| `loadDictionaryFiles(name)` | Read the nine files back as a `{ metadata, dictTrie, dictValsIdx, dictVals, dictWordsIdx, dictWords, matrixMtx, charDef, unk }` object suitable for `JapaneseAnalyzer.fromBytes`. |
 | `hasDictionary(name)` | `true` if the dictionary directory exists in OPFS. |
 | `listDictionaries()` | Return an array of stored dictionary names. |
 | `removeDictionary(name)` | Delete the dictionary directory. |

--- a/docs/src/laurus-wasm/development.md
+++ b/docs/src/laurus-wasm/development.md
@@ -78,7 +78,7 @@ fallbacks for parallelism.
 
 ### Japanese Morphological Analysis
 
-Browser WASM has no filesystem, so the standard `{ "language": "japanese", "dict": "/path/to/ipadic" }` analyzer preset cannot be used. `laurus-wasm` exposes `JapaneseAnalyzer.fromBytes(...)` (defined in [`src/analysis.rs`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/src/analysis.rs)) so that a Lindera IPADIC dictionary archive can be fetched into OPFS at runtime, read back as the eight raw byte arrays Lindera needs, and handed to the analyzer:
+Browser WASM has no filesystem, so the standard `{ "language": "japanese", "dict": "/path/to/ipadic" }` analyzer preset cannot be used. `laurus-wasm` exposes `JapaneseAnalyzer.fromBytes(...)` (defined in [`src/analysis.rs`](https://github.com/mosuka/laurus/blob/main/laurus-wasm/src/analysis.rs)) so that a Lindera IPADIC dictionary archive can be fetched into OPFS at runtime, read back as the nine raw byte arrays Lindera needs, and handed to the analyzer:
 
 ```javascript
 import { JapaneseAnalyzer, Schema } from "laurus-wasm";
@@ -87,8 +87,8 @@ import { downloadDictionary, loadDictionaryFiles } from "laurus-wasm/opfs";
 await downloadDictionary("./dict/lindera-ipadic.zip", "ipadic");
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal",
 );
 
 const schema = new Schema();

--- a/docs/src/laurus-wasm/quickstart.md
+++ b/docs/src/laurus-wasm/quickstart.md
@@ -95,11 +95,11 @@ if (
   });
 }
 
-// 2. Read the eight component files back and construct the analyzer.
+// 2. Read the nine component files back and construct the analyzer.
 const f = await loadDictionaryFiles("ipadic");
 const ja = JapaneseAnalyzer.fromBytes(
-  f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-  f.dictWords, f.matrixMtx, f.charDef, f.unk,
+  f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+  f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk,
   "normal",
 );
 

--- a/laurus-wasm/examples/shared/dictionary.js
+++ b/laurus-wasm/examples/shared/dictionary.js
@@ -147,7 +147,8 @@ export async function buildJapaneseAnalyzer({ mode = 'normal' } = {}) {
   const files = await loadDictionaryFiles(DICT_NAME);
   return JapaneseAnalyzer.fromBytes(
     files.metadata,
-    files.dictDa,
+    files.dictTrie,
+    files.dictValsIdx,
     files.dictVals,
     files.dictWordsIdx,
     files.dictWords,

--- a/laurus-wasm/js/opfs.d.ts
+++ b/laurus-wasm/js/opfs.d.ts
@@ -12,8 +12,10 @@
 export interface DictionaryFiles {
   /** Contents of metadata.json */
   metadata: Uint8Array;
-  /** Contents of dict.da (Double-Array Trie) */
-  dictDa: Uint8Array;
+  /** Contents of dict.trie (prefix trie) */
+  dictTrie: Uint8Array;
+  /** Contents of dict.valsidx (per-surface value index) */
+  dictValsIdx: Uint8Array;
   /** Contents of dict.vals (word value data) */
   dictVals: Uint8Array;
   /** Contents of dict.wordsidx (word details index) */

--- a/laurus-wasm/js/opfs.js
+++ b/laurus-wasm/js/opfs.js
@@ -8,15 +8,16 @@
  * filesystem-based dictionary loading is not available.
  *
  * The dictionary archive format and OPFS layout follow the Lindera
- * convention: a zip containing the eight files
- * `metadata.json`, `dict.da`, `dict.vals`, `dict.wordsidx`,
- * `dict.words`, `matrix.mtx`, `char_def.bin`, `unk.bin`. Files are
- * placed under `laurus/dictionaries/<name>/` within OPFS.
+ * convention: a zip containing the nine files
+ * `metadata.json`, `dict.trie`, `dict.valsidx`, `dict.vals`,
+ * `dict.wordsidx`, `dict.words`, `matrix.mtx`, `char_def.bin`,
+ * `unk.bin`. Files are placed under `laurus/dictionaries/<name>/`
+ * within OPFS.
  *
- * The binary dictionary format is tied to the Lindera (and its
- * daachorse dependency) version compiled into the WASM binary, so a
- * cached dictionary can become unreadable after the site updates its
- * Lindera version. To let callers detect this, `downloadDictionary()`
+ * The binary dictionary format is tied to the Lindera version compiled
+ * into the WASM binary -- both the file set and the encoding of each
+ * file change across releases -- so a cached dictionary can become
+ * unreadable after the site updates its Lindera version. To let callers detect this, `downloadDictionary()`
  * accepts a `version` string that is stored alongside the dictionary
  * files and can be read back with `getDictionaryVersion()`.
  *
@@ -26,7 +27,8 @@
 /** Dictionary file names that make up a built Lindera dictionary. */
 const DICTIONARY_FILES = [
   "metadata.json",
-  "dict.da",
+  "dict.trie",
+  "dict.valsidx",
   "dict.vals",
   "dict.wordsidx",
   "dict.words",
@@ -176,10 +178,10 @@ async function extractZip(zipBuffer) {
 /**
  * Downloads a dictionary archive, extracts it, and stores the files in OPFS.
  *
- * The archive should be a zip containing the eight Lindera dictionary
- * files (`metadata.json`, `dict.da`, `dict.vals`, `dict.wordsidx`,
- * `dict.words`, `matrix.mtx`, `char_def.bin`, `unk.bin`), optionally
- * nested in a subdirectory.
+ * The archive should be a zip containing the nine Lindera dictionary
+ * files (`metadata.json`, `dict.trie`, `dict.valsidx`, `dict.vals`,
+ * `dict.wordsidx`, `dict.words`, `matrix.mtx`, `char_def.bin`,
+ * `unk.bin`), optionally nested in a subdirectory.
  *
  * @param {string} url - URL of the dictionary zip archive.
  * @param {string} name - Name to store the dictionary under (e.g., "ipadic").
@@ -344,7 +346,8 @@ export async function loadDictionaryFiles(name) {
 
   return {
     metadata: await readFile("metadata.json"),
-    dictDa: await readFile("dict.da"),
+    dictTrie: await readFile("dict.trie"),
+    dictValsIdx: await readFile("dict.valsidx"),
     dictVals: await readFile("dict.vals"),
     dictWordsIdx: await readFile("dict.wordsidx"),
     dictWords: await readFile("dict.words"),

--- a/laurus-wasm/src/analysis.rs
+++ b/laurus-wasm/src/analysis.rs
@@ -206,8 +206,9 @@ impl WasmSynonymGraphFilter {
 /// await downloadDictionary("./dict/lindera-ipadic.zip", "ipadic");
 /// const f = await loadDictionaryFiles("ipadic");
 /// const ja = JapaneseAnalyzer.fromBytes(
-///   f.metadata, f.dictDa, f.dictVals, f.dictWordsIdx,
-///   f.dictWords, f.matrixMtx, f.charDef, f.unk, "normal"
+///   f.metadata, f.dictTrie, f.dictValsIdx, f.dictVals,
+///   f.dictWordsIdx, f.dictWords, f.matrixMtx, f.charDef, f.unk,
+///   "normal"
 /// );
 /// const schema = new Schema();
 /// schema.addAnalyzer("ja-ipadic", ja);
@@ -223,7 +224,7 @@ pub struct WasmJapaneseAnalyzer {
 impl WasmJapaneseAnalyzer {
     /// Build a Japanese analyzer from raw dictionary byte arrays.
     ///
-    /// The eight byte arrays must come from a built Lindera dictionary
+    /// The nine byte arrays must come from a built Lindera dictionary
     /// directory (e.g. `lindera-ipadic-X.Y.Z.zip` extracted to OPFS).
     /// A trailing `mode` argument (default `"normal"`) selects the
     /// Lindera segmentation mode.
@@ -231,7 +232,8 @@ impl WasmJapaneseAnalyzer {
     /// # Arguments
     ///
     /// * `metadata` - `metadata.json`
-    /// * `dict_da` - `dict.da` (Double-Array Trie)
+    /// * `dict_trie` - `dict.trie` (prefix trie)
+    /// * `dict_vals_idx` - `dict.valsidx`
     /// * `dict_vals` - `dict.vals`
     /// * `dict_words_idx` - `dict.wordsidx`
     /// * `dict_words` - `dict.words`
@@ -248,7 +250,8 @@ impl WasmJapaneseAnalyzer {
     #[allow(clippy::too_many_arguments)]
     pub fn from_bytes(
         metadata: &[u8],
-        dict_da: &[u8],
+        dict_trie: &[u8],
+        dict_vals_idx: &[u8],
         dict_vals: &[u8],
         dict_words_idx: &[u8],
         dict_words: &[u8],
@@ -261,7 +264,8 @@ impl WasmJapaneseAnalyzer {
         let analyzer = JapaneseAnalyzer::from_bytes(
             mode_str,
             metadata,
-            dict_da,
+            dict_trie,
+            dict_vals_idx,
             dict_vals,
             dict_words_idx,
             dict_words,

--- a/laurus/Cargo.toml
+++ b/laurus/Cargo.toml
@@ -33,8 +33,8 @@ csv = "1.4.0"
 fst = "0.4.7"
 futures = "0.3.33"
 lazy_static = "1.5.0"
-lindera = { version = "5.2.0" }
-lindera-dictionary = { version = "5.2.0", default-features = false }
+lindera = { version = "5.3.0" }
+lindera-dictionary = { version = "5.3.0", default-features = false }
 log = "0.4.33"
 lru = "0.18.2"
 parking_lot = "0.12.5"
@@ -286,7 +286,7 @@ criterion = { version = "0.8.2", features = ["async_tokio"] }
 # unification activates these features only for test/example/bench builds, so
 # the release library (and downstream bindings) ship without the embedded
 # dictionaries.
-lindera = { version = "5.2.0", features = [
+lindera = { version = "5.3.0", features = [
     "embed-ipadic",
     "embed-ko-dic",
     "embed-cc-cedict",

--- a/laurus/src/analysis/analyzer/language/japanese.rs
+++ b/laurus/src/analysis/analyzer/language/japanese.rs
@@ -126,9 +126,10 @@ impl JapaneseAnalyzer {
     ///
     /// * `mode_str` - Lindera segmentation mode: `"normal"` or
     ///   `"decompose"`.
-    /// * `metadata` / `dict_da` / `dict_vals` / `dict_words_idx` /
-    ///   `dict_words` / `matrix_mtx` / `char_def` / `unk` - the eight
-    ///   files that make up a built Lindera dictionary directory.
+    /// * `metadata` / `dict_trie` / `dict_vals_idx` / `dict_vals` /
+    ///   `dict_words_idx` / `dict_words` / `matrix_mtx` / `char_def` /
+    ///   `unk` - the nine files that make up a built Lindera dictionary
+    ///   directory.
     ///
     /// # Errors
     ///
@@ -138,7 +139,8 @@ impl JapaneseAnalyzer {
     pub fn from_bytes(
         mode_str: &str,
         metadata: &[u8],
-        dict_da: &[u8],
+        dict_trie: &[u8],
+        dict_vals_idx: &[u8],
         dict_vals: &[u8],
         dict_words_idx: &[u8],
         dict_words: &[u8],
@@ -149,7 +151,8 @@ impl JapaneseAnalyzer {
         let tokenizer = Arc::new(LinderaTokenizer::from_bytes(
             mode_str,
             metadata,
-            dict_da,
+            dict_trie,
+            dict_vals_idx,
             dict_vals,
             dict_words_idx,
             dict_words,

--- a/laurus/src/analysis/tokenizer/lindera.rs
+++ b/laurus/src/analysis/tokenizer/lindera.rs
@@ -148,7 +148,9 @@ impl LinderaTokenizer {
     ///
     /// * `mode_str` - Segmentation mode: `"normal"` or `"decompose"`.
     /// * `metadata` - Contents of `metadata.json`.
-    /// * `dict_da` - Contents of `dict.da` (Double-Array Trie).
+    /// * `dict_trie` - Contents of `dict.trie` (prefix trie).
+    /// * `dict_vals_idx` - Contents of `dict.valsidx` (prefix sum from
+    ///   a surface ordinal to its run of `dict.vals` records).
     /// * `dict_vals` - Contents of `dict.vals` (word value data).
     /// * `dict_words_idx` - Contents of `dict.wordsidx` (word details
     ///   index).
@@ -171,7 +173,8 @@ impl LinderaTokenizer {
     pub fn from_bytes(
         mode_str: &str,
         metadata: &[u8],
-        dict_da: &[u8],
+        dict_trie: &[u8],
+        dict_vals_idx: &[u8],
         dict_vals: &[u8],
         dict_words_idx: &[u8],
         dict_words: &[u8],
@@ -185,24 +188,23 @@ impl LinderaTokenizer {
         use lindera_dictionary::dictionary::character_definition::CharacterDefinition;
         use lindera_dictionary::dictionary::connection_cost_matrix::ConnectionCostMatrix;
         use lindera_dictionary::dictionary::metadata::Metadata;
-        use lindera_dictionary::dictionary::prefix_dictionary::{DaTrust, PrefixDictionary};
+        use lindera_dictionary::dictionary::prefix_dictionary::PrefixDictionary;
         use lindera_dictionary::dictionary::unknown_dictionary::UnknownDictionary;
 
         let mode = Mode::from_str(mode_str)
             .map_err(|e| LaurusError::analysis(format!("Invalid mode '{}': {}", mode_str, e)))?;
         let meta = Metadata::load(metadata)
             .map_err(|e| LaurusError::analysis(format!("Failed to load metadata: {}", e)))?;
-        // `DaTrust::Trusted` is reserved for byte-exact `include_bytes!` output
-        // of lindera's own build pipeline; these bytes come from the caller
-        // (e.g. a user-supplied dictionary read from disk or the wasm embed),
-        // so they must go through the validating deserialization path.
+        // `PrefixDictionary::load` validates the trie header and the
+        // `dict.valsidx` record alignment before the bytes are walked, so
+        // caller-supplied dictionaries (a user dictionary read from disk,
+        // the wasm OPFS cache) cannot make later lookups read out of bounds.
         let prefix_dictionary = PrefixDictionary::load(
-            dict_da.to_vec(),
+            dict_trie.to_vec(),
+            dict_vals_idx.to_vec(),
             dict_vals.to_vec(),
             dict_words_idx.to_vec(),
             dict_words.to_vec(),
-            true,
-            DaTrust::Untrusted,
         )
         .map_err(|e| LaurusError::analysis(format!("Failed to load prefix dictionary: {}", e)))?;
         let connection_cost_matrix = ConnectionCostMatrix::load(matrix_mtx.to_vec())
@@ -397,12 +399,74 @@ mod tests {
         assert_eq!(tokenizer.name(), "lindera");
     }
 
+    /// Minimal dictionary source files, mirroring the fixture used by
+    /// `lindera-dictionary`'s own builder tests: the mandatory DEFAULT
+    /// character category plus KANJI, one unknown-word entry per category,
+    /// a two-word lexicon and a 1x1 connection cost matrix.
+    #[cfg(feature = "native")]
+    const TEST_CHAR_DEF: &str = "DEFAULT 0 1 0\nKANJI 0 0 2\n0x4E00..0x9FFF KANJI\n";
+    #[cfg(feature = "native")]
+    const TEST_UNK_DEF: &str = "DEFAULT,0,0,0,補助記号,一般,*,*,*,*,*,*,*\n\
+         KANJI,0,0,0,名詞,一般,*,*,*,*,*,*,*\n";
+    #[cfg(feature = "native")]
+    const TEST_LEX_CSV: &str = "日本,0,0,100,名詞,固有名詞,地域,国,*,*,日本,ニッポン,ニッポン\n\
+         本,0,0,200,名詞,一般,*,*,*,*,本,ホン,ホン\n";
+    #[cfg(feature = "native")]
+    const TEST_MATRIX_DEF: &str = "1 1\n0 0 0\n";
+
+    /// A dictionary built by Lindera's own builder must round-trip through
+    /// [`LinderaTokenizer::from_bytes`] and segment text.
+    ///
+    /// The component files are positional, so this pins the mapping between
+    /// each on-disk artifact and its `from_bytes` argument: passing them in
+    /// the wrong order (for instance swapping `dict.trie` and `dict.valsidx`)
+    /// fails here, where the error-path tests below cannot see it.
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_from_bytes_round_trips_a_built_dictionary() {
+        use std::fs;
+
+        use lindera_dictionary::builder::DictionaryBuilder;
+        use lindera_dictionary::dictionary::metadata::Metadata;
+
+        let input = tempfile::tempdir().unwrap();
+        let output = tempfile::tempdir().unwrap();
+        fs::write(input.path().join("char.def"), TEST_CHAR_DEF).unwrap();
+        fs::write(input.path().join("unk.def"), TEST_UNK_DEF).unwrap();
+        fs::write(input.path().join("lex.csv"), TEST_LEX_CSV).unwrap();
+        fs::write(input.path().join("matrix.def"), TEST_MATRIX_DEF).unwrap();
+
+        DictionaryBuilder::new(Metadata::default())
+            .build_dictionary(input.path(), output.path())
+            .expect("building the fixture dictionary should succeed");
+
+        let read = |name: &str| fs::read(output.path().join(name)).unwrap();
+        let tokenizer = LinderaTokenizer::from_bytes(
+            "normal",
+            &read("metadata.json"),
+            &read("dict.trie"),
+            &read("dict.valsidx"),
+            &read("dict.vals"),
+            &read("dict.wordsidx"),
+            &read("dict.words"),
+            &read("matrix.mtx"),
+            &read("char_def.bin"),
+            &read("unk.bin"),
+        )
+        .expect("a freshly built dictionary should load from bytes");
+
+        let tokens: Vec<Token> = tokenizer.tokenize("日本").unwrap().collect();
+        let texts: Vec<&str> = tokens.iter().map(|t| t.text.as_ref()).collect();
+        assert_eq!(texts, vec!["日本"]);
+    }
+
     #[test]
     fn test_from_bytes_invalid_metadata_errors() {
         let empty: &[u8] = &[];
         let result = LinderaTokenizer::from_bytes(
             "normal",
             b"not valid json".as_slice(),
+            empty,
             empty,
             empty,
             empty,
@@ -427,6 +491,7 @@ mod tests {
         let result = LinderaTokenizer::from_bytes(
             "not-a-mode",
             b"{}".as_slice(),
+            empty,
             empty,
             empty,
             empty,


### PR DESCRIPTION
## Summary

Supersedes #1026, whose Clippy job fails with exit code 101. The `cargo-minor-patch`
group bumps six packages but only **lindera 5.2.0 → 5.3.0** is breaking; this PR
carries the whole group and adapts the code.

Lindera 5.3.0 replaced the daachorse Double-Array prefix dictionary with an
in-place trie. Two things changed at once:

**1. `PrefixDictionary::load()` — 6 args → 5**

```rust
// 5.2.0
load(da_data, vals_data, words_idx_data, words_data, is_system: bool, trust: DaTrust)
// 5.3.0
load(trie_data, vals_idx, vals_data, words_idx_data, words_data)
```

`DaTrust` is gone entirely (the new loader validates the trie header, node count
and `dict.valsidx` alignment, so there is no unchecked path left to opt out of),
and `is_system` was dropped from the struct. That accounts for all three CI errors
(`E0432`, `E0277`, `E0061`), which come from one call site.

**2. Built-dictionary file layout**

Verified against the real v5.3.0 archive (`lindera-cc-cedict-5.3.0.zip`): `dict.da`
is gone, replaced by `dict.trie` + `dict.valsidx`. A Rust-only fix would give green
CI and a dead demo — `DICTIONARY_FILES` in `laurus-wasm/js/opfs.js` is a hard
requirement list, so `downloadDictionary()` would throw
`Missing dictionary files in archive: dict.da` against a 5.3.0 archive.

## Changes

- `laurus/Cargo.toml`: raise the lindera / lindera-dictionary floor to 5.3.0. The
  other four bumps stay lock-only, exactly as Dependabot had them — only lindera is
  a version the code actually *requires*, so leaving its floor at 5.2.0 would let a
  stale lock or a `--precise` downgrade break the build.
- `LinderaTokenizer::from_bytes` / `JapaneseAnalyzer::from_bytes` / the WASM
  `JapaneseAnalyzer.fromBytes`: eight byte arrays → nine, ordered to match
  Lindera's own `load()` so the correspondence stays easy to follow.
- `laurus-wasm/js/opfs.js`, `opfs.d.ts`, `examples/shared/dictionary.js`: file
  list, returned keys, and the positional call site.
- Docs (en + ja): `api_reference.md`, `quickstart.md`, `development.md`.

No OPFS cache work was needed: the `.dict_version` stamp plus the `manifest.json`
`lindera_version` gate (#975, #981) already discards a cache from an older Lindera,
and the deploy workflow resolves the archive version from `cargo metadata`.

Python / Node.js / Ruby / PHP / CLI / server are unaffected — they only ever take a
dictionary *path*.

`crawdad 0.3.0` enters the graph as the new trie implementation. MIT OR Apache-2.0,
so license-compatible.

## Test gap closed

`from_bytes` had two tests, both negative (invalid metadata, invalid mode). Both
short-circuit before `PrefixDictionary::load` runs, so neither could see the
arguments being reordered — and 5.3.0 reorders them by inserting `dict.valsidx` in
the middle.

`test_from_bytes_round_trips_a_built_dictionary` builds a two-word dictionary into
a temp directory with `DictionaryBuilder`, feeds the nine generated files to
`from_bytes`, and asserts the tokenizer segments `日本`. Proven RED by swapping
`dict.trie` and `dict.valsidx`: it fails with
`dict.trie declares 2 nodes (28 bytes) but the file is 12 bytes`.

## Verification

| Check | Result |
| --- | --- |
| `cargo fmt --all --check` | pass |
| `cargo clippy --all-targets --features embeddings-all -- -D warnings` | pass |
| `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings` | pass |
| `cargo test -p laurus --lib` | 1389 passed |
| `cargo test -p laurus-mcp -p laurus-server -p laurus-cli` | 98 passed |
| `markdownlint-cli2` (en + ja) | 0 errors |

Closes #1029
