### PR TITLE
refactor(lexical): derive writer state from the manifest, reserve generations

### DIFF
--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -175,7 +175,10 @@ impl InvertedIndex {
             extra_fields: RwLock::new(HashMap::new()),
             closed: AtomicBool::new(false),
             metadata: Arc::new(RwLock::new(metadata)),
-            segment_manifest: Arc::new(RwLock::new(Vec::new())),
+            segment_manifest: Arc::new(RwLock::new(segment_manifest::ManifestState {
+                segments: Vec::new(),
+                next_generation: 0,
+            })),
         };
 
         index.write_metadata()?;
@@ -207,16 +210,43 @@ impl InvertedIndex {
             &loaded,
             Some((version, _)) if *version >= segment_manifest::AUTHORITATIVE_VERSION
         );
+        // One listing serves the lost-manifest guard, the generation-counter
+        // seed and the sweep. Taken BEFORE the sweep on purpose: seeding
+        // from pre-sweep stems is conservative (a swept ordinal leaves a
+        // harmless gap), and it is what covers ordinals whose files survive
+        // a failed best-effort deletion.
+        let files = storage.list_files()?;
         let segments = match loaded {
             Some((version, segments)) if version >= segment_manifest::AUTHORITATIVE_VERSION => {
                 segments
             }
             _ => {
+                // Lost-manifest guard (#1024): segment-shaped files with
+                // neither a manifest nor any `.meta` to migrate from means
+                // the manifest was deleted or lost. Opening anyway would
+                // serve a silently empty index, and the first commit would
+                // publish a fresh manifest that the NEXT open's sweep
+                // enforces by deleting every pre-existing segment —
+                // delayed, permanent data loss the WAL cannot cover (the
+                // metadata.json checkpoint is intact, so replay skips
+                // everything). Refuse loudly instead.
+                let has_meta = files
+                    .iter()
+                    .any(|f| f.ends_with(".meta") && segment_manifest::stem_ordinal(f).is_some());
+                let has_segment_files = files
+                    .iter()
+                    .any(|f| segment_manifest::stem_ordinal(f).is_some());
+                if loaded.is_none() && !has_meta && has_segment_files {
+                    return Err(LaurusError::index(
+                        "segments.json is missing but segment files are present; refusing to                          open — restore the manifest (or remove the segment files) instead of                          losing the segments to the next sweep",
+                    ));
+                }
                 let mut scanned = Self::scan_segment_metas_from(storage.as_ref())?;
                 scanned.retain(|s| s.committed);
                 scanned
             }
         };
+        let next_generation = segment_manifest::derive_next_generation(&segments, &files);
 
         // Orphan sweep (#1021): reclaim segment files the manifest does not
         // know — crash-orphaned uncommitted flushes, and the leftovers of a
@@ -227,7 +257,7 @@ impl InvertedIndex {
         // ignored, and correctness never depends on the sweep — WAL replay
         // covers anything a crash left unpublished.
         if authoritative {
-            Self::sweep_orphans(storage.as_ref(), &segments);
+            Self::sweep_orphans(storage.as_ref(), &segments, &files);
         }
 
         Ok(InvertedIndex {
@@ -236,7 +266,10 @@ impl InvertedIndex {
             extra_fields: RwLock::new(HashMap::new()),
             closed: AtomicBool::new(false),
             metadata: Arc::new(RwLock::new(metadata)),
-            segment_manifest: Arc::new(RwLock::new(segments)),
+            segment_manifest: Arc::new(RwLock::new(segment_manifest::ManifestState {
+                segments,
+                next_generation,
+            })),
         })
     }
 
@@ -330,23 +363,9 @@ impl InvertedIndex {
         // and every entry in it is committed by construction. Zero storage
         // I/O per reader construction, where the `.meta` scan paid
         // O(segments) opens + parses.
-        let mut segments = self.segment_manifest.read().clone();
+        let mut segments = self.segment_manifest.read().segments.clone();
         segments.sort_by_key(|s| s.generation);
         Ok(segments)
-    }
-
-    /// Read every segment `.meta` on storage, published or not.
-    ///
-    /// Generation numbering must come from this rather than from
-    /// [`Self::load_segments`]: a merge that numbered itself from the
-    /// published set alone could collide with a segment that is flushed but
-    /// not yet committed (#1017).
-    ///
-    /// # Returns
-    ///
-    /// Every segment described on storage, in directory order.
-    fn scan_segment_metas(&self) -> Result<Vec<SegmentInfo>> {
-        Self::scan_segment_metas_from(self.storage.as_ref())
     }
 
     /// Delete segment-shaped files the manifest does not list (#1021).
@@ -363,13 +382,10 @@ impl InvertedIndex {
     /// manifest wins by design), but it can also mean segments committed
     /// through a standalone `InvertedIndexWriter` into a directory owned
     /// by a manifest-bearing index — a documented misuse.
-    fn sweep_orphans(storage: &dyn Storage, manifest: &[SegmentInfo]) {
-        let Ok(files) = storage.list_files() else {
-            return;
-        };
+    fn sweep_orphans(storage: &dyn Storage, manifest: &[SegmentInfo], files: &[String]) {
         for file in files {
             if file == "segments.json.tmp" {
-                let _ = storage.delete_file(&file);
+                let _ = storage.delete_file(file);
                 continue;
             }
             let Some(stem) = file.split('.').next() else {
@@ -388,7 +404,7 @@ impl InvertedIndex {
                 continue;
             }
             if file.ends_with(".meta")
-                && let Ok(mut input) = storage.open_input(&file)
+                && let Ok(mut input) = storage.open_input(file)
             {
                 let mut data = Vec::new();
                 if Read::read_to_end(&mut input, &mut data).is_ok()
@@ -400,7 +416,7 @@ impl InvertedIndex {
                     );
                 }
             }
-            let _ = storage.delete_file(&file);
+            let _ = storage.delete_file(file);
         }
     }
 
@@ -486,23 +502,20 @@ impl InvertedIndex {
         self.merge_segment_set(&subset, next_generation)
     }
 
-    /// One past the highest generation on storage.
+    /// Reserve the generation for a newly merged segment (#1024).
     ///
-    /// Derived from every `.meta`, not just the published ones: a merge that
-    /// numbered itself from the visible set alone could collide with a
-    /// segment that is flushed but not yet committed (#1017).
+    /// Taken from the shared in-memory counter, which every flush also
+    /// reserves from — so a merge can no longer collide with a segment
+    /// flushed but not yet committed (#1017), nor tie with a surviving
+    /// writer's next flush (both used to compute `max + 1` independently).
+    /// A reservation consumed by a merge that later fails leaves a gap in
+    /// the numbering, which is harmless.
     ///
     /// # Returns
     ///
     /// The generation a newly merged segment should take.
     fn next_generation(&self) -> Result<u64> {
-        Ok(self
-            .scan_segment_metas()?
-            .iter()
-            .map(|s| s.generation)
-            .max()
-            .unwrap_or(0)
-            + 1)
+        Ok(segment_manifest::reserve_generation(&self.segment_manifest))
     }
 
     /// Merge a set of source segments into a single new segment.

--- a/laurus/src/lexical/index/inverted/segment_manifest.rs
+++ b/laurus/src/lexical/index/inverted/segment_manifest.rs
@@ -55,8 +55,30 @@ pub(crate) const MANIFEST_VERSION: u32 = 2;
 /// for the orphan sweep — see [`MANIFEST_VERSION`].
 pub(crate) const AUTHORITATIVE_VERSION: u32 = 2;
 
-/// Shared handle to the in-memory committed-segment set.
-pub(crate) type SharedSegmentManifest = Arc<RwLock<Vec<SegmentInfo>>>;
+/// In-memory manifest state shared between the index and its writers.
+#[derive(Debug)]
+pub(crate) struct ManifestState {
+    /// The committed segments — the mirror of the last successfully
+    /// persisted `segments.json`.
+    pub(crate) segments: Vec<SegmentInfo>,
+
+    /// Next segment generation ordinal to hand out (#1024).
+    ///
+    /// **In-memory only, never persisted.** Persistence is unnecessary
+    /// because a lexical merge always inserts its entry with a generation
+    /// strictly above its sources, so re-deriving from the entries can
+    /// never regress past a live segment; crash-lost reservations are
+    /// covered because the seed also scans surviving segment-file stems
+    /// (see `InvertedIndex::open`), which is strictly stronger than a
+    /// persisted counter (a memory-only bump would not have been saved
+    /// anyway). Reserved under this lock at flush/merge time via
+    /// [`reserve_generation`], which is what keeps a surviving writer and
+    /// a concurrent merge from minting the same generation.
+    pub(crate) next_generation: u64,
+}
+
+/// Shared handle to the in-memory manifest state.
+pub(crate) type SharedSegmentManifest = Arc<RwLock<ManifestState>>;
 
 /// Serialized form of [`MANIFEST_FILE`].
 #[derive(Debug, Serialize, Deserialize)]
@@ -132,18 +154,66 @@ pub(crate) fn save(storage: &dyn Storage, segments: &[SegmentInfo]) -> Result<()
 /// Returns the persistence error, leaving memory unchanged.
 pub(crate) fn publish_with<F>(
     storage: &dyn Storage,
-    shared: &RwLock<Vec<SegmentInfo>>,
+    shared: &RwLock<ManifestState>,
     mutate: F,
 ) -> Result<()>
 where
     F: FnOnce(&mut Vec<SegmentInfo>),
 {
     let mut guard = shared.write();
-    let mut candidate = guard.clone();
+    let mut candidate = guard.segments.clone();
     mutate(&mut candidate);
     save(storage, &candidate)?;
-    *guard = candidate;
+    guard.segments = candidate;
     Ok(())
+}
+
+/// Hand out the next segment generation ordinal (#1024).
+///
+/// Taken under the manifest write lock so a flushing writer and a
+/// concurrent merge can never mint the same generation — the tie the old
+/// scan-derived numbering allowed (a writer surviving `optimize` and the
+/// merged segment both computed `max + 1` independently).
+pub(crate) fn reserve_generation(shared: &RwLock<ManifestState>) -> u64 {
+    let mut guard = shared.write();
+    let generation = guard.next_generation;
+    guard.next_generation += 1;
+    generation
+}
+
+/// The generation ordinal encoded in a segment-shaped file name, if any.
+///
+/// Accepts the two stems this index mints — `segment_<digits>` and
+/// `merged_<digits>` — taking the stem before the first `.` so data
+/// files, `.delmap`s and per-field `.bkd`s all count.
+pub(crate) fn stem_ordinal(file_name: &str) -> Option<u64> {
+    let stem = file_name.split('.').next()?;
+    let ordinal = stem
+        .strip_prefix("segment_")
+        .or_else(|| stem.strip_prefix("merged_"))?;
+    if ordinal.is_empty() || !ordinal.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    ordinal.parse().ok()
+}
+
+/// Derive the generation-counter seed for an opening index (#1024).
+///
+/// `max(entry generations, surviving file-stem ordinals) + 1`. The file
+/// stems are load-bearing: a crash can lose an in-memory reservation
+/// while its flushed files survive (a legacy directory the sweep never
+/// touches, or a best-effort sweep deletion that failed), and reusing
+/// such an ordinal would let the new segment adopt stale foreign
+/// per-field `.bkd`s or a stale `.delmap` by name-prefix.
+pub(crate) fn derive_next_generation(entries: &[SegmentInfo], files: &[String]) -> u64 {
+    let from_entries = entries.iter().map(|s| s.generation + 1).max().unwrap_or(0);
+    let from_files = files
+        .iter()
+        .filter_map(|f| stem_ordinal(f))
+        .map(|ordinal| ordinal + 1)
+        .max()
+        .unwrap_or(0);
+    from_entries.max(from_files)
 }
 
 /// Insert `info` into `list`, replacing any entry with the same
@@ -212,7 +282,10 @@ mod tests {
     #[test]
     fn publish_with_applies_deltas_to_the_live_list() {
         let storage = MemoryStorage::new(MemoryStorageConfig::default());
-        let shared = RwLock::new(vec![seg("segment_000001", 1)]);
+        let shared = RwLock::new(ManifestState {
+            segments: vec![seg("segment_000001", 1)],
+            next_generation: 2,
+        });
 
         // A concurrent publication lands first.
         publish_with(&storage, &shared, |list| {
@@ -228,7 +301,12 @@ mod tests {
         })
         .unwrap();
 
-        let ids: Vec<String> = shared.read().iter().map(|s| s.segment_id.clone()).collect();
+        let ids: Vec<String> = shared
+            .read()
+            .segments
+            .iter()
+            .map(|s| s.segment_id.clone())
+            .collect();
         assert_eq!(
             ids,
             vec!["segment_000002".to_string(), "merged_3".to_string()],
@@ -287,13 +365,16 @@ mod tests {
         }
 
         let storage = ReadOnly(MemoryStorage::new(MemoryStorageConfig::default()));
-        let shared = RwLock::new(vec![seg("segment_000001", 1)]);
+        let shared = RwLock::new(ManifestState {
+            segments: vec![seg("segment_000001", 1)],
+            next_generation: 2,
+        });
         let err = publish_with(&storage, &shared, |list| {
             upsert_entry(list, seg("segment_000002", 2));
         });
         assert!(err.is_err());
         assert_eq!(
-            shared.read().len(),
+            shared.read().segments.len(),
             1,
             "a failed save must not advance the in-memory manifest"
         );

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -159,8 +159,14 @@ pub struct InvertedIndexWriter {
     /// Document ID counter.
     next_doc_id: u64,
 
-    /// Current segment number.
-    current_segment: u32,
+    /// Generation ordinal of the segment currently being buffered.
+    ///
+    /// For a writer holding the shared manifest handle this is (re)reserved
+    /// from the shared counter at each flush (#1024), so it can never tie
+    /// with a concurrent merge's generation. For a handle-less writer it is
+    /// a plain local counter seeded by the constructor scan, exactly as
+    /// before. Widened to `u64`: it doubles as `SegmentInfo::generation`.
+    current_segment: u64,
 
     /// Whether the writer is closed.
     closed: bool,
@@ -344,15 +350,32 @@ impl InvertedIndexWriter {
         metadata: Option<Arc<parking_lot::RwLock<IndexMetadata>>>,
         segment_manifest: Option<super::segment_manifest::SharedSegmentManifest>,
     ) -> Result<Self> {
-        // Recover state from existing segments. The same scan also seeds the
-        // segment-range cache (Issue #559 / #864), so the cache is warm from
-        // birth at no extra I/O.
+        // Recover state from the committed segment set. A writer holding
+        // the shared manifest handle reads it from memory — zero I/O, where
+        // the `.meta` scan paid O(segments) opens + parses (#1024). A
+        // handle-less writer (standalone constructions, the merge replay
+        // writer) keeps the storage scan verbatim: its segments live only
+        // in their `.meta` files. Either way the same four values are
+        // seeded, and the recovery doubles as the segment-range cache seed
+        // (Issue #559 / #864).
         let mut next_doc_id = 0;
-        let mut max_segment_id = -1i32;
+        let mut current_segment = 0u64;
         let mut segment_ranges = Vec::new();
         let mut max_committed_doc_id = 0u64;
 
-        if let Ok(files) = storage.list_files() {
+        if let Some(manifest) = &segment_manifest {
+            let state = manifest.read();
+            for entry in &state.segments {
+                if entry.shard_id == config.shard_id {
+                    let local_id = crate::util::id::get_local_id(entry.max_doc_id);
+                    next_doc_id = next_doc_id.max(local_id + 1);
+                }
+                max_committed_doc_id = max_committed_doc_id.max(entry.max_doc_id);
+                segment_ranges.push((entry.segment_id.clone(), entry.min_doc_id, entry.max_doc_id));
+            }
+            // Advisory only — the real ordinal is reserved at flush time.
+            current_segment = state.next_generation;
+        } else if let Ok(files) = storage.list_files() {
             for file in files {
                 if file.ends_with(".meta") && file != "index.meta" {
                     // unexpected error handling: ignore malformed files
@@ -364,15 +387,13 @@ impl InvertedIndexWriter {
                             let local_id = crate::util::id::get_local_id(meta.max_doc_id);
                             next_doc_id = next_doc_id.max(local_id + 1);
                         }
-                        max_segment_id = max_segment_id.max(meta.generation as i32);
+                        current_segment = current_segment.max(meta.generation + 1);
                         max_committed_doc_id = max_committed_doc_id.max(meta.max_doc_id);
                         segment_ranges.push((meta.segment_id, meta.min_doc_id, meta.max_doc_id));
                     }
                 }
             }
         }
-
-        let current_segment = (max_segment_id + 1) as u32;
 
         // Create initial DocValuesWriter (will be reset per segment)
         let initial_segment_name = format!("{}_{:06}", config.segment_prefix, current_segment);
@@ -928,6 +949,14 @@ impl InvertedIndexWriter {
             self.index_dirty = false;
         }
 
+        // Reserve the generation ordinal from the shared counter (#1024) —
+        // at flush time, not at construction, so a merge that ran since
+        // this writer was built cannot end up tied with (or above) this
+        // segment's generation. Handle-less writers keep their local
+        // counter, seeded by the constructor scan.
+        if let Some(manifest) = &self.segment_manifest {
+            self.current_segment = super::segment_manifest::reserve_generation(manifest);
+        }
         let segment_name = format!("{}_{:06}", self.config.segment_prefix, self.current_segment);
 
         // A buffer flush is not a publication: these documents are not
@@ -1574,7 +1603,7 @@ impl InvertedIndexWriter {
             doc_count: self.buffered_docs.len() as u64,
             min_doc_id: min_id,
             max_doc_id: max_id,
-            generation: self.current_segment as u64,
+            generation: self.current_segment,
             has_deletions: false, // New segments initially have no deletions
             shard_id: self.config.shard_id,
             committed,
@@ -1954,9 +1983,12 @@ impl InvertedIndexWriter {
             .collect())
     }
 
-    /// Rebuild [`Self::segment_ranges`] / [`Self::max_committed_doc_id`] from
-    /// the `*.meta` files on storage and drop the cached
-    /// [`Self::deletion_manager`].
+    /// Rebuild [`Self::segment_ranges`] / [`Self::max_committed_doc_id`]
+    /// and drop the cached [`Self::deletion_manager`].
+    ///
+    /// A writer holding the shared manifest handle rebuilds from memory —
+    /// infallible and I/O-free (#1024); a handle-less writer re-scans the
+    /// `*.meta` files as before.
     ///
     /// Must be called after an external segment rewrite that this writer did
     /// not perform itself — today that is only
@@ -1968,9 +2000,32 @@ impl InvertedIndexWriter {
     ///
     /// # Errors
     ///
-    /// Returns an error if listing the storage fails; malformed `.meta` files
-    /// are skipped, matching the constructor's recovery scan.
+    /// Returns an error if listing the storage fails (handle-less path
+    /// only); malformed `.meta` files are skipped, matching the
+    /// constructor's recovery scan.
     pub fn invalidate_segment_cache(&mut self) -> Result<()> {
+        if let Some(manifest) = &self.segment_manifest {
+            // The merge published its transition to the shared manifest
+            // before this call, so memory is already the post-merge truth.
+            let state = manifest.read();
+            self.segment_ranges = state
+                .segments
+                .iter()
+                .map(|entry| (entry.segment_id.clone(), entry.min_doc_id, entry.max_doc_id))
+                .collect();
+            self.max_committed_doc_id = state
+                .segments
+                .iter()
+                .map(|entry| entry.max_doc_id)
+                .max()
+                .unwrap_or(0);
+            drop(state);
+            self.deletion_manager = None;
+            self.pending_meta_deletions.clear();
+            self.flushed_segments.clear();
+            return Ok(());
+        }
+
         // Build the new view first and swap it in only on success: clearing
         // eagerly and then failing (e.g. on `list_files`) would leave the
         // writer alive with an EMPTY cache and `max_committed_doc_id == 0`,

--- a/laurus/tests/lexical_segment_manifest_test.rs
+++ b/laurus/tests/lexical_segment_manifest_test.rs
@@ -786,3 +786,116 @@ fn merge_crash_after_manifest_save_resolves_to_the_merged_segment() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// #1024 PR A — writer state derives from the manifest; the scan is legacy.
+// ---------------------------------------------------------------------------
+
+/// The lost-manifest guard: segment files with neither a manifest nor any
+/// `.meta` to migrate from must refuse to open — the alternative is a
+/// silently empty index whose next commit publishes a fresh manifest that
+/// the following open's sweep enforces by deleting every old segment.
+#[test]
+fn open_refuses_segment_files_with_nothing_to_describe_them() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    store.upsert_document(1, doc("alpha")).unwrap();
+    store.commit().unwrap();
+    drop(store);
+
+    // Simulate the lost-manifest state of a post-#1024 index: no
+    // segments.json, no .meta, but the segment data files are there.
+    storage.delete_file("segments.json").unwrap();
+    for f in storage.list_files().unwrap() {
+        if f.ends_with(".meta") && f != "index.meta" {
+            storage.delete_file(&f).unwrap();
+        }
+    }
+
+    let err = LexicalStore::new(storage.clone(), LexicalIndexConfig::default());
+    assert!(
+        err.is_err(),
+        "segment files without a manifest or .meta must refuse to open, not \
+         serve a silently empty index"
+    );
+}
+
+/// The generation seed counts surviving segment-file stems, not just
+/// manifest entries: an ordinal whose files survived (a failed best-effort
+/// sweep deletion, a legacy crash) must never be reused — the new segment
+/// would adopt stale foreign `.bkd`s / `.delmap`s by name prefix.
+#[test]
+fn generation_seed_never_reuses_a_surviving_file_ordinal() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    store.upsert_document(1, doc("alpha")).unwrap();
+    store.commit().unwrap();
+    drop(store);
+
+    // A stray high-ordinal data file the manifest does not know. The sweep
+    // will reclaim it, but the seed is taken from the pre-sweep listing.
+    plant_stray_segment(&storage, "segment_000009", /* with_meta */ false);
+
+    let reopened = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+    reopened.upsert_document(2, doc("beta")).unwrap();
+    reopened.commit().unwrap();
+
+    let new_entry_generation = read_manifest(&storage)
+        .iter()
+        .map(|s| s.generation)
+        .max()
+        .unwrap();
+    assert_eq!(
+        new_entry_generation, 10,
+        "the next generation must clear the surviving stray ordinal (9), got {new_entry_generation}"
+    );
+}
+
+/// Flush-time reservation from the shared counter: a writer surviving
+/// `optimize` and the merge can no longer mint the same generation (both
+/// used to compute `max + 1` independently), and the post-merge flush
+/// sorts strictly NEWER than the merged segment.
+#[test]
+fn surviving_writer_and_merge_never_tie_on_generation() {
+    let storage = memory_storage();
+    let store = LexicalStore::new(storage.clone(), LexicalIndexConfig::default()).unwrap();
+
+    for i in 1..=2u64 {
+        store.upsert_document(i, doc("alpha")).unwrap();
+        store.commit().unwrap();
+    }
+    // A live writer with buffered docs survives optimize (#864/#1017).
+    store.upsert_document(3, doc("alpha")).unwrap();
+    store.optimize().unwrap();
+    // The same writer flushes again after the merge.
+    store.upsert_document(4, doc("alpha")).unwrap();
+    store.commit().unwrap();
+
+    let manifest = read_manifest(&storage);
+    let mut generations: Vec<u64> = manifest.iter().map(|s| s.generation).collect();
+    generations.sort_unstable();
+    let unique = generations.len();
+    generations.dedup();
+    assert_eq!(
+        generations.len(),
+        unique,
+        "generations must be unique across the merge and the surviving writer: {manifest:?}"
+    );
+
+    let merged_generation = manifest
+        .iter()
+        .find(|s| s.segment_id.starts_with("merged_"))
+        .map(|s| s.generation)
+        .expect("optimize must have produced a merged segment");
+    let post_merge_flush = manifest
+        .iter()
+        .filter(|s| s.segment_id.starts_with("segment_"))
+        .map(|s| s.generation)
+        .max()
+        .expect("the post-merge commit must have published a segment");
+    assert!(
+        post_merge_flush > merged_generation,
+        "a segment flushed after the merge must sort newer than the merged \
+         segment (merged={merged_generation}, flush={post_merge_flush})"
+    );
+}


### PR DESCRIPTION
## Summary

First half of #1024 (PR A of 2). Writer-side segment state — ranges, committed high-water, doc-id seed, and the generation ordinal — now derives from the shared manifest instead of the `.meta` scan, while **every `.meta` is still written**. Behavior-invariant by design: the 13 pre-existing manifest/authority tests pass unmodified. PR B (one release later) removes the `.meta`/`index.meta` writers, `SegmentInfo::committed`, and the dead SEGS + maintenance cluster.

The design went through an adversarial review that **simplified it substantially**: no counters are persisted and the manifest schema does not change. Doc ids are externally assigned by `DocumentLog` on every hot path, so a persisted `next_doc_id` would buy nothing (and imports a per-shard representation bug); the generation counter needs no persistence because a lexical merge always inserts above its sources, and crash-lost reservations are covered by seeding from **surviving file stems** — which a persisted counter would not cover anyway.

## What's in here

- `ManifestState { segments, next_generation }` with `reserve_generation` (fetch-and-increment under the manifest lock), `stem_ordinal`, and `derive_next_generation` (max over entries and surviving file stems).
- **The lost-manifest guard**: open hard-errors on "manifest absent + no `.meta` to migrate from + segment files present". Without it, losing `segments.json` from a post-#1024 index degrades to a silently empty index, and the first commit arms the *next* open's sweep to delete every pre-existing segment — delayed, permanent data loss the WAL cannot cover (the `metadata.json` checkpoint is intact, so replay skips everything).
- **Files-derived seeding** from the pre-sweep listing: an ordinal whose files survived a failed best-effort sweep deletion (or a legacy crash) is never reused — a reused name would adopt stale foreign per-field `.bkd`s or a stale `.delmap` by prefix.
- Handle-holding writers seed from shared state (zero I/O; `invalidate_segment_cache` becomes an infallible memory rebuild); **handle-less writers keep today's scan verbatim** — the anchor that keeps this PR behavior-invariant.
- **Flush-time reservation fixes an existing bug**: a writer surviving `optimize` and the merge both computed `max + 1` independently and could mint the *same* generation, breaking the newest-sorts-last contract (#754). The ordinal also widens to u64 (was u32 through an i32 intermediate).

## Verification

- 13 pre-existing tests unmodified and green; 3 new tests (guard / files-derived seed with a surviving stray ordinal / generation-tie with all-unique generations and post-merge flush strictly newer).
- **Each element proven non-inert**: disabling the guard, restricting the seed to entries-only, or removing the reservation turns exactly its own test red.
- `cargo test --workspace`: 0 failures. Clippy (CI-identical): exit 0. `cargo fmt --all --check`: clean.

Details: [investigation](https://github.com/mosuka/laurus/issues/1024#issuecomment-5395358201) / [plan](https://github.com/mosuka/laurus/issues/1024#issuecomment-5395602465) / [PR A report](https://github.com/mosuka/laurus/issues/1024#issuecomment-5396573901).

Refs #1024
