### PR TITLE
feat(lexical): write an atomic segment manifest alongside the .meta files

### DIFF
--- a/laurus/src/lexical/index/factory.rs
+++ b/laurus/src/lexical/index/factory.rs
@@ -60,10 +60,14 @@ impl LexicalIndexFactory {
     /// use laurus::lexical::index::factory::LexicalIndexFactory;
     /// use laurus::storage::{StorageFactory, StorageConfig};
     /// use laurus::storage::file::FileStorageConfig;
+    /// use tempfile::TempDir;
     ///
     /// # fn main() -> laurus::Result<()> {
-    /// // Create file storage
-    /// let storage_config = StorageConfig::File(FileStorageConfig::new("/tmp/index"));
+    /// // Create file storage in a private temporary directory. A fixed
+    /// // path would race the other doctests: index control files
+    /// // (metadata.json, segments.json) are per-directory.
+    /// let dir = TempDir::new().unwrap();
+    /// let storage_config = StorageConfig::File(FileStorageConfig::new(dir.path()));
     /// let storage = StorageFactory::create(storage_config)?;
     ///
     /// // Create inverted index

--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -43,6 +43,7 @@ pub mod query_cache;
 pub mod reader;
 pub mod searcher;
 pub mod segment;
+pub(crate) mod segment_manifest;
 pub mod writer;
 
 use self::reader::{InvertedIndexReader, InvertedIndexReaderConfig};
@@ -138,6 +139,18 @@ pub struct InvertedIndex {
     /// lock and persists a snapshot of it. Nothing re-reads the file into
     /// this lock after `open`, so disk can never clobber fresher state.
     metadata: Arc<RwLock<IndexMetadata>>,
+
+    /// The committed segment set, mirroring `segments.json` (#1021).
+    ///
+    /// Mutated only through
+    /// [`segment_manifest::publish_with`] (save-then-swap), so it is never
+    /// ahead of the persisted manifest. Shared with writers built by
+    /// [`Self::writer`]; writers built through the public
+    /// `InvertedIndexWriter::new` get no handle. Deliberately NOT part of
+    /// the `Debug` impl: publication holds the write guard across storage
+    /// I/O, and a blocking `.read()` in `Debug` would deadlock any error
+    /// path that formats the index mid-publish.
+    segment_manifest: segment_manifest::SharedSegmentManifest,
 }
 
 impl std::fmt::Debug for InvertedIndex {
@@ -162,9 +175,14 @@ impl InvertedIndex {
             extra_fields: RwLock::new(HashMap::new()),
             closed: AtomicBool::new(false),
             metadata: Arc::new(RwLock::new(metadata)),
+            segment_manifest: Arc::new(RwLock::new(Vec::new())),
         };
 
         index.write_metadata()?;
+        // An empty manifest from birth (#1021): "manifest present" then
+        // reliably means "authoritative record exists", and a fresh index
+        // is never mistaken for a legacy one.
+        segment_manifest::save(index.storage.as_ref(), &[])?;
         Ok(index)
     }
 
@@ -176,12 +194,27 @@ impl InvertedIndex {
 
         let metadata = Self::read_metadata(storage.as_ref())?;
 
+        // Manifest, or legacy migration (#1021): an index written before
+        // `segments.json` existed is read through the committed `.meta`
+        // scan, in memory only — `open` performs no writes (read-only and
+        // WASM storages must keep opening), so the first mutation persists
+        // the migrated manifest.
+        let segments = match segment_manifest::load(storage.as_ref())? {
+            Some(segments) => segments,
+            None => {
+                let mut scanned = Self::scan_segment_metas_from(storage.as_ref())?;
+                scanned.retain(|s| s.committed);
+                scanned
+            }
+        };
+
         Ok(InvertedIndex {
             storage,
             config,
             extra_fields: RwLock::new(HashMap::new()),
             closed: AtomicBool::new(false),
             metadata: Arc::new(RwLock::new(metadata)),
+            segment_manifest: Arc::new(RwLock::new(segments)),
         })
     }
 
@@ -287,7 +320,13 @@ impl InvertedIndex {
     ///
     /// Every segment described on storage, in directory order.
     fn scan_segment_metas(&self) -> Result<Vec<SegmentInfo>> {
-        let files = self.storage.list_files()?;
+        Self::scan_segment_metas_from(self.storage.as_ref())
+    }
+
+    /// [`Self::scan_segment_metas`] as an associated function, so `open`
+    /// can run the legacy-migration scan before `self` exists (#1021).
+    fn scan_segment_metas_from(storage: &dyn Storage) -> Result<Vec<SegmentInfo>> {
+        let files = storage.list_files()?;
         let mut segments = Vec::new();
 
         for file in &files {
@@ -296,7 +335,7 @@ impl InvertedIndex {
             if (file.starts_with("segment_") || file.starts_with("merged_"))
                 && file.ends_with(".meta")
             {
-                let mut input = self.storage.open_input(file)?;
+                let mut input = storage.open_input(file)?;
                 let mut data = Vec::new();
                 Read::read_to_end(&mut input, &mut data)?;
 
@@ -421,6 +460,22 @@ impl InvertedIndex {
 
         let engine = MergeEngine::new(MergeConfig::default(), self.storage.clone());
         let result = engine.merge_segments(&candidate, &managed, next_generation)?;
+
+        // Publish the merge transition as ONE manifest write (#1021): drop
+        // the sources and insert the merged segment with its final
+        // generation, applied as a delta to the LIVE list — never a
+        // snapshot replacement, which would lose a mutation that landed
+        // since this merge computed its sources. Everything after this is
+        // advisory (`.meta`) or physical cleanup, and every crash window
+        // below resolves in the manifest's favor.
+        let mut merged_info = result.new_segment.segment_info.clone();
+        merged_info.generation = next_generation;
+        let source_ids: Vec<String> = sources.iter().map(|s| s.segment_id.clone()).collect();
+        segment_manifest::publish_with(self.storage.as_ref(), &self.segment_manifest, |list| {
+            list.retain(|entry| !source_ids.contains(&entry.segment_id));
+            segment_manifest::upsert_entry(list, merged_info);
+        })?;
+
         self.set_segment_generation(&result.new_segment.segment_info.segment_id, next_generation)?;
 
         // Delete each source's `.meta` first (drops it from discovery), then the
@@ -585,15 +640,17 @@ impl LexicalIndex for InvertedIndex {
             fields,
             ..Default::default()
         };
-        // Hand the writer the shared metadata handle (#1023). This is the
-        // ONLY constructor that does: writers built through the public
-        // `InvertedIndexWriter::new` — the merge engine's internal replay
-        // writer included — get no handle and therefore cannot touch
-        // `metadata.json` at all.
-        let writer = InvertedIndexWriter::with_shared_metadata(
+        // Hand the writer the shared metadata and manifest handles
+        // (#1023 / #1021). This is the ONLY constructor that does: writers
+        // built through the public `InvertedIndexWriter::new` — the merge
+        // engine's internal replay writer included — get neither handle
+        // and therefore can touch neither `metadata.json` nor
+        // `segments.json`.
+        let writer = InvertedIndexWriter::with_shared_state(
             self.storage.clone(),
             writer_config,
             Arc::clone(&self.metadata),
+            Arc::clone(&self.segment_manifest),
         )?;
         Ok(Box::new(writer))
     }

--- a/laurus/src/lexical/index/inverted/segment_manifest.rs
+++ b/laurus/src/lexical/index/inverted/segment_manifest.rs
@@ -1,0 +1,259 @@
+//! Atomic segment manifest for the lexical inverted index (#1021).
+//!
+//! `segments.json` is the single, atomically replaced record of the
+//! committed segment set — the counterpart of the vector side's
+//! `SegmentManager` manifest, built on the shared
+//! [`storage::manifest`](crate::storage::manifest) helpers (CRC-verified,
+//! written via temp + rename + directory sync).
+//!
+//! # Authority and the save-then-swap rule
+//!
+//! The in-memory copy (owned by
+//! [`InvertedIndex`](super::InvertedIndex), shared with its writer) is a
+//! mirror of the last **successfully persisted** manifest, never ahead of
+//! it. Every mutation goes through [`publish_with`]: build a candidate
+//! under the write guard, persist it, and only on success swap it into
+//! memory. This deliberately deviates from the vector manager's
+//! mutate-then-save: there, a failed save leaves memory ahead of disk,
+//! which is survivable when every later save rewrites the full list — but
+//! here a retried commit would find its pending state consumed, publish
+//! nothing, and still advance the WAL checkpoint, after which a reopen
+//! would neither replay nor discover the segments.
+//!
+//! The manifest lock is a **leaf**: nothing under its guard may construct
+//! readers, list storage, or take the index's metadata lock. The guard is
+//! intentionally held across the save so two racing mutators cannot
+//! publish manifests out of order (the same argument as
+//! `SegmentManager::save_state_locked`); this is safe only while no other
+//! code path — `Debug` impls included — blocks on this lock.
+
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::storage::Storage;
+use crate::storage::manifest as manifest_io;
+
+use super::segment::SegmentInfo;
+
+/// Manifest file name inside the lexical storage namespace.
+pub(crate) const MANIFEST_FILE: &str = "segments.json";
+
+/// On-disk manifest version written by this build.
+///
+/// Version 1 means "written while segment discovery still ran on the
+/// `.meta` scan" (#1021 PR 1). The discovery flip bumps this to 2, and the
+/// orphan sweep is gated on `>= 2` so a version-1 manifest is never used
+/// as a deletion warrant.
+pub(crate) const MANIFEST_VERSION: u32 = 1;
+
+/// Shared handle to the in-memory committed-segment set.
+pub(crate) type SharedSegmentManifest = Arc<RwLock<Vec<SegmentInfo>>>;
+
+/// Serialized form of [`MANIFEST_FILE`].
+#[derive(Debug, Serialize, Deserialize)]
+struct SegmentManifest {
+    /// Format version — see [`MANIFEST_VERSION`].
+    version: u32,
+    /// The committed segments, in publication order.
+    segments: Vec<SegmentInfo>,
+}
+
+/// Load the manifest from `storage`.
+///
+/// # Arguments
+///
+/// * `storage` - The lexical index's storage.
+///
+/// # Returns
+///
+/// `Ok(Some(segments))` when the manifest exists, `Ok(None)` when it does
+/// not (a legacy index — the caller falls back to the `.meta` scan).
+///
+/// # Errors
+///
+/// Returns an error if the file exists but is corrupted (checksum
+/// mismatch) or fails to parse — a torn or damaged manifest must surface,
+/// not silently degrade to an empty segment set.
+pub(crate) fn load(storage: &dyn Storage) -> Result<Option<Vec<SegmentInfo>>> {
+    match manifest_io::load_checksummed_json::<SegmentManifest>(storage, MANIFEST_FILE, None)? {
+        Some((manifest, _format)) => Ok(Some(manifest.segments)),
+        None => Ok(None),
+    }
+}
+
+/// Persist `segments` as the new manifest, atomically.
+///
+/// # Arguments
+///
+/// * `storage` - The lexical index's storage.
+/// * `segments` - The complete committed segment set to record.
+///
+/// # Errors
+///
+/// Returns an error if serializing or persisting fails; the previous
+/// manifest is left intact in that case (temp + rename).
+pub(crate) fn save(storage: &dyn Storage, segments: &[SegmentInfo]) -> Result<()> {
+    let manifest = SegmentManifest {
+        version: MANIFEST_VERSION,
+        segments: segments.to_vec(),
+    };
+    manifest_io::save_checksummed_json(storage, MANIFEST_FILE, None, &manifest)
+}
+
+/// Mutate the shared manifest under the save-then-swap rule.
+///
+/// Clones the current list, applies `mutate` to the clone, persists the
+/// candidate while still holding the write guard, and swaps it into
+/// memory **only if the save succeeded**. On failure the in-memory copy
+/// (and the caller's pending state) is untouched, so a retried commit
+/// republishes the same mutation.
+///
+/// # Arguments
+///
+/// * `storage` - The lexical index's storage.
+/// * `shared` - The shared in-memory manifest.
+/// * `mutate` - Delta to apply to the candidate list. It receives the
+///   candidate, never the live list.
+///
+/// # Errors
+///
+/// Returns the persistence error, leaving memory unchanged.
+pub(crate) fn publish_with<F>(
+    storage: &dyn Storage,
+    shared: &RwLock<Vec<SegmentInfo>>,
+    mutate: F,
+) -> Result<()>
+where
+    F: FnOnce(&mut Vec<SegmentInfo>),
+{
+    let mut guard = shared.write();
+    let mut candidate = guard.clone();
+    mutate(&mut candidate);
+    save(storage, &candidate)?;
+    *guard = candidate;
+    Ok(())
+}
+
+/// Insert `info` into `list`, replacing any entry with the same
+/// `segment_id`.
+///
+/// The dedup is what makes a retried publication idempotent: a commit
+/// whose manifest save succeeded but whose later ladder step failed
+/// re-runs the whole publish, and must not double-add.
+pub(crate) fn upsert_entry(list: &mut Vec<SegmentInfo>, info: SegmentInfo) {
+    if let Some(existing) = list
+        .iter_mut()
+        .find(|entry| entry.segment_id == info.segment_id)
+    {
+        *existing = info;
+    } else {
+        list.push(info);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+    fn seg(id: &str, generation: u64) -> SegmentInfo {
+        SegmentInfo {
+            segment_id: id.to_string(),
+            doc_count: 1,
+            min_doc_id: 0,
+            max_doc_id: 0,
+            generation,
+            has_deletions: false,
+            shard_id: 0,
+            committed: true,
+        }
+    }
+
+    #[test]
+    fn save_load_roundtrip() {
+        let storage = MemoryStorage::new(MemoryStorageConfig::default());
+        assert!(load(&storage).unwrap().is_none(), "no manifest yet");
+
+        let segments = vec![seg("segment_000001", 1), seg("merged_2", 2)];
+        save(&storage, &segments).unwrap();
+        assert_eq!(load(&storage).unwrap().unwrap(), segments);
+    }
+
+    #[test]
+    fn upsert_entry_replaces_by_id() {
+        let mut list = vec![seg("segment_000001", 1)];
+        let mut updated = seg("segment_000001", 1);
+        updated.has_deletions = true;
+        upsert_entry(&mut list, updated.clone());
+        assert_eq!(list, vec![updated], "same id must replace, not append");
+
+        upsert_entry(&mut list, seg("segment_000002", 2));
+        assert_eq!(list.len(), 2, "new id must append");
+    }
+
+    #[test]
+    fn failed_save_leaves_memory_and_disk_untouched() {
+        // A storage that refuses every write.
+        #[derive(Debug)]
+        struct ReadOnly(MemoryStorage);
+        impl Storage for ReadOnly {
+            fn create_output(&self, _n: &str) -> Result<Box<dyn crate::storage::StorageOutput>> {
+                Err(crate::LaurusError::storage("read-only"))
+            }
+            fn create_output_append(
+                &self,
+                n: &str,
+            ) -> Result<Box<dyn crate::storage::StorageOutput>> {
+                self.0.create_output_append(n)
+            }
+            fn open_input(&self, n: &str) -> Result<Box<dyn crate::storage::StorageInput>> {
+                self.0.open_input(n)
+            }
+            fn file_exists(&self, n: &str) -> bool {
+                self.0.file_exists(n)
+            }
+            fn delete_file(&self, n: &str) -> Result<()> {
+                self.0.delete_file(n)
+            }
+            fn rename_file(&self, a: &str, b: &str) -> Result<()> {
+                self.0.rename_file(a, b)
+            }
+            fn list_files(&self) -> Result<Vec<String>> {
+                self.0.list_files()
+            }
+            fn file_size(&self, n: &str) -> Result<u64> {
+                self.0.file_size(n)
+            }
+            fn sync(&self) -> Result<()> {
+                Ok(())
+            }
+            fn metadata(&self, n: &str) -> Result<crate::storage::FileMetadata> {
+                self.0.metadata(n)
+            }
+            fn create_temp_output(
+                &self,
+                p: &str,
+            ) -> Result<(String, Box<dyn crate::storage::StorageOutput>)> {
+                self.0.create_temp_output(p)
+            }
+            fn close(&mut self) -> Result<()> {
+                Ok(())
+            }
+        }
+
+        let storage = ReadOnly(MemoryStorage::new(MemoryStorageConfig::default()));
+        let shared = RwLock::new(vec![seg("segment_000001", 1)]);
+        let err = publish_with(&storage, &shared, |list| {
+            upsert_entry(list, seg("segment_000002", 2));
+        });
+        assert!(err.is_err());
+        assert_eq!(
+            shared.read().len(),
+            1,
+            "a failed save must not advance the in-memory manifest"
+        );
+    }
+}

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -182,6 +182,15 @@ pub struct InvertedIndexWriter {
     /// checkpoint on the next commit).
     metadata: Option<Arc<parking_lot::RwLock<IndexMetadata>>>,
 
+    /// Shared handle to the index's committed-segment manifest (#1021).
+    ///
+    /// `Some` only for writers built via [`Self::with_shared_state`] —
+    /// like [`Self::metadata`], and with the same rationale: handle-less
+    /// writers (the merge engine's replay writer, direct test
+    /// constructions) keep today's `.meta`-only behavior and cannot touch
+    /// `segments.json`.
+    segment_manifest: Option<super::segment_manifest::SharedSegmentManifest>,
+
     /// Last processed WAL sequence number.
     last_wal_seq: u64,
 
@@ -211,13 +220,20 @@ pub struct InvertedIndexWriter {
     ///
     /// `flush_segment` writes a segment as soon as the buffer fills, with
     /// `committed: false` in its `.meta` so discovery skips it. `commit`
-    /// walks this list and flips the flag, which is the moment those
-    /// documents become searchable.
+    /// publishes this list — one manifest write adds every entry (#1021),
+    /// then the per-`.meta` flags are flipped as advisory dual-writes —
+    /// which is the moment those documents become searchable.
+    ///
+    /// Holds the full [`SegmentInfo`] (as flushed, `committed: false`) so
+    /// publication needs no `.meta` re-read; [`Self::flush_deletions`]
+    /// updates `has_deletions` here too, or a segment deleted-from and
+    /// published in the same commit would enter the manifest with the
+    /// flag still false and resurrect its deleted documents.
     ///
     /// Kept separate from [`Self::flushed_segments`], which exists for NRT
     /// `_id` resolution and is cleared on the same events: the two answer
     /// different questions and one is not derivable from the other.
-    pending_publish: Vec<String>,
+    pending_publish: Vec<SegmentInfo>,
 
     /// Cached `(segment_id, min_doc_id, max_doc_id)` for every committed
     /// segment, mirroring the `*.meta` files on storage (Issue #559 / #864).
@@ -281,18 +297,22 @@ impl std::fmt::Debug for InvertedIndexWriter {
 impl InvertedIndexWriter {
     /// Create a new inverted index writer (schema-less mode).
     ///
-    /// A writer built this way has no handle to an index's metadata and
-    /// therefore never writes `metadata.json` (#1023) — this is what keeps
-    /// the merge engine's internal replay writer (and every direct test
-    /// construction) from competing with the index over the control file.
-    /// Writers that should maintain the metadata are built by
+    /// A writer built this way has no handle to an index's shared state
+    /// and therefore never writes `metadata.json` (#1023) or
+    /// `segments.json` (#1021) — this is what keeps the merge engine's
+    /// internal replay writer (and every direct test construction) from
+    /// competing with the index over the control files. Segments committed
+    /// by a standalone writer are recorded only in their `.meta` files and
+    /// are NOT registered with an index's manifest. Writers that should
+    /// maintain the shared state are built by
     /// [`InvertedIndex::writer`](crate::lexical::index::inverted::InvertedIndex)
-    /// through [`Self::with_shared_metadata`].
+    /// through [`Self::with_shared_state`].
     pub fn new(storage: Arc<dyn Storage>, config: InvertedIndexWriterConfig) -> Result<Self> {
-        Self::build(storage, config, None)
+        Self::build(storage, config, None, None)
     }
 
-    /// Create a writer that maintains the index's shared metadata (#1023).
+    /// Create a writer that maintains the index's shared state
+    /// (#1023 / #1021).
     ///
     /// # Arguments
     ///
@@ -301,24 +321,28 @@ impl InvertedIndexWriter {
     /// * `metadata` - Handle to the owning index's authoritative metadata;
     ///   the writer applies its per-commit deltas to it and persists a
     ///   snapshot at every commit.
+    /// * `segment_manifest` - Handle to the owning index's committed-segment
+    ///   manifest; `commit` publishes flushed segments into it atomically.
     ///
     /// # Errors
     ///
     /// Returns an error if recovering writer state from storage fails.
-    pub(crate) fn with_shared_metadata(
+    pub(crate) fn with_shared_state(
         storage: Arc<dyn Storage>,
         config: InvertedIndexWriterConfig,
         metadata: Arc<parking_lot::RwLock<IndexMetadata>>,
+        segment_manifest: super::segment_manifest::SharedSegmentManifest,
     ) -> Result<Self> {
-        Self::build(storage, config, Some(metadata))
+        Self::build(storage, config, Some(metadata), Some(segment_manifest))
     }
 
     /// Shared constructor body behind [`Self::new`] and
-    /// [`Self::with_shared_metadata`].
+    /// [`Self::with_shared_state`].
     fn build(
         storage: Arc<dyn Storage>,
         config: InvertedIndexWriterConfig,
         metadata: Option<Arc<parking_lot::RwLock<IndexMetadata>>>,
+        segment_manifest: Option<super::segment_manifest::SharedSegmentManifest>,
     ) -> Result<Self> {
         // Recover state from existing segments. The same scan also seeds the
         // segment-range cache (Issue #559 / #864), so the cache is warm from
@@ -382,6 +406,7 @@ impl InvertedIndexWriter {
             },
             last_wal_seq,
             metadata,
+            segment_manifest,
             pending_deletions: std::collections::HashSet::new(),
             flushed_segments: Vec::new(),
             pending_publish: Vec::new(),
@@ -924,8 +949,11 @@ impl InvertedIndexWriter {
             self.storage.clone(),
         )?);
 
-        // Remember to publish it at the next commit (#1017).
-        self.pending_publish.push(segment_name.clone());
+        // Remember to publish it at the next commit (#1017). The full
+        // description is retained so publication needs no `.meta` re-read
+        // (#1021); `flush_deletions` keeps its `has_deletions` current.
+        self.pending_publish
+            .push(self.segment_info_for(&segment_name, /* committed */ false));
 
         // Clear buffers
         self.buffered_docs.clear();
@@ -2014,8 +2042,33 @@ impl InvertedIndexWriter {
     /// A segment already published (for instance one this writer adopted
     /// from an older index) is left alone.
     fn publish_pending_segments(&mut self) -> Result<()> {
-        for segment_id in std::mem::take(&mut self.pending_publish) {
-            self.update_segment_meta(&segment_id, |meta| {
+        if self.pending_publish.is_empty() {
+            return Ok(());
+        }
+
+        // Manifest first (#1021): ONE atomic write adds every pending
+        // segment — all-or-nothing, unlike the per-`.meta` flips below.
+        // save-then-swap: the pending list is consumed only after the whole
+        // publication succeeds, so the #875 retained-writer retry simply
+        // re-runs it; the upsert dedups by segment_id, so a retry whose
+        // manifest save had already landed cannot double-add.
+        if let Some(manifest) = &self.segment_manifest {
+            let pending = &self.pending_publish;
+            super::segment_manifest::publish_with(self.storage.as_ref(), manifest, |list| {
+                for info in pending {
+                    let mut info = info.clone();
+                    info.committed = true;
+                    super::segment_manifest::upsert_entry(list, info);
+                }
+            })?;
+        }
+
+        // Advisory `.meta` flips (dual-write during the #1021 transition).
+        // Iterating without draining fixes a latent partial-publish bug:
+        // the old `std::mem::take` dropped every not-yet-flipped id on a
+        // mid-loop error, permanently hiding those committed documents.
+        for info in &self.pending_publish {
+            self.update_segment_meta(&info.segment_id, |meta| {
                 if meta.committed {
                     false
                 } else {
@@ -2024,6 +2077,7 @@ impl InvertedIndexWriter {
                 }
             })?;
         }
+        self.pending_publish.clear();
         Ok(())
     }
 
@@ -2094,6 +2148,39 @@ impl InvertedIndexWriter {
             return Ok(());
         }
         let pending: Vec<String> = self.pending_meta_deletions.iter().cloned().collect();
+
+        // Apply the flips to the manifest (#1021), AFTER the bitmaps above
+        // are durable (#875's contract: a reader that sees the flag always
+        // finds the `.delmap`) and BEFORE the advisory `.meta` flips. One
+        // atomic write covers every flipped segment. A failed save leaves
+        // `pending_meta_deletions` intact for the retry; a repeated save
+        // after a partial advisory failure is idempotent.
+        if let Some(manifest) = &self.segment_manifest {
+            super::segment_manifest::publish_with(self.storage.as_ref(), manifest, |list| {
+                for segment_id in &pending {
+                    if let Some(entry) = list.iter_mut().find(|s| &s.segment_id == segment_id) {
+                        entry.has_deletions = true;
+                    }
+                }
+            })?;
+        }
+
+        // A segment flushed in THIS commit has no manifest entry yet — it
+        // is still in `pending_publish`. Update the retained description,
+        // or the deleted-from-then-published segment would enter the
+        // manifest with `has_deletions: false` and resurrect its deleted
+        // documents once discovery trusts the manifest (#1021).
+        for segment_id in &pending {
+            if let Some(entry) = self
+                .pending_publish
+                .iter_mut()
+                .find(|s| &s.segment_id == segment_id)
+            {
+                entry.has_deletions = true;
+            }
+        }
+
+        // Advisory `.meta` flips (dual-write during the #1021 transition).
         for segment_id in pending {
             self.persist_segment_meta_deletions(&segment_id)?;
             self.pending_meta_deletions.remove(&segment_id);

--- a/laurus/src/storage.rs
+++ b/laurus/src/storage.rs
@@ -749,14 +749,18 @@ impl StorageFactory {
     /// use laurus::storage::{StorageFactory, StorageConfig};
     /// use laurus::storage::file::FileStorageConfig;
     /// use laurus::storage::memory::MemoryStorageConfig;
+    /// use tempfile::TempDir;
     ///
     /// # fn main() -> laurus::Result<()> {
     /// // Create memory storage
     /// let config = StorageConfig::Memory(MemoryStorageConfig::default());
     /// let storage = StorageFactory::create(config)?;
     ///
-    /// // Create file storage
-    /// let file_config = FileStorageConfig::new("/tmp/index");
+    /// // Create file storage in a private temporary directory (doctests
+    /// // must not share a fixed path — index control files are
+    /// // per-directory).
+    /// let dir = TempDir::new().unwrap();
+    /// let file_config = FileStorageConfig::new(dir.path());
     /// let config = StorageConfig::File(file_config);
     /// let storage = StorageFactory::create(config)?;
     /// # Ok(())

--- a/laurus/src/vector/index/factory.rs
+++ b/laurus/src/vector/index/factory.rs
@@ -64,10 +64,15 @@ impl VectorIndexFactory {
     /// use laurus::vector::index::config::{VectorIndexTypeConfig, FlatIndexConfig};
     /// use laurus::storage::{StorageFactory, StorageConfig};
     /// use laurus::storage::file::FileStorageConfig;
+    /// use tempfile::TempDir;
     ///
     /// # fn main() -> laurus::Result<()> {
-    /// // Create file storage
-    /// let storage_config = StorageConfig::File(FileStorageConfig::new("/tmp/index"));
+    /// // Create file storage in a private temporary directory. A fixed
+    /// // path would race the other doctests: index control files
+    /// // (metadata.json, segments.json) are per-directory, and this
+    /// // doctest once failed on another doctest's lexical manifest.
+    /// let dir = TempDir::new().unwrap();
+    /// let storage_config = StorageConfig::File(FileStorageConfig::new(dir.path()));
     /// let storage = StorageFactory::create(storage_config)?;
     ///
     /// // Create flat index

--- a/laurus/tests/lexical_segment_manifest_test.rs
+++ b/laurus/tests/lexical_segment_manifest_test.rs
@@ -1,0 +1,378 @@
+//! #1021 PR 1 — the lexical segment manifest is written alongside the
+//! `.meta` files, and the two records agree after every mutation class.
+//!
+//! In this PR segment DISCOVERY still runs on the `.meta` scan, so a
+//! manifest content bug would be behaviorally invisible — and PR 2 would
+//! then trust that manifest and enforce it with the orphan sweep. This
+//! equivalence property suite is what makes such a bug fail loudly here:
+//! after every mutation class, `segments.json` must equal the committed
+//! `.meta` scan, `has_deletions` and `generation` included.
+
+use std::io::Read;
+use std::sync::Arc;
+
+use laurus::lexical::index::inverted::segment::SegmentInfo;
+use laurus::lexical::{LexicalIndexConfig, LexicalStore};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::storage::{Storage, StorageInput, StorageOutput};
+use laurus::{Document, LaurusError, Result as LaurusResult};
+
+/// Storage decorator failing the next `rename_file` whose destination
+/// matches the armed `(prefix, suffix)` — the atomic-write publish step of
+/// either the manifest (`segments.json`) or an advisory `.meta` flip.
+#[derive(Debug)]
+struct FailingStorage {
+    inner: Arc<dyn Storage>,
+    fail_rename_to: parking_lot::Mutex<Option<(String, String)>>,
+}
+
+impl FailingStorage {
+    fn new(inner: Arc<dyn Storage>) -> Self {
+        Self {
+            inner,
+            fail_rename_to: parking_lot::Mutex::new(None),
+        }
+    }
+
+    fn fail_next_rename_matching(&self, prefix: &str, suffix: &str) {
+        *self.fail_rename_to.lock() = Some((prefix.to_string(), suffix.to_string()));
+    }
+}
+
+impl Storage for FailingStorage {
+    fn create_output(&self, name: &str) -> LaurusResult<Box<dyn StorageOutput>> {
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> LaurusResult<Box<dyn StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+
+    fn open_input(&self, name: &str) -> LaurusResult<Box<dyn StorageInput>> {
+        self.inner.open_input(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> LaurusResult<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> LaurusResult<()> {
+        let armed = {
+            let mut guard = self.fail_rename_to.lock();
+            if guard
+                .as_ref()
+                .is_some_and(|(p, x)| new_name.starts_with(p) && new_name.ends_with(x))
+            {
+                *guard = None;
+                true
+            } else {
+                false
+            }
+        };
+        if armed {
+            return Err(LaurusError::storage(format!(
+                "injected failure renaming {old_name} to {new_name}"
+            )));
+        }
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn list_files(&self) -> LaurusResult<Vec<String>> {
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> LaurusResult<u64> {
+        self.inner.file_size(name)
+    }
+
+    fn sync(&self) -> LaurusResult<()> {
+        self.inner.sync()
+    }
+
+    fn metadata(&self, name: &str) -> LaurusResult<laurus::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+
+    fn create_temp_output(&self, prefix: &str) -> LaurusResult<(String, Box<dyn StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn close(&mut self) -> LaurusResult<()> {
+        Ok(())
+    }
+}
+
+/// Read a file's bytes.
+fn read_bytes(storage: &Arc<dyn Storage>, name: &str) -> Vec<u8> {
+    let mut input = storage.open_input(name).unwrap();
+    let mut bytes = Vec::new();
+    input.read_to_end(&mut bytes).unwrap();
+    bytes
+}
+
+/// Parse the checksummed manifest: `varint(len) || json || crc`.
+fn read_manifest(storage: &Arc<dyn Storage>) -> Vec<SegmentInfo> {
+    let bytes = read_bytes(storage, "segments.json");
+    let payload = if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) {
+        value
+    } else {
+        let mut len: u64 = 0;
+        let mut shift = 0;
+        let mut cursor = 0usize;
+        loop {
+            let byte = bytes[cursor];
+            cursor += 1;
+            len |= u64::from(byte & 0x7F) << shift;
+            if byte & 0x80 == 0 {
+                break;
+            }
+            shift += 7;
+        }
+        serde_json::from_slice(&bytes[cursor..cursor + len as usize]).unwrap()
+    };
+    let segments = payload["segments"].as_array().unwrap().clone();
+    segments
+        .into_iter()
+        .map(|v| serde_json::from_value(v).unwrap())
+        .collect()
+}
+
+/// Scan the committed `.meta` files, exactly as discovery does today.
+fn scan_committed_metas(storage: &Arc<dyn Storage>) -> Vec<SegmentInfo> {
+    let mut segments: Vec<SegmentInfo> = storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .filter(|f| (f.starts_with("segment_") || f.starts_with("merged_")) && f.ends_with(".meta"))
+        .map(|f| serde_json::from_slice::<SegmentInfo>(&read_bytes(storage, &f)).unwrap())
+        .filter(|s| s.committed)
+        .collect();
+    segments.sort_by(|a, b| a.segment_id.cmp(&b.segment_id));
+    segments
+}
+
+/// The equivalence property: the manifest and the committed-`.meta` scan
+/// describe the same segments, field for field.
+#[track_caller]
+fn assert_equiv(storage: &Arc<dyn Storage>) {
+    let mut manifest = read_manifest(storage);
+    manifest.sort_by(|a, b| a.segment_id.cmp(&b.segment_id));
+    let metas = scan_committed_metas(storage);
+    assert_eq!(
+        manifest, metas,
+        "segments.json must equal the committed .meta scan"
+    );
+}
+
+fn doc(body: &str) -> Document {
+    Document::builder().add_text("body", body).build()
+}
+
+fn memory_storage() -> Arc<dyn Storage> {
+    Arc::new(MemoryStorage::new(MemoryStorageConfig::default()))
+}
+
+/// Plain commits: every commit adds its segment to the manifest.
+#[test]
+fn manifest_matches_meta_after_plain_commits() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+
+    assert_eq!(
+        read_manifest(&storage).len(),
+        0,
+        "create() must write an empty manifest from birth"
+    );
+
+    for round in 1..=2u64 {
+        store.upsert_document(round, doc("alpha")).unwrap();
+        store.commit().unwrap();
+        assert_equiv(&storage);
+    }
+    assert_eq!(read_manifest(&storage).len(), 2);
+}
+
+/// A deleting commit: the `has_deletions` flip reaches the manifest.
+#[test]
+fn manifest_matches_meta_after_a_deleting_commit() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+
+    store.upsert_document(1, doc("alpha")).unwrap();
+    store.commit().unwrap();
+    // Overwrite the committed doc: marks a deletion in its segment.
+    store.upsert_document(1, doc("alpha-v2")).unwrap();
+    store.commit().unwrap();
+
+    assert_equiv(&storage);
+    assert!(
+        read_manifest(&storage).iter().any(|s| s.has_deletions),
+        "the deleting commit must flip has_deletions in the manifest"
+    );
+}
+
+/// The BLOCKER-1 canary: a segment that is deleted-from and published in
+/// the SAME commit must enter the manifest with `has_deletions: true`.
+///
+/// The pending `SegmentInfo` is captured at flush time, before the
+/// deletion exists; without the `pending_publish` update in
+/// `flush_deletions`, the manifest would say `false` while the `.meta`
+/// (read back from disk at flip time) says `true` — and once discovery
+/// trusts the manifest, the deleted version would resurrect.
+#[test]
+fn delete_and_publish_in_one_commit_keeps_has_deletions() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+
+    // Past max_buffered_docs (10_000) so a segment auto-flushes,
+    // uncommitted. Doc 1 lands in it.
+    for i in 1..=10_050u64 {
+        store.upsert_document(i, doc("alpha")).unwrap();
+    }
+    // Overwrite doc 1: the deletion targets the FLUSHED, unpublished
+    // segment.
+    store.upsert_document(1, doc("alpha-v2")).unwrap();
+    store.commit().unwrap();
+
+    assert_equiv(&storage);
+    assert!(
+        read_manifest(&storage)
+            .iter()
+            .any(|s| s.has_deletions && s.segment_id.starts_with("segment_")),
+        "the flushed-then-deleted-from segment must carry has_deletions in the manifest"
+    );
+}
+
+/// Auto-merge: the merge transition (drop sources, add merged with its
+/// final generation) reaches the manifest atomically.
+#[test]
+fn manifest_matches_meta_after_auto_merge() {
+    let storage = memory_storage();
+    let config = LexicalIndexConfig::builder()
+        .max_segments(1)
+        .merge_factor(2)
+        .build();
+    let store = LexicalStore::new(storage.clone(), config).unwrap();
+
+    for round in 1..=3u64 {
+        store.upsert_document(round, doc("alpha")).unwrap();
+        store.commit().unwrap();
+        assert_equiv(&storage);
+    }
+}
+
+/// Optimize (force-merge-all): same property on the other merge path.
+#[test]
+fn manifest_matches_meta_after_optimize() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+
+    for round in 1..=3u64 {
+        store.upsert_document(round, doc("alpha")).unwrap();
+        store.commit().unwrap();
+    }
+    store.optimize().unwrap();
+    assert_equiv(&storage);
+}
+
+/// save-then-swap: a failed manifest save leaves the previous manifest
+/// intact, and the retained writer's retry republishes without
+/// double-adding.
+#[test]
+fn failed_manifest_save_retries_cleanly() {
+    let inner = memory_storage();
+    let failing = Arc::new(FailingStorage::new(inner.clone()));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    store.upsert_document(1, doc("alpha")).unwrap();
+    store.commit().unwrap();
+    let before = read_bytes(&inner, "segments.json");
+
+    store.upsert_document(2, doc("beta")).unwrap();
+    failing.fail_next_rename_matching("segments.json", "");
+    assert!(
+        store.commit().is_err(),
+        "the injected manifest-save failure must surface"
+    );
+    assert_eq!(
+        read_bytes(&inner, "segments.json"),
+        before,
+        "a failed save must leave the previous manifest byte-identical"
+    );
+
+    // The retained writer retries (#875) and republishes.
+    store.commit().unwrap();
+    assert_equiv(&inner);
+    let manifest = read_manifest(&inner);
+    let mut ids: Vec<&str> = manifest.iter().map(|s| s.segment_id.as_str()).collect();
+    ids.sort_unstable();
+    let unique = ids.len();
+    ids.dedup();
+    assert_eq!(ids.len(), unique, "a retried publish must not double-add");
+    assert_eq!(manifest.len(), 2);
+}
+
+/// The `mem::take` partial-publish regression: an advisory `.meta` flip
+/// failing mid-publish must not drop the unflipped segments — the retry
+/// publishes every pending segment.
+#[test]
+fn partial_meta_flip_failure_republishes_everything() {
+    let inner = memory_storage();
+    let failing = Arc::new(FailingStorage::new(inner.clone()));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    // Two pending segments in one commit: one auto-flushed, one flushed by
+    // the commit itself.
+    for i in 1..=10_050u64 {
+        store.upsert_document(i, doc("alpha")).unwrap();
+    }
+    // Fail the first advisory `.meta` publish flip (a rename onto a
+    // `segment_*.meta`); the manifest save (`segments.json`) has already
+    // succeeded by then.
+    failing.fail_next_rename_matching("segment_", ".meta");
+    assert!(
+        store.commit().is_err(),
+        "the injected .meta flip failure must surface"
+    );
+
+    // Retry: everything is republished — manifest and .meta agree and
+    // every segment is committed.
+    store.commit().unwrap();
+    assert_equiv(&inner);
+    assert_eq!(
+        read_manifest(&inner).len(),
+        2,
+        "both pending segments must be published after the retry"
+    );
+}
+
+/// Legacy migration: an index without a manifest opens through the `.meta`
+/// scan, and the first mutation persists the migrated manifest.
+#[test]
+fn legacy_index_without_manifest_migrates_on_first_mutation() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    store.upsert_document(1, doc("alpha")).unwrap();
+    store.commit().unwrap();
+    drop(store);
+
+    // Simulate a pre-manifest index.
+    storage.delete_file("segments.json").unwrap();
+
+    let reopened = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    reopened.upsert_document(2, doc("beta")).unwrap();
+    reopened.commit().unwrap();
+
+    assert_equiv(&storage);
+    assert_eq!(
+        read_manifest(&storage).len(),
+        2,
+        "the migrated manifest must contain the legacy segment AND the new one"
+    );
+}


### PR DESCRIPTION
## Summary

First half of #1021 (PR 1 of 2). The lexical index gains `segments.json` — an atomically replaced, CRC-verified record of the committed segment set, built on the `storage::manifest` helpers from #1027 — written at every publication point, while segment **discovery still runs on the `.meta` scan**. This PR is behavior-invariant by design; PR 2 flips discovery to the manifest, bumps its version to 2, and adds the version-gated orphan sweep.

The design went through an adversarial review (2 BLOCKER / 2 HIGH findings, all folded in — details on the issue: [investigation](https://github.com/mosuka/laurus/issues/1021#issuecomment-5389891039) / [plan](https://github.com/mosuka/laurus/issues/1021#issuecomment-5390284571) / [implementation report](https://github.com/mosuka/laurus/issues/1021#issuecomment-5390658069)).

## Key decisions

- **save-then-swap**, a deliberate deviation from the vector manager's mutate-then-save: the candidate list is built under the write guard, persisted, and only on success swapped into memory with its pending state consumed. Memory is never ahead of disk — load-bearing once discovery reads memory, because a consumed-but-unsaved publication would advance the WAL checkpoint over segments no reopen could ever discover (the reviewer's BLOCKER-2). Inserts dedup by `segment_id`, keeping the #875 retained-writer retry idempotent.
- **Three publication points, one atomic save each**: commit publish (pending segments now carried as full `SegmentInfo`s), `flush_deletions` (which also flips `has_deletions` on entries still in `pending_publish` — a segment deleted-from and published in the same commit would otherwise enter the manifest with the flag false and resurrect its deleted documents: BLOCKER-1), and `merge_segment_set` (the merge transition as a delta to the live list, before any advisory step).
- `create()` writes an empty manifest from birth; `open()` migrates legacy indexes from the committed-`.meta` scan **in memory only** — the open path performs no writes (read-only/WASM-safe).
- The public `InvertedIndexWriter::new` keeps its signature and stays handle-less; only `InvertedIndex::writer()` hands out the shared state (constructor renamed `with_shared_state`).

## Bonus fix

The old `publish_pending_segments` had a live latent bug: `std::mem::take` dropped every not-yet-flipped segment on a mid-loop error, permanently hiding committed documents. The rewrite iterates without draining and clears only after full success — regression-tested.

## Verification

- **Equivalence property suite** (8 tests): after every mutation class — plain commits, a deleting commit, delete-then-publish-in-one-commit, three auto-merging rounds, optimize, a failed manifest save + retry, a partial advisory-flip failure + retry, legacy migration — `segments.json == committed-.meta scan`, `has_deletions`/`generation` included. This is what makes a manifest content bug fail loudly *before* PR 2 starts trusting (and enforcing) the manifest.
- **Every amendment proven non-inert**: disabling the `pending_publish` flip, reverting to consume-before-save, restoring the `mem::take` drain, or removing the merge publication each turns exactly its own test red.
- `cargo test --workspace`: 0 failures. Clippy (CI-identical): exit 0. `cargo fmt --all --check`: clean.

Refs #1021
