### PR TITLE
fix(lexical): keep a failed merge from publishing its partial segment

### DIFF
--- a/laurus/src/lexical/index/inverted/segment/merge_engine.rs
+++ b/laurus/src/lexical/index/inverted/segment/merge_engine.rs
@@ -332,12 +332,26 @@ impl MergeEngine {
         // here re-added the whole merged output to `doc_count` on every
         // merge, compounding on each auto-merging commit.
         let mut writer = InvertedIndexWriter::new(self.storage.clone(), writer_config)?;
-        for doc_id in &order {
-            if let Some(analyzed) = docs.remove(doc_id) {
-                writer.upsert_analyzed_document(*doc_id, analyzed)?;
+        // Replay + flush as one fallible unit. On ANY error the writer is
+        // aborted before it can drop: `Drop` would otherwise commit the
+        // partially replayed buffer into a fresh `segment_*` and publish it
+        // (#1032) — silent document duplication, since the source segments
+        // are only deleted after a successful merge.
+        let replayed = (|| -> Result<Vec<String>> {
+            for doc_id in &order {
+                if let Some(analyzed) = docs.remove(doc_id) {
+                    writer.upsert_analyzed_document(*doc_id, analyzed)?;
+                }
             }
-        }
-        let file_paths = writer.flush_buffered_to_segment(new_segment_id)?;
+            writer.flush_buffered_to_segment(new_segment_id)
+        })();
+        let file_paths = match replayed {
+            Ok(paths) => paths,
+            Err(e) => {
+                writer.abort();
+                return Err(e);
+            }
+        };
 
         stats.docs_processed = doc_count;
         stats.postings_merged = doc_count;

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -964,8 +964,13 @@ impl InvertedIndexWriter {
         self.write_field_lengths(segment_name)?;
         self.write_field_stats(segment_name)?;
         self.write_doc_values(segment_name)?;
-        self.write_segment_metadata(segment_name, committed)?;
         self.write_bkd_trees(segment_name)?;
+        // The `.meta` goes LAST (#1032): it is what makes the segment
+        // discoverable, so writing it before the data files would let a
+        // failure in a later write leave a discoverable segment with files
+        // missing — a BKD-less segment, for instance, silently returns
+        // zero hits for numeric-range and geo queries.
+        self.write_segment_metadata(segment_name, committed)?;
         // The redundant `.json` stored-field mirror is no longer written
         // (Issue #756); stored fields are read from the typed `.docs` file.
 
@@ -1704,6 +1709,27 @@ impl InvertedIndexWriter {
         self.inverted_index = TermPostingIndex::new();
 
         Ok(())
+    }
+
+    /// Discard all pending state and make [`Drop`] fully inert (#1032).
+    ///
+    /// [`Drop`] runs `close()`, which commits anything still buffered — the
+    /// right default for a store-owned writer, but fatal for the merge
+    /// engine's replay writer: if the merge dies partway, that implicit
+    /// commit would flush the partially replayed documents into a fresh
+    /// `segment_*` and publish it, leaving every document live twice while
+    /// the source segments still exist. This discards the buffers (via
+    /// [`Self::rollback`]) and marks the writer closed so `close()` does
+    /// nothing at all — no flush, no publish, no `index.meta` write.
+    ///
+    /// Buffered deletion state is untouched, exactly as `rollback`
+    /// documents; the merge replay never creates any.
+    pub(crate) fn abort(&mut self) {
+        // Infallible in practice: `rollback` only clears in-memory buffers
+        // after the `check_closed` guard, and the writer cannot be closed
+        // here — `abort` is what closes it.
+        let _ = self.rollback();
+        self.closed = true;
     }
 
     /// Get writer statistics.

--- a/laurus/tests/merge_failure_publication_test.rs
+++ b/laurus/tests/merge_failure_publication_test.rs
@@ -1,0 +1,263 @@
+//! Reproduction for #1032: a failed merge publishes a partially merged
+//! segment through the merge writer's implicit `Drop`-commit.
+//!
+//! `MergeEngine::perform_merge` replays the source documents through an
+//! internally constructed `InvertedIndexWriter` and writes the merged
+//! segment via `flush_buffered_to_segment`. If that fails (or the replay
+//! loop errors), the function returns early and the writer is dropped with
+//! its buffers full — and `Drop` runs `close()` → `commit()`, whose
+//! `flush_segment()` + `publish_pending_segments()` write a `segment_*`
+//! holding the partially merged documents and flip it to `committed: true`
+//! in the same call. The source segments still exist, so every document in
+//! the orphaned segment is now live TWICE.
+
+use std::io::Read;
+use std::sync::Arc;
+
+use laurus::lexical::{LexicalIndexConfig, LexicalSearchRequest, LexicalStore, TermQuery};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::storage::{Storage, StorageInput, StorageOutput};
+use laurus::{Document, LaurusError, Result as LaurusResult};
+
+/// Storage decorator failing the next `create_output` whose name matches
+/// the armed `(prefix, suffix)` — aimed at a chosen file of the merged
+/// segment, so the merge dies inside `flush_buffered_to_segment` with the
+/// writer's buffers still full.
+#[derive(Debug)]
+struct FailingStorage {
+    inner: Arc<dyn Storage>,
+    fail_create_matching: parking_lot::Mutex<Option<(String, String)>>,
+}
+
+impl FailingStorage {
+    fn new(inner: Arc<dyn Storage>) -> Self {
+        Self {
+            inner,
+            fail_create_matching: parking_lot::Mutex::new(None),
+        }
+    }
+
+    /// Arm a one-shot failure for the next `create_output` whose name has
+    /// this prefix (suffix unconstrained).
+    fn fail_next_create_with_prefix(&self, prefix: &str) {
+        self.fail_next_create_matching(prefix, "");
+    }
+
+    /// Arm a one-shot failure for the next `create_output` whose name has
+    /// both this prefix and this suffix.
+    fn fail_next_create_matching(&self, prefix: &str, suffix: &str) {
+        *self.fail_create_matching.lock() = Some((prefix.to_string(), suffix.to_string()));
+    }
+}
+
+impl Storage for FailingStorage {
+    fn create_output(&self, name: &str) -> LaurusResult<Box<dyn StorageOutput>> {
+        let armed = {
+            let mut guard = self.fail_create_matching.lock();
+            if guard
+                .as_ref()
+                .is_some_and(|(p, x)| name.starts_with(p) && name.ends_with(x))
+            {
+                *guard = None;
+                true
+            } else {
+                false
+            }
+        };
+        if armed {
+            return Err(LaurusError::storage(format!(
+                "injected failure creating {name}"
+            )));
+        }
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> LaurusResult<Box<dyn StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+
+    fn open_input(&self, name: &str) -> LaurusResult<Box<dyn StorageInput>> {
+        self.inner.open_input(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> LaurusResult<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> LaurusResult<()> {
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn list_files(&self) -> LaurusResult<Vec<String>> {
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> LaurusResult<u64> {
+        self.inner.file_size(name)
+    }
+
+    fn sync(&self) -> LaurusResult<()> {
+        self.inner.sync()
+    }
+
+    fn metadata(&self, name: &str) -> LaurusResult<laurus::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+
+    fn create_temp_output(&self, prefix: &str) -> LaurusResult<(String, Box<dyn StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn close(&mut self) -> LaurusResult<()> {
+        Ok(())
+    }
+}
+
+fn doc(body: &str) -> Document {
+    Document::builder().add_text("body", body).build()
+}
+
+/// Auto-merging config: the second commit's `maybe_merge` merges the two
+/// single-doc segments.
+fn merging_config() -> LexicalIndexConfig {
+    LexicalIndexConfig::builder()
+        .max_segments(1)
+        .merge_factor(2)
+        .build()
+}
+
+/// A failed merge must not leave a published segment holding the partially
+/// merged documents while the source segments still exist.
+#[test]
+fn failed_merge_must_not_duplicate_documents() {
+    let inner: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let failing = Arc::new(FailingStorage::new(inner.clone()));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let store = LexicalStore::new(storage.clone(), merging_config()).unwrap();
+    store.upsert_document(1, doc("apple")).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(2, doc("banana")).unwrap();
+
+    // The second commit's maybe_merge merges the two segments; kill the
+    // merged segment's first file write.
+    failing.fail_next_create_with_prefix("merged_");
+    let result = store.commit();
+    assert!(result.is_err(), "the injected merge failure must surface");
+    drop(store);
+
+    // Reopen over the clean storage: discovery sees whatever the failed
+    // merge left behind.
+    let reopened = LexicalStore::new(inner.clone(), merging_config()).unwrap();
+    let hits = reopened
+        .search(LexicalSearchRequest::new(Box::new(TermQuery::new(
+            "body", "apple",
+        ))))
+        .unwrap();
+    assert_eq!(
+        hits.hits.len(),
+        1,
+        "a failed merge must not leave a second live copy of a document"
+    );
+}
+
+/// Structural variant of the same defect: after a failed merge, no NEW
+/// committed segment may exist beyond the sources.
+#[test]
+fn failed_merge_must_not_publish_a_segment() {
+    let inner: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let failing = Arc::new(FailingStorage::new(inner.clone()));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let store = LexicalStore::new(storage.clone(), merging_config()).unwrap();
+    store.upsert_document(1, doc("apple")).unwrap();
+    store.commit().unwrap();
+
+    let metas_before: Vec<String> = list_metas(&inner);
+
+    store.upsert_document(2, doc("banana")).unwrap();
+    failing.fail_next_create_with_prefix("merged_");
+    assert!(store.commit().is_err());
+    drop(store);
+
+    // The new source segment from commit 2 is expected; a further
+    // `segment_*` beyond it is the Drop-published orphan.
+    let metas_after = list_metas(&inner);
+    let new_metas: Vec<&String> = metas_after
+        .iter()
+        .filter(|m| !metas_before.contains(m))
+        .collect();
+    assert_eq!(
+        new_metas.len(),
+        1,
+        "a failed merge must add only commit 2's own segment, found: {new_metas:?}"
+    );
+}
+
+/// The segment `.meta` must be written LAST, so a failure in any data file
+/// cannot leave a discoverable segment with files missing.
+///
+/// Kills the merged segment's `.bkd` write — under the old order the
+/// `.meta` (with `committed: true`) had already been written by then, so
+/// the half-segment was discoverable and its numeric-range queries would
+/// silently return zero hits.
+#[test]
+fn segment_meta_is_written_after_every_data_file() {
+    let inner: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let failing = Arc::new(FailingStorage::new(inner.clone()));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let store = LexicalStore::new(storage.clone(), merging_config()).unwrap();
+    // Numeric field so the segment has a `.bkd` to fail.
+    let numbered = |body: &str, n: i64| {
+        Document::builder()
+            .add_text("body", body)
+            .add_integer("rank", n)
+            .build()
+    };
+    store.upsert_document(1, numbered("apple", 1)).unwrap();
+    store.commit().unwrap();
+    store.upsert_document(2, numbered("banana", 2)).unwrap();
+
+    failing.fail_next_create_matching("merged_", ".bkd");
+    assert!(
+        store.commit().is_err(),
+        "the injected .bkd failure must surface"
+    );
+    drop(store);
+
+    let leaked: Vec<String> = inner
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| f.starts_with("merged_") && f.ends_with(".meta"))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "a failed data-file write must not leave a discoverable merged segment: {leaked:?}"
+    );
+}
+
+/// List the committed `segment_*` / `merged_*` `.meta` names.
+fn list_metas(storage: &Arc<dyn Storage>) -> Vec<String> {
+    let mut metas: Vec<String> = storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| f.ends_with(".meta") && f != "index.meta")
+        .filter(|f| {
+            // Only count committed (published) segments.
+            let mut input = storage.open_input(f).unwrap();
+            let mut bytes = Vec::new();
+            input.read_to_end(&mut bytes).unwrap();
+            let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            v["committed"].as_bool().unwrap_or(true)
+        })
+        .collect();
+    metas.sort();
+    metas
+}


### PR DESCRIPTION
## Summary

Found during #1023's pre-implementation audit: a failed merge published a segment holding the partially merged documents, silently duplicating every document in it.

`MergeEngine::perform_merge` replays the source documents through an internally constructed writer. On a replay or flush failure the function returned early and the writer dropped with its buffers full — and `Drop` runs `close()` → `commit()`, whose `flush_segment()` + `publish_pending_segments()` wrote a fresh `segment_*` with the partial replay and flipped it to `committed: true` in the same ladder. The source segments are only deleted after a *successful* merge, so every document in the orphan was live twice. Reproduced: after an injected merge failure, a term that exists in exactly one document returns **2 hits**.

(#1034 already stopped this writer from touching `metadata.json`; the segment publication was the remaining half of its `Drop` damage.)

## The fix

- **Explicit lifecycle for the merge writer**: a new `pub(crate) InvertedIndexWriter::abort()` (`rollback()` + `closed = true`) makes `Drop` fully inert — no flush, no publish, not even the `index.meta` write. `perform_merge` runs the replay + flush as one fallible closure and aborts the writer before propagating any error.
- **`.meta` written last**: investigation found a sibling defect — `write_segment_files` wrote the segment `.meta` sixth of seven, before the BKD trees, so a failure in `write_bkd_trees` left a *discoverable committed* segment whose numeric-range/geo queries silently return zero hits (the #1000 symptom class). The `.meta` now goes last: a segment becomes discoverable only once every data file it advertises exists.

## Verification

- Three tests in `laurus/tests/merge_failure_publication_test.rs`, RED-proven on main: duplicate search hits (2 for 1), an extra `committed: true` `.meta` beyond the commit's own segment, and (for the ordering) a merged `.bkd` failure leaving no `merged_*.meta`.
- **Each fix proven non-inert independently**: `abort()` disabled → the two duplication tests fail, ordering test stays green; reorder reverted → the ordering test fails, duplication tests stay green. The fixes are orthogonal and separately load-bearing.
- `cargo test --workspace`: 0 failures. Clippy (CI-identical): exit 0. `cargo fmt --all --check`: clean. No docs changes needed — internal error-path behavior only.

Details: [investigation](https://github.com/mosuka/laurus/issues/1032#issuecomment-5389568266) / [plan](https://github.com/mosuka/laurus/issues/1032#issuecomment-5389568378) / [implementation report](https://github.com/mosuka/laurus/issues/1032#issuecomment-5389639348).

Closes #1032
