### PR TITLE
feat(lexical): add the compound segment container machinery

### DIFF
--- a/laurus/src/lexical/index/config.rs
+++ b/laurus/src/lexical/index/config.rs
@@ -17,6 +17,16 @@ use crate::lexical::core::field::FieldOption;
 /// including segment management, buffering, compression, and term storage options.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct InvertedIndexConfig {
+    /// Write flushed segments as one compound `.cfs` container instead of
+    /// loose per-part files (#554).
+    ///
+    /// One `create` + one fsync per segment instead of one per part.
+    /// Readers detect the layout per segment, so loose and compound
+    /// segments coexist freely. Off by default until the #554 rollout
+    /// flips it.
+    #[serde(default)]
+    pub use_compound: bool,
+
     /// Maximum number of documents per segment.
     ///
     /// When a segment reaches this size, it will be considered for merging.
@@ -108,6 +118,7 @@ fn default_parsed_query_cache_capacity() -> usize {
 impl Default for InvertedIndexConfig {
     fn default() -> Self {
         InvertedIndexConfig {
+            use_compound: false,
             max_docs_per_segment: 1000000,
             write_buffer_size: 1024 * 1024, // 1MB
             compress_stored_fields: false,

--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -34,6 +34,7 @@ use crate::storage::file::{FileStorage, FileStorageConfig};
 use crate::storage::manifest as manifest_io;
 
 pub(crate) mod bmw;
+pub(crate) mod compound;
 pub mod core;
 pub mod parsed_query_cache;
 pub(crate) mod per_segment_view;
@@ -573,7 +574,13 @@ impl InvertedIndex {
             strategy: MergeStrategy::SizeBased,
         };
 
-        let engine = MergeEngine::new(MergeConfig::default(), self.storage.clone());
+        let engine = MergeEngine::new(
+            MergeConfig {
+                use_compound: self.config.use_compound,
+                ..MergeConfig::default()
+            },
+            self.storage.clone(),
+        );
         let result = engine.merge_segments(&candidate, &managed, next_generation)?;
 
         // Publish the merge transition as ONE manifest write (#1021): drop
@@ -729,6 +736,7 @@ impl LexicalIndex for InvertedIndex {
             analyzer: self.config.analyzer.clone(),
             shard_id: self.config.shard_id,
             fields,
+            use_compound: self.config.use_compound,
             ..Default::default()
         };
         // Hand the writer the shared metadata and manifest handles

--- a/laurus/src/lexical/index/inverted/compound.rs
+++ b/laurus/src/lexical/index/inverted/compound.rs
@@ -1,0 +1,876 @@
+//! Compound segment file (#554) — Lucene-CFS-style container fusing the
+//! per-segment data files into one `segment_<N>.cfs`.
+//!
+//! # Format
+//!
+//! ```text
+//! [parts, concatenated — each part keeps its own internal framing]
+//! [table: varint part_count, repeat { varint suffix_len, suffix bytes,
+//!         u64 offset, u64 len }]
+//! [trailer, fixed 20 bytes: u64 table_offset, u32 table_crc32,
+//!         u32 version, u32 magic "CFND"]
+//! ```
+//!
+//! All integers little-endian. Suffixes are opaque strings — everything
+//! after `"{segment_id}."` (e.g. `"post"`, `"score.bkd"`). The `.delmap`
+//! is deliberately NOT part of the container: it is the only segment file
+//! rewritten after sealing (deferred deletion flushes, #875).
+//!
+//! # Roles
+//!
+//! - [`CompoundSegmentWriter`] writes parts sequentially through
+//!   [`PartOutput`] wrappers over one shared output — one `create`, one
+//!   fsync, one `close` per segment instead of one per part.
+//! - [`CompoundSegmentStorage`] is a per-segment [`Storage`] facade
+//!   (shaped like `PrefixedStorage`): part names resolve to windowed
+//!   views over the container, everything else passes through to the
+//!   inner storage — crucially including `file_exists` misses, because
+//!   the `.delmap` probe treats a missing file as "no deletions" and a
+//!   table-only answer would silently resurrect deleted documents.
+
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use crate::storage::{FileMetadata, LoadingMode, Storage, StorageInput, StorageOutput};
+use crate::{LaurusError, Result};
+
+/// File suffix of the container: `{segment_id}.cfs`.
+pub(crate) const COMPOUND_SUFFIX: &str = "cfs";
+
+/// Trailer magic, "CFND".
+const COMPOUND_MAGIC: u32 = 0x4346_4E44;
+
+/// Container format version written by this build.
+const COMPOUND_VERSION: u32 = 1;
+
+/// Fixed trailer size: table_offset (8) + table_crc (4) + version (4) +
+/// magic (4).
+const TRAILER_LEN: u64 = 20;
+
+/// The container file name for a segment.
+pub(crate) fn container_name(segment_id: &str) -> String {
+    format!("{segment_id}.{COMPOUND_SUFFIX}")
+}
+
+/// One table entry: a part's suffix and its window in the container.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct PartEntry {
+    /// Everything after `"{segment_id}."` in the loose file name.
+    pub(crate) suffix: String,
+    /// Byte offset of the part's first byte in the container.
+    pub(crate) offset: u64,
+    /// Part length in bytes.
+    pub(crate) len: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Write side
+// ---------------------------------------------------------------------------
+
+/// Shared state behind every [`PartOutput`] of one container write.
+#[derive(Debug)]
+struct ContainerWriteState {
+    /// The single real output. `None` only after [`CompoundSegmentWriter::finish`].
+    out: Option<Box<dyn StorageOutput>>,
+    /// Base offset of the part currently being written.
+    part_base: u64,
+    /// High-water mark of the current part, as an ABSOLUTE container
+    /// position. Part lengths derive from this logical mark, never from
+    /// storage sizes: `FileOutput` buffers 64 KiB, and `MemoryStorage`
+    /// reports size 0 until the final publish.
+    part_max: u64,
+}
+
+impl ContainerWriteState {
+    fn out(&mut self) -> Result<&mut Box<dyn StorageOutput>> {
+        self.out
+            .as_mut()
+            .ok_or_else(|| LaurusError::storage("compound container already finished"))
+    }
+}
+
+/// Writes one compound container, handing out a [`PartOutput`] per part.
+#[derive(Debug)]
+pub(crate) struct CompoundSegmentWriter {
+    state: Arc<Mutex<ContainerWriteState>>,
+    entries: Vec<PartEntry>,
+    container: String,
+}
+
+impl CompoundSegmentWriter {
+    /// Open the container output.
+    pub(crate) fn create(storage: &dyn Storage, segment_id: &str) -> Result<Self> {
+        let container = container_name(segment_id);
+        let out = storage.create_output(&container)?;
+        Ok(Self {
+            state: Arc::new(Mutex::new(ContainerWriteState {
+                out: Some(out),
+                part_base: 0,
+                part_max: 0,
+            })),
+            entries: Vec::new(),
+            container,
+        })
+    }
+
+    /// Begin the next part and return the output to write it through.
+    ///
+    /// Parts are strictly sequential: the previous part's extent seeds the
+    /// next base, and the shared handle is repositioned there (a part like
+    /// the BKD tree ends on a backfill seek, not necessarily at its end).
+    pub(crate) fn begin_part(&mut self, suffix: &str) -> Result<PartOutput> {
+        let mut state = self.state.lock().unwrap();
+        let base = state.part_max;
+        let out = state.out()?;
+        out.seek(SeekFrom::Start(base))?;
+        state.part_base = base;
+        state.part_max = base;
+        drop(state);
+        self.entries.push(PartEntry {
+            suffix: suffix.to_string(),
+            offset: base,
+            len: 0, // filled by end_part
+        });
+        Ok(PartOutput {
+            state: Arc::clone(&self.state),
+        })
+    }
+
+    /// The container's file name.
+    pub(crate) fn container_name_owned(&self) -> String {
+        self.container.clone()
+    }
+
+    /// Seal the part begun by the last [`Self::begin_part`], recording its
+    /// length from the logical high-water mark.
+    pub(crate) fn end_part(&mut self) -> Result<()> {
+        let state = self.state.lock().unwrap();
+        let entry = self
+            .entries
+            .last_mut()
+            .ok_or_else(|| LaurusError::storage("end_part without begin_part"))?;
+        entry.len = state.part_max - entry.offset;
+        Ok(())
+    }
+
+    /// Write the table + trailer, fsync once, close once.
+    pub(crate) fn finish(self) -> Result<Vec<PartEntry>> {
+        let mut state = self.state.lock().unwrap();
+        let table_offset = state.part_max;
+        let mut table = Vec::new();
+        write_varint(&mut table, self.entries.len() as u64);
+        for entry in &self.entries {
+            write_varint(&mut table, entry.suffix.len() as u64);
+            table.extend_from_slice(entry.suffix.as_bytes());
+            table.extend_from_slice(&entry.offset.to_le_bytes());
+            table.extend_from_slice(&entry.len.to_le_bytes());
+        }
+        let table_crc = crc32fast::hash(&table);
+
+        let out = state.out()?;
+        out.seek(SeekFrom::Start(table_offset))?;
+        out.write_all(&table)?;
+        out.write_all(&table_offset.to_le_bytes())?;
+        out.write_all(&table_crc.to_le_bytes())?;
+        out.write_all(&COMPOUND_VERSION.to_le_bytes())?;
+        out.write_all(&COMPOUND_MAGIC.to_le_bytes())?;
+        out.flush_and_sync()?;
+        let mut out = state.out.take().expect("checked by out() above");
+        out.close()?;
+        drop(state);
+        Ok(self.entries)
+    }
+}
+
+/// A [`StorageOutput`] view over the shared container output, offset by
+/// the current part's base.
+///
+/// Seeks are translated in BOTH directions — arguments AND return values.
+/// The return-value half is load-bearing: `StructWriter::seek` adopts the
+/// returned position as its internal counter, and `BKDWriter` persists
+/// stream positions into the part (header backfill via `Start(0)`,
+/// `index_start_offset` from `stream_position()`), which its reader then
+/// interprets as part-relative offsets.
+///
+/// `close()` and `flush_and_sync()` are deliberate no-ops: part writers
+/// end in `StructWriter::close`, which would otherwise fsync per part and
+/// poison the shared handle for the parts after it. The single real fsync
+/// + close happens in [`CompoundSegmentWriter::finish`].
+#[derive(Debug)]
+pub(crate) struct PartOutput {
+    state: Arc<Mutex<ContainerWriteState>>,
+}
+
+impl Write for PartOutput {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut state = self.state.lock().unwrap();
+        let base = state.part_base;
+        let out = state
+            .out
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("compound container already finished"))?;
+        let written = out.write(buf)?;
+        let pos = out
+            .position()
+            .map_err(|e| std::io::Error::other(e.to_string()))?;
+        debug_assert!(pos >= base);
+        state.part_max = state.part_max.max(pos);
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        // Plain flush is forwarded (it does not fsync); harmless and it
+        // keeps `Write` adapters that flush explicitly working.
+        let mut state = self.state.lock().unwrap();
+        match state.out.as_mut() {
+            Some(out) => out.flush(),
+            None => Ok(()),
+        }
+    }
+}
+
+impl Seek for PartOutput {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let mut state = self.state.lock().unwrap();
+        let base = state.part_base;
+        let part_end = state.part_max;
+        let out = state
+            .out
+            .as_mut()
+            .ok_or_else(|| std::io::Error::other("compound container already finished"))?;
+        let translated = match pos {
+            SeekFrom::Start(offset) => SeekFrom::Start(base + offset),
+            // Relative to the part's extent so far, NOT the container end:
+            // during a sequential write both coincide, which is exactly why
+            // this must be translated deliberately (tests cannot tell the
+            // difference) — a future non-tail part would corrupt silently.
+            SeekFrom::End(delta) => SeekFrom::Start((part_end as i64 + delta) as u64),
+            SeekFrom::Current(delta) => SeekFrom::Current(delta),
+        };
+        let absolute = out.seek(translated)?;
+        debug_assert!(absolute >= base);
+        Ok(absolute - base)
+    }
+}
+
+impl StorageOutput for PartOutput {
+    fn flush_and_sync(&mut self) -> Result<()> {
+        // No-op: the container is synced exactly once, in `finish`.
+        Ok(())
+    }
+
+    fn position(&self) -> Result<u64> {
+        let state = self.state.lock().unwrap();
+        let base = state.part_base;
+        let out = state
+            .out
+            .as_ref()
+            .ok_or_else(|| LaurusError::storage("compound container already finished"))?;
+        Ok(out.position()? - base)
+    }
+
+    fn close(&mut self) -> Result<()> {
+        // No-op: the shared handle stays open for the remaining parts.
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Read side
+// ---------------------------------------------------------------------------
+
+/// How part reads obtain container bytes.
+#[derive(Debug, Clone)]
+enum ContainerHandle {
+    /// Open the container per part read. Cheap where `open_input` is —
+    /// mmap-backed FileStorage (an `Arc<Mmap>` clone from the cache) and
+    /// buffered non-mmap files (a fresh descriptor).
+    PerOpen,
+    /// One buffered copy shared by every window. Used for eager in-memory
+    /// backends, whose `open_input` deep-copies the whole file per call —
+    /// the postings path re-opens per query, so per-part opens would copy
+    /// the container per search.
+    Buffered(Arc<Vec<u8>>),
+}
+
+/// Per-segment [`Storage`] facade resolving part names to windowed views
+/// over the container; every miss passes through to the inner storage.
+#[derive(Debug)]
+pub(crate) struct CompoundSegmentStorage {
+    inner: Arc<dyn Storage>,
+    segment_prefix: String,
+    container: String,
+    parts: Vec<PartEntry>,
+    handle: ContainerHandle,
+}
+
+impl CompoundSegmentStorage {
+    /// Wrap `inner` for `segment_id` if a container exists.
+    ///
+    /// # Returns
+    ///
+    /// `Ok(Some(facade))` when `{segment_id}.cfs` exists and parses;
+    /// `Ok(None)` when it does not (a loose, pre-#554 segment).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the container exists but its trailer or table
+    /// is invalid — a referenced-but-torn container must surface, not
+    /// degrade to "no parts".
+    pub(crate) fn try_open(inner: Arc<dyn Storage>, segment_id: &str) -> Result<Option<Arc<Self>>> {
+        let container = container_name(segment_id);
+        if !inner.file_exists(&container) {
+            return Ok(None);
+        }
+        let mut input = inner.open_input(&container)?;
+        let size = input.size()?;
+        if size < TRAILER_LEN {
+            return Err(LaurusError::storage(format!(
+                "{container}: too short for a compound trailer ({size} bytes)"
+            )));
+        }
+        input.seek(SeekFrom::Start(size - TRAILER_LEN))?;
+        let mut trailer = [0u8; TRAILER_LEN as usize];
+        input.read_exact(&mut trailer)?;
+        let table_offset = u64::from_le_bytes(trailer[0..8].try_into().expect("fixed len"));
+        let table_crc = u32::from_le_bytes(trailer[8..12].try_into().expect("fixed len"));
+        let version = u32::from_le_bytes(trailer[12..16].try_into().expect("fixed len"));
+        let magic = u32::from_le_bytes(trailer[16..20].try_into().expect("fixed len"));
+        if magic != COMPOUND_MAGIC {
+            return Err(LaurusError::storage(format!(
+                "{container}: bad compound magic {magic:#010x}"
+            )));
+        }
+        if version != COMPOUND_VERSION {
+            return Err(LaurusError::storage(format!(
+                "{container}: unsupported compound version {version}"
+            )));
+        }
+        if table_offset > size - TRAILER_LEN {
+            return Err(LaurusError::storage(format!(
+                "{container}: table offset {table_offset} out of bounds"
+            )));
+        }
+        let table_len = (size - TRAILER_LEN - table_offset) as usize;
+        input.seek(SeekFrom::Start(table_offset))?;
+        let mut table = vec![0u8; table_len];
+        input.read_exact(&mut table)?;
+        if crc32fast::hash(&table) != table_crc {
+            return Err(LaurusError::storage(format!(
+                "{container}: compound table checksum mismatch — the file is corrupted"
+            )));
+        }
+        let parts = parse_table(&table, table_offset, &container)?;
+
+        // Handle strategy (see `ContainerHandle`). `loading_mode` is what
+        // separates paging-friendly backends from eager ones; the slice
+        // probe separates in-memory (cheap to buffer once, expensive to
+        // re-open) from buffered files (the reverse).
+        let handle = if inner.loading_mode() == LoadingMode::Eager && input.as_slice().is_some() {
+            input.seek(SeekFrom::Start(0))?;
+            let mut bytes = Vec::with_capacity(size as usize);
+            input.read_to_end(&mut bytes)?;
+            ContainerHandle::Buffered(Arc::new(bytes))
+        } else {
+            ContainerHandle::PerOpen
+        };
+
+        Ok(Some(Arc::new(Self {
+            inner,
+            segment_prefix: format!("{segment_id}."),
+            container,
+            parts,
+            handle,
+        })))
+    }
+
+    /// The table entry for a full loose-style file name, if it is a part.
+    fn entry_for(&self, name: &str) -> Option<&PartEntry> {
+        let suffix = name.strip_prefix(&self.segment_prefix)?;
+        self.parts.iter().find(|p| p.suffix == suffix)
+    }
+
+    /// The BKD field names recorded in the container (#554 BLOCKER-1: the
+    /// merge engine used to enumerate `*.bkd` files by listing raw
+    /// storage, which finds nothing once the parts live in a container —
+    /// silently dropping every numeric/geo point at the first merge).
+    pub(crate) fn bkd_field_names(&self) -> Vec<String> {
+        self.parts
+            .iter()
+            .filter_map(|p| p.suffix.strip_suffix(".bkd"))
+            .map(str::to_string)
+            .collect()
+    }
+
+    fn open_window(&self, entry: &PartEntry) -> Result<Box<dyn StorageInput>> {
+        match &self.handle {
+            ContainerHandle::Buffered(bytes) => Ok(Box::new(PartInput {
+                backing: WindowBacking::Buffered(Arc::clone(bytes)),
+                base: entry.offset,
+                len: entry.len,
+                pos: 0,
+            })),
+            ContainerHandle::PerOpen => {
+                let input = self.inner.open_input(&self.container)?;
+                Ok(Box::new(PartInput {
+                    backing: WindowBacking::Handle(input),
+                    base: entry.offset,
+                    len: entry.len,
+                    pos: 0,
+                }))
+            }
+        }
+    }
+}
+
+impl Storage for CompoundSegmentStorage {
+    fn loading_mode(&self) -> LoadingMode {
+        self.inner.loading_mode()
+    }
+
+    fn open_input(&self, name: &str) -> Result<Box<dyn StorageInput>> {
+        match self.entry_for(name) {
+            Some(entry) => self.open_window(&entry.clone()),
+            None => self.inner.open_input(name),
+        }
+    }
+
+    fn create_output(&self, name: &str) -> Result<Box<dyn StorageOutput>> {
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> Result<Box<dyn StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.entry_for(name).is_some() || self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> Result<()> {
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn list_files(&self) -> Result<Vec<String>> {
+        // Passthrough: the facade serves named part reads; enumeration of
+        // parts goes through the typed API (`bkd_field_names`), not
+        // through directory listings.
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> Result<u64> {
+        match self.entry_for(name) {
+            Some(entry) => Ok(entry.len),
+            None => self.inner.file_size(name),
+        }
+    }
+
+    fn metadata(&self, name: &str) -> Result<FileMetadata> {
+        match self.entry_for(name) {
+            Some(entry) => {
+                let container_meta = self.inner.metadata(&self.container)?;
+                Ok(FileMetadata {
+                    size: entry.len,
+                    ..container_meta
+                })
+            }
+            None => self.inner.metadata(name),
+        }
+    }
+
+    fn create_temp_output(&self, prefix: &str) -> Result<(String, Box<dyn StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn sync(&self) -> Result<()> {
+        self.inner.sync()
+    }
+
+    fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// The bytes behind a window.
+enum WindowBacking {
+    Handle(Box<dyn StorageInput>),
+    Buffered(Arc<Vec<u8>>),
+}
+
+impl std::fmt::Debug for WindowBacking {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Handle(_) => f.write_str("WindowBacking::Handle"),
+            Self::Buffered(b) => write!(f, "WindowBacking::Buffered({} bytes)", b.len()),
+        }
+    }
+}
+
+/// A windowed [`StorageInput`] over `[base, base + len)` of the container.
+///
+/// Everything is clamped to the window: `size()` reports the window
+/// length (`StructReader`'s framing depends on it), `Read` cannot run
+/// past the window end even when the underlying bytes continue (a corrupt
+/// part boundary must fail, not silently consume the next part), and
+/// `as_slice` is clamped on BOTH ends — the #504 zero-copy posting
+/// decode only checks that the slice is long *enough*, so an unclamped
+/// tail would hand it the next part's bytes.
+#[derive(Debug)]
+struct PartInput {
+    backing: WindowBacking,
+    base: u64,
+    len: u64,
+    /// Cursor within the window.
+    pos: u64,
+}
+
+impl Read for PartInput {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let remaining = self.len.saturating_sub(self.pos);
+        if remaining == 0 {
+            return Ok(0);
+        }
+        let want = buf.len().min(remaining as usize);
+        let read = match &mut self.backing {
+            WindowBacking::Buffered(bytes) => {
+                let start = (self.base + self.pos) as usize;
+                let end = start + want;
+                buf[..want].copy_from_slice(&bytes[start..end]);
+                want
+            }
+            WindowBacking::Handle(input) => {
+                input.seek(SeekFrom::Start(self.base + self.pos))?;
+                input.read(&mut buf[..want])?
+            }
+        };
+        self.pos += read as u64;
+        Ok(read)
+    }
+}
+
+impl Seek for PartInput {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let target = match pos {
+            SeekFrom::Start(offset) => offset as i64,
+            SeekFrom::End(delta) => self.len as i64 + delta,
+            SeekFrom::Current(delta) => self.pos as i64 + delta,
+        };
+        if target < 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "seek before window start",
+            ));
+        }
+        self.pos = target as u64;
+        Ok(self.pos)
+    }
+}
+
+impl StorageInput for PartInput {
+    fn size(&self) -> Result<u64> {
+        Ok(self.len)
+    }
+
+    fn clone_input(&self) -> Result<Box<dyn StorageInput>> {
+        let backing = match &self.backing {
+            WindowBacking::Buffered(bytes) => WindowBacking::Buffered(Arc::clone(bytes)),
+            WindowBacking::Handle(input) => WindowBacking::Handle(input.clone_input()?),
+        };
+        Ok(Box::new(PartInput {
+            backing,
+            base: self.base,
+            len: self.len,
+            pos: 0,
+        }))
+    }
+
+    fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn as_slice(&self) -> Option<&[u8]> {
+        let start = (self.base + self.pos) as usize;
+        let end = (self.base + self.len) as usize;
+        match &self.backing {
+            WindowBacking::Buffered(bytes) => bytes.get(start..end),
+            WindowBacking::Handle(input) => {
+                // The inner slice starts at the inner cursor, which this
+                // window does not control; recover the absolute view via
+                // pointer arithmetic-free slicing is impossible here, so
+                // only serve the fast path when the inner input exposes the
+                // whole container from position 0 semantics. Conservative:
+                // decline (the sequential read path stays correct).
+                let _ = input;
+                None
+            }
+        }
+    }
+}
+
+/// Parse the table bytes.
+fn parse_table(table: &[u8], table_offset: u64, container: &str) -> Result<Vec<PartEntry>> {
+    let mut cursor = 0usize;
+    let count = read_varint(table, &mut cursor, container)?;
+    let mut parts = Vec::with_capacity(count as usize);
+    for _ in 0..count {
+        let suffix_len = read_varint(table, &mut cursor, container)? as usize;
+        let suffix_end = cursor
+            .checked_add(suffix_len)
+            .filter(|&end| end <= table.len())
+            .ok_or_else(|| LaurusError::storage(format!("{container}: truncated table")))?;
+        let suffix = std::str::from_utf8(&table[cursor..suffix_end])
+            .map_err(|_| LaurusError::storage(format!("{container}: non-UTF-8 part suffix")))?
+            .to_string();
+        cursor = suffix_end;
+        if cursor + 16 > table.len() {
+            return Err(LaurusError::storage(format!(
+                "{container}: truncated table entry"
+            )));
+        }
+        let offset = u64::from_le_bytes(table[cursor..cursor + 8].try_into().expect("checked"));
+        let len = u64::from_le_bytes(table[cursor + 8..cursor + 16].try_into().expect("checked"));
+        cursor += 16;
+        let end = offset
+            .checked_add(len)
+            .ok_or_else(|| LaurusError::storage(format!("{container}: part range overflow")))?;
+        if end > table_offset {
+            return Err(LaurusError::storage(format!(
+                "{container}: part {suffix} overlaps the table"
+            )));
+        }
+        parts.push(PartEntry {
+            suffix,
+            offset,
+            len,
+        });
+    }
+    Ok(parts)
+}
+
+fn write_varint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7F) as u8;
+        value >>= 7;
+        if value == 0 {
+            buf.push(byte);
+            break;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+fn read_varint(bytes: &[u8], cursor: &mut usize, container: &str) -> Result<u64> {
+    let mut value = 0u64;
+    let mut shift = 0;
+    loop {
+        let byte = *bytes
+            .get(*cursor)
+            .ok_or_else(|| LaurusError::storage(format!("{container}: truncated varint")))?;
+        *cursor += 1;
+        value |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            return Ok(value);
+        }
+        shift += 7;
+        if shift >= 64 {
+            return Err(LaurusError::storage(format!(
+                "{container}: varint overflow"
+            )));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::memory::{MemoryStorage, MemoryStorageConfig};
+
+    fn memory() -> Arc<dyn Storage> {
+        Arc::new(MemoryStorage::new(MemoryStorageConfig::default()))
+    }
+
+    /// Sequential writes cannot distinguish translation from passthrough,
+    /// so the wrapper's seek semantics are pinned directly, at a non-zero
+    /// base.
+    #[test]
+    fn part_output_translates_seeks_and_positions() {
+        let storage = memory();
+        let mut writer = CompoundSegmentWriter::create(storage.as_ref(), "segment_000000").unwrap();
+
+        // Part 1 pushes part 2's base past zero.
+        let mut p1 = writer.begin_part("first").unwrap();
+        p1.write_all(b"0123456789").unwrap();
+        writer.end_part().unwrap();
+
+        let mut p2 = writer.begin_part("second").unwrap();
+        assert_eq!(p2.position().unwrap(), 0, "part positions start at 0");
+
+        // The BKD pattern: reserve a header, write payload, backfill.
+        p2.write_all(&[0u8; 4]).unwrap(); // header placeholder
+        p2.write_all(b"PAYLOAD").unwrap();
+        let end = p2.seek(SeekFrom::End(0)).unwrap();
+        assert_eq!(
+            end, 11,
+            "End(0) must be the part extent, not the container's"
+        );
+        let back = p2.seek(SeekFrom::Start(0)).unwrap();
+        assert_eq!(back, 0, "seek return values must be part-relative");
+        p2.write_all(b"HDR!").unwrap();
+        let sp = p2.stream_position().unwrap();
+        assert_eq!(sp, 4, "stream_position must be part-relative");
+        p2.seek(SeekFrom::End(0)).unwrap();
+        writer.end_part().unwrap();
+
+        let entries = writer.finish().unwrap();
+        assert_eq!(entries[0].offset, 0);
+        assert_eq!(entries[0].len, 10);
+        assert_eq!(entries[1].offset, 10);
+        assert_eq!(entries[1].len, 11);
+
+        // Read back through the facade: the backfilled header is at the
+        // part's byte 0, exactly as a part-relative reader expects.
+        let facade = CompoundSegmentStorage::try_open(storage, "segment_000000")
+            .unwrap()
+            .expect("container must be detected");
+        let mut input = facade.open_input("segment_000000.second").unwrap();
+        let mut bytes = Vec::new();
+        input.read_to_end(&mut bytes).unwrap();
+        assert_eq!(&bytes, b"HDR!PAYLOAD");
+    }
+
+    /// Reads, seeks, `size()` and `as_slice` are all clamped to the window.
+    #[test]
+    fn part_input_clamps_to_the_window() {
+        let storage = memory();
+        let mut writer = CompoundSegmentWriter::create(storage.as_ref(), "segment_000001").unwrap();
+        let mut p = writer.begin_part("a").unwrap();
+        p.write_all(b"AAAA").unwrap();
+        writer.end_part().unwrap();
+        let mut p = writer.begin_part("b").unwrap();
+        p.write_all(b"BBBB").unwrap();
+        writer.end_part().unwrap();
+        writer.finish().unwrap();
+
+        let facade = CompoundSegmentStorage::try_open(storage, "segment_000001")
+            .unwrap()
+            .unwrap();
+        let mut input = facade.open_input("segment_000001.a").unwrap();
+        assert_eq!(input.size().unwrap(), 4);
+
+        // Read cannot cross into part b even with a bigger buffer.
+        let mut buf = [0u8; 16];
+        let n = input.read(&mut buf).unwrap();
+        assert_eq!(&buf[..n], b"AAAA", "read must stop at the window end");
+        assert_eq!(input.read(&mut buf).unwrap(), 0, "EOF at the window end");
+
+        // as_slice starts at the cursor and clamps at the window end.
+        input.seek(SeekFrom::Start(1)).unwrap();
+        if let Some(slice) = input.as_slice() {
+            assert_eq!(slice, b"AAA", "as_slice must clamp both ends");
+        }
+
+        // Seek relative to the window end.
+        let pos = input.seek(SeekFrom::End(-2)).unwrap();
+        assert_eq!(pos, 2);
+        let mut two = [0u8; 2];
+        input.read_exact(&mut two).unwrap();
+        assert_eq!(&two, b"AA");
+    }
+
+    /// The facade is table-then-passthrough: part names resolve virtually,
+    /// everything else (the `.delmap` probe above all) reaches the inner
+    /// storage.
+    #[test]
+    fn facade_is_table_then_passthrough() {
+        let storage = memory();
+        let mut writer = CompoundSegmentWriter::create(storage.as_ref(), "segment_000002").unwrap();
+        let mut p = writer.begin_part("post").unwrap();
+        p.write_all(b"P").unwrap();
+        writer.end_part().unwrap();
+        writer.finish().unwrap();
+
+        // A loose sibling file next to the container (the `.delmap` shape).
+        {
+            let mut out = storage.create_output("segment_000002.delmap").unwrap();
+            out.write_all(b"D").unwrap();
+            out.close().unwrap();
+        }
+
+        let facade = CompoundSegmentStorage::try_open(storage, "segment_000002")
+            .unwrap()
+            .unwrap();
+        assert!(facade.file_exists("segment_000002.post"), "table hit");
+        assert!(
+            facade.file_exists("segment_000002.delmap"),
+            "passthrough hit — a table-only answer would resurrect deletions"
+        );
+        assert!(!facade.file_exists("segment_000002.lens"), "true miss");
+        assert_eq!(facade.file_size("segment_000002.post").unwrap(), 1);
+        let mut input = facade.open_input("segment_000002.delmap").unwrap();
+        let mut bytes = Vec::new();
+        input.read_to_end(&mut bytes).unwrap();
+        assert_eq!(&bytes, b"D");
+    }
+
+    /// A torn container must refuse loudly, never degrade to "no parts".
+    #[test]
+    fn torn_container_is_refused() {
+        let storage = memory();
+        let mut writer = CompoundSegmentWriter::create(storage.as_ref(), "segment_000003").unwrap();
+        let mut p = writer.begin_part("post").unwrap();
+        p.write_all(b"PPPP").unwrap();
+        writer.end_part().unwrap();
+        writer.finish().unwrap();
+
+        // Truncate the trailer.
+        let mut bytes = {
+            let mut input = storage.open_input("segment_000003.cfs").unwrap();
+            let mut b = Vec::new();
+            input.read_to_end(&mut b).unwrap();
+            b
+        };
+        bytes.truncate(bytes.len() - 6);
+        let mut out = storage.create_output("segment_000003.cfs").unwrap();
+        out.write_all(&bytes).unwrap();
+        out.close().unwrap();
+
+        let err = CompoundSegmentStorage::try_open(storage, "segment_000003");
+        assert!(err.is_err(), "a torn container must surface as an error");
+    }
+
+    /// Absent container → None (a loose, pre-#554 segment).
+    #[test]
+    fn loose_segment_is_not_wrapped() {
+        let storage = memory();
+        assert!(
+            CompoundSegmentStorage::try_open(storage, "segment_000004")
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    /// BKD field names come from the table.
+    #[test]
+    fn bkd_field_names_from_table() {
+        let storage = memory();
+        let mut writer = CompoundSegmentWriter::create(storage.as_ref(), "segment_000005").unwrap();
+        for suffix in ["post", "rank.bkd", "geo.field.bkd"] {
+            let mut p = writer.begin_part(suffix).unwrap();
+            p.write_all(b"x").unwrap();
+            writer.end_part().unwrap();
+        }
+        writer.finish().unwrap();
+
+        let facade = CompoundSegmentStorage::try_open(storage, "segment_000005")
+            .unwrap()
+            .unwrap();
+        let mut fields = facade.bkd_field_names();
+        fields.sort();
+        assert_eq!(fields, vec!["geo.field".to_string(), "rank".to_string()]);
+    }
+}

--- a/laurus/src/lexical/index/inverted/reader.rs
+++ b/laurus/src/lexical/index/inverted/reader.rs
@@ -441,6 +441,12 @@ pub struct SegmentReader {
     /// Storage backend.
     storage: Arc<dyn Storage>,
 
+    /// The compound-container facade when this segment is a `.cfs`
+    /// (#554); `None` for loose segments. Kept typed alongside the
+    /// type-erased `storage` clone so part enumeration (`bkd_field_names`)
+    /// can consult the table.
+    compound: Option<Arc<crate::lexical::index::inverted::compound::CompoundSegmentStorage>>,
+
     /// Term dictionary for efficient term lookup.
     term_dictionary: RwLock<Option<Arc<BlockTermDictionary>>>,
 
@@ -483,9 +489,22 @@ impl SegmentReader {
 
     /// Open a segment reader (schema-less mode).
     pub fn open(info: SegmentInfo, storage: Arc<dyn Storage>) -> Result<Self> {
+        // Layout detection (#554): a `{segment_id}.cfs` container routes
+        // every part read through a windowed facade; its absence means a
+        // loose (pre-#554) segment and the storage is used as-is. Loose
+        // and compound segments therefore coexist freely in one index.
+        let compound = crate::lexical::index::inverted::compound::CompoundSegmentStorage::try_open(
+            Arc::clone(&storage),
+            &info.segment_id,
+        )?;
+        let storage: Arc<dyn Storage> = match &compound {
+            Some(facade) => Arc::clone(facade) as Arc<dyn Storage>,
+            None => storage,
+        };
         let reader = SegmentReader {
             info,
             storage,
+            compound,
             term_dictionary: RwLock::new(None),
             stored_documents: RwLock::new(None),
             field_lengths: RwLock::new(None),
@@ -499,6 +518,39 @@ impl SegmentReader {
         };
 
         Ok(reader)
+    }
+
+    /// The numeric/geo field names this segment carries BKD trees for
+    /// (#554).
+    ///
+    /// Compound segments answer from the container table; loose segments
+    /// scan storage for `{segment_id}.{field}.bkd` files — the enumeration
+    /// the merge engine used to do against raw storage, which would find
+    /// nothing once the parts moved into a container and silently drop
+    /// every point at the first merge.
+    ///
+    /// # Returns
+    ///
+    /// The field names, in no particular order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if listing a loose segment's storage fails.
+    pub fn bkd_field_names(&self) -> Result<Vec<String>> {
+        if let Some(facade) = &self.compound {
+            return Ok(facade.bkd_field_names());
+        }
+        let prefix = format!("{}.", self.info.segment_id);
+        Ok(self
+            .storage
+            .list_files()?
+            .into_iter()
+            .filter_map(|file| {
+                file.strip_prefix(&prefix)
+                    .and_then(|rest| rest.strip_suffix(".bkd"))
+                    .map(str::to_string)
+            })
+            .collect())
     }
 
     /// Enable (or resize) this segment's decoded posting-list cache with a byte

--- a/laurus/src/lexical/index/inverted/segment/merge_engine.rs
+++ b/laurus/src/lexical/index/inverted/segment/merge_engine.rs
@@ -22,6 +22,12 @@ use crate::storage::Storage;
 /// Configuration for merge operations.
 #[derive(Debug, Clone)]
 pub struct MergeConfig {
+    /// Write the merged segment as a compound `.cfs` container (#554).
+    ///
+    /// Set from the owning index's `use_compound`, so the merged output
+    /// follows the same layout as fresh flushes.
+    pub use_compound: bool,
+
     /// Maximum memory usage during merge (in bytes).
     pub max_memory_mb: u64,
 
@@ -44,6 +50,7 @@ pub struct MergeConfig {
 impl Default for MergeConfig {
     fn default() -> Self {
         MergeConfig {
+            use_compound: false,
             max_memory_mb: 256,
             batch_size: 10000,
             enable_compression: true,
@@ -290,12 +297,8 @@ impl MergeEngine {
         for segment in segments {
             let reader = SegmentReader::open(segment.segment_info.clone(), self.storage.clone())?;
             let deleted = self.load_deleted_docs(&segment.segment_info)?;
-            let reconstructed = self.reconstruct_segment(
-                &reader,
-                &segment.segment_info.segment_id,
-                &deleted,
-                &mut store_positions,
-            )?;
+            let reconstructed =
+                self.reconstruct_segment(&reader, &deleted, &mut store_positions)?;
             stats.deleted_docs_removed += deleted.len();
             for (doc_id, analyzed) in reconstructed {
                 if docs.insert(doc_id, analyzed).is_none() {
@@ -321,6 +324,7 @@ impl MergeEngine {
             shard_id: stats.shard_id,
             max_buffered_docs: usize::MAX,
             max_buffer_memory: usize::MAX,
+            use_compound: self.config.use_compound,
             ..Default::default()
         };
         // Deliberately `new`, not `with_shared_metadata` (#1023): this
@@ -445,7 +449,6 @@ impl MergeEngine {
     fn reconstruct_segment(
         &self,
         reader: &SegmentReader,
-        segment_id: &str,
         deleted: &RoaringTreemap,
         store_positions: &mut Option<bool>,
     ) -> Result<Vec<(u64, AnalyzedDocument)>> {
@@ -514,15 +517,12 @@ impl MergeEngine {
         // index-only (`stored=false`) and multi-valued numeric fields, which a
         // stored-field derivation would miss (Issue #758).
         let mut points: AHashMap<u64, AHashMap<String, Vec<Vec<f64>>>> = AHashMap::new();
-        let bkd_prefix = format!("{segment_id}.");
-        let bkd_suffix = ".bkd";
-        for file in self.storage.list_files()? {
-            let Some(field) = file
-                .strip_prefix(&bkd_prefix)
-                .and_then(|rest| rest.strip_suffix(bkd_suffix))
-            else {
-                continue;
-            };
+        // Enumerate through the reader (#554): a raw `list_files` scan
+        // finds no `.bkd` files once the parts live inside a compound
+        // container, and the merged segment would silently drop every
+        // numeric/geo point (`verify_after_merge` only checks doc_count).
+        for field in reader.bkd_field_names()? {
+            let field = field.as_str();
             if let Some(tree) = reader.get_bkd_tree(field)? {
                 let mut visitor = CollectPointsVisitor::default();
                 tree.intersect(&mut visitor)?;

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -35,6 +35,15 @@ use crate::storage::structured::StructWriter;
 /// Inverted index writer configuration.
 #[derive(Clone)]
 pub struct InvertedIndexWriterConfig {
+    /// Write flushed segments as one compound `.cfs` container instead of
+    /// loose per-part files (#554).
+    ///
+    /// One `create` + one fsync per segment instead of one per part.
+    /// Readers detect the layout per segment, so loose and compound
+    /// segments coexist freely in one index. Off by default until the
+    /// #554 rollout flips it.
+    pub use_compound: bool,
+
     /// Maximum number of documents to buffer before flushing to disk.
     pub max_buffered_docs: usize,
 
@@ -76,6 +85,7 @@ impl std::fmt::Debug for InvertedIndexWriterConfig {
 impl Default for InvertedIndexWriterConfig {
     fn default() -> Self {
         InvertedIndexWriterConfig {
+            use_compound: false,
             max_buffered_docs: 10000,
             max_buffer_memory: 64 * 1024 * 1024, // 64MB
             segment_prefix: "segment".to_string(),
@@ -1004,26 +1014,30 @@ impl InvertedIndexWriter {
         // the manifest at publication, never through its files — which is
         // also what makes a crash mid-write harmless (the sweep reclaims
         // unreferenced files at the next open).
-        self.write_inverted_index(segment_name)?;
-        self.write_stored_documents(segment_name)?;
-        self.write_field_lengths(segment_name)?;
-        self.write_field_stats(segment_name)?;
-        self.write_doc_values(segment_name)?;
-        self.write_bkd_trees(segment_name)?;
-        // The redundant `.json` stored-field mirror is no longer written
-        // (Issue #756); stored fields are read from the typed `.docs` file.
-
-        // Collect every file written under this segment prefix (the BKD step
-        // writes one `.{field}.bkd` per numeric/geo field, so enumerate rather
-        // than hard-code the set).
-        let prefix = format!("{segment_name}.");
-        let paths = self
-            .storage
-            .list_files()?
-            .into_iter()
-            .filter(|f| f.starts_with(&prefix))
-            .collect();
-        Ok(paths)
+        //
+        // The same orchestration serves both layouts (#554): loose files
+        // (one create per part) or one compound container (`.cfs` — one
+        // create, one fsync). The parts themselves cannot tell the
+        // difference: the sink hands them a `StorageOutput` either way.
+        let mut sink = if self.config.use_compound {
+            PartSink::Compound(super::compound::CompoundSegmentWriter::create(
+                self.storage.as_ref(),
+                segment_name,
+            )?)
+        } else {
+            PartSink::Loose {
+                storage: self.storage.as_ref(),
+                segment_name: segment_name.to_string(),
+                paths: Vec::new(),
+            }
+        };
+        self.write_inverted_index(&mut sink)?;
+        self.write_stored_documents(&mut sink)?;
+        self.write_field_lengths(&mut sink)?;
+        self.write_field_stats(&mut sink)?;
+        self.write_doc_values(&mut sink)?;
+        self.write_bkd_trees(&mut sink)?;
+        sink.finish()
     }
 
     /// Flush the currently buffered documents to a caller-named segment,
@@ -1063,10 +1077,9 @@ impl InvertedIndexWriter {
     }
 
     /// Write the inverted index to storage.
-    fn write_inverted_index(&self, segment_name: &str) -> Result<()> {
+    fn write_inverted_index(&self, sink: &mut PartSink<'_>) -> Result<()> {
         // Write posting lists
-        let posting_file = format!("{segment_name}.post");
-        let posting_output = self.storage.create_output(&posting_file)?;
+        let posting_output = sink.part("post")?;
         let mut posting_writer = StructWriter::new(posting_output);
 
         let mut term_dict_builder = TermDictionaryBuilder::new();
@@ -1147,15 +1160,16 @@ impl InvertedIndexWriter {
         }
 
         posting_writer.close()?;
+        sink.seal()?;
 
         // Write term dictionary
-        let dict_file = format!("{segment_name}.dict");
-        let dict_output = self.storage.create_output(&dict_file)?;
+        let dict_output = sink.part("dict")?;
         let mut dict_writer = StructWriter::new(dict_output);
 
         let term_dict = term_dict_builder.build()?;
         term_dict.write_to_storage(&mut dict_writer)?;
         dict_writer.close()?;
+        sink.seal()?;
 
         Ok(())
     }
@@ -1294,9 +1308,8 @@ impl InvertedIndexWriter {
     }
 
     /// Write stored documents to storage with type information preserved.
-    fn write_stored_documents(&self, segment_name: &str) -> Result<()> {
-        let stored_file = format!("{segment_name}.docs");
-        let stored_output = self.storage.create_output(&stored_file)?;
+    fn write_stored_documents(&self, sink: &mut PartSink<'_>) -> Result<()> {
+        let stored_output = sink.part("docs")?;
         let mut stored_writer = StructWriter::new(stored_output);
 
         // Write document count
@@ -1382,6 +1395,7 @@ impl InvertedIndexWriter {
         }
 
         stored_writer.close()?;
+        sink.seal()?;
         Ok(())
     }
 
@@ -1419,9 +1433,8 @@ impl InvertedIndexWriter {
     }
 
     /// Write field lengths to storage.
-    fn write_field_lengths(&self, segment_name: &str) -> Result<()> {
-        let lens_file = format!("{segment_name}.lens");
-        let lens_output = self.storage.create_output(&lens_file)?;
+    fn write_field_lengths(&self, sink: &mut PartSink<'_>) -> Result<()> {
+        let lens_output = sink.part("lens")?;
         let mut lens_writer = StructWriter::new(lens_output);
 
         // Write document count
@@ -1439,13 +1452,13 @@ impl InvertedIndexWriter {
         }
 
         lens_writer.close()?;
+        sink.seal()?;
         Ok(())
     }
 
     /// Write field statistics to storage.
-    fn write_field_stats(&self, segment_name: &str) -> Result<()> {
-        let fstats_file = format!("{segment_name}.fstats");
-        let fstats_output = self.storage.create_output(&fstats_file)?;
+    fn write_field_stats(&self, sink: &mut PartSink<'_>) -> Result<()> {
+        let fstats_output = sink.part("fstats")?;
         let mut fstats_writer = StructWriter::new(fstats_output);
 
         let field_stats = self.calculate_field_stats();
@@ -1462,16 +1475,16 @@ impl InvertedIndexWriter {
         }
 
         fstats_writer.close()?;
+        sink.seal()?;
         Ok(())
     }
 
     /// Write DocValues to storage.
-    fn write_doc_values(&self, segment_name: &str) -> Result<()> {
-        // Write under the caller-supplied segment name. On the normal flush
-        // path this equals the writer's own `segment_name`; the merge path
-        // (Issue #753) passes the merged segment's name so accumulated values
-        // land in the right `.dv` file.
-        self.doc_values_writer.write_to(segment_name)?;
+    fn write_doc_values(&self, sink: &mut PartSink<'_>) -> Result<()> {
+        let mut output = sink.part("dv")?;
+        self.doc_values_writer.write_to_output(&mut output)?;
+        output.flush()?;
+        sink.seal()?;
         Ok(())
     }
 
@@ -1481,7 +1494,7 @@ impl InvertedIndexWriter {
     /// (`points`) and parallel doc-id buffers (`doc_ids`) so the BKD writer
     /// can be fed without re-allocating per point. The dimensionality is
     /// captured from the first point seen for each field.
-    fn write_bkd_trees(&self, segment_name: &str) -> Result<()> {
+    fn write_bkd_trees(&self, sink: &mut PartSink<'_>) -> Result<()> {
         // (flat points, doc_ids, num_dims)
         let mut field_buckets: AHashMap<String, (Vec<f64>, Vec<u64>, usize)> = AHashMap::new();
 
@@ -1507,11 +1520,11 @@ impl InvertedIndexWriter {
                 continue;
             }
 
-            let file_name = format!("{segment_name}.{field}.bkd");
-            let output = self.storage.create_output(&file_name)?;
+            let output = sink.part(&format!("{field}.bkd"))?;
             let mut writer = BKDWriter::new(output, num_dims as u32);
             writer.write(&points, &doc_ids)?;
             writer.finish()?;
+            sink.seal()?;
         }
         Ok(())
     }
@@ -2222,5 +2235,62 @@ impl LexicalIndexWriter for InvertedIndexWriter {
 
     fn find_doc_ids_by_term(&self, field: &str, term: &str) -> Result<Option<Vec<u64>>> {
         InvertedIndexWriter::find_doc_ids_by_term(self, field, term)
+    }
+}
+
+/// Where a flushing segment's parts are written (#554).
+///
+/// The part-writing functions receive a `StorageOutput` per part and
+/// cannot tell the layouts apart: `Loose` hands out one real file per
+/// part (each closed by its `StructWriter`), `Compound` hands out
+/// [`super::compound::PartOutput`] views over one shared container
+/// (whose `close` is a no-op; the container fsyncs once in `finish`).
+enum PartSink<'a> {
+    /// One file per part: `{segment_name}.{suffix}`.
+    Loose {
+        storage: &'a dyn crate::storage::Storage,
+        segment_name: String,
+        paths: Vec<String>,
+    },
+    /// One `.cfs` container for every part.
+    Compound(super::compound::CompoundSegmentWriter),
+}
+
+impl PartSink<'_> {
+    /// Open the output for the next part.
+    fn part(&mut self, suffix: &str) -> crate::Result<Box<dyn crate::storage::StorageOutput>> {
+        match self {
+            PartSink::Loose {
+                storage,
+                segment_name,
+                paths,
+            } => {
+                let name = format!("{segment_name}.{suffix}");
+                paths.push(name.clone());
+                storage.create_output(&name)
+            }
+            PartSink::Compound(writer) => Ok(Box::new(writer.begin_part(suffix)?)),
+        }
+    }
+
+    /// Seal the part opened by the last [`Self::part`]. Must be called
+    /// after the part's writer has finished (its `close` included).
+    fn seal(&mut self) -> crate::Result<()> {
+        match self {
+            PartSink::Loose { .. } => Ok(()),
+            PartSink::Compound(writer) => writer.end_part(),
+        }
+    }
+
+    /// Finish the layout and return the written file paths.
+    fn finish(self) -> crate::Result<Vec<String>> {
+        match self {
+            PartSink::Loose { paths, .. } => Ok(paths),
+            PartSink::Compound(writer) => {
+                let container = writer.container_name_owned();
+                writer.finish()?;
+                Ok(vec![container])
+            }
+        }
     }
 }

--- a/laurus/src/lexical/index/structures/doc_values.rs
+++ b/laurus/src/lexical/index/structures/doc_values.rs
@@ -105,7 +105,25 @@ impl DocValuesWriter {
     pub fn write_to(&self, segment_name: &str) -> Result<()> {
         let dv_filename = format!("{}{}", segment_name, DOC_VALUES_EXTENSION);
         let mut output = self.storage.create_output(&dv_filename)?;
+        self.write_to_output(&mut output)?;
+        output.flush()?;
+        Ok(())
+    }
 
+    /// Write the DocValues payload to an already-open output (#554).
+    ///
+    /// The format is position-independent, so it serializes identically
+    /// into a loose `.dv` file or a compound-container part. The output is
+    /// neither flushed nor closed here — the caller owns its lifecycle.
+    ///
+    /// # Arguments
+    ///
+    /// * `output` - Destination for the DVFF payload.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if serialization or a write fails.
+    pub fn write_to_output(&self, output: &mut dyn std::io::Write) -> Result<()> {
         // Write magic number and version
         output.write_all(b"DVFF")?; // DocValues File Format
         output.write_all(&[1u8, 0u8])?; // Version 1.0
@@ -140,7 +158,6 @@ impl DocValuesWriter {
             output.write_all(&serialized)?;
         }
 
-        output.flush()?;
         Ok(())
     }
 }

--- a/laurus/src/storage/prefixed.rs
+++ b/laurus/src/storage/prefixed.rs
@@ -98,6 +98,14 @@ impl PrefixedStorage {
 }
 
 impl Storage for PrefixedStorage {
+    fn loading_mode(&self) -> crate::storage::LoadingMode {
+        // Delegate (#554): the trait default is `Eager`, which misclassified
+        // an mmap-backed FileStorage behind the engine's prefix wrapper —
+        // and consumers use this to pick between paging-friendly lazy reads
+        // and one-shot buffering.
+        self.inner.loading_mode()
+    }
+
     fn open_input(&self, name: &str) -> Result<Box<dyn StorageInput>> {
         self.inner.open_input(&self.map_name(name))
     }

--- a/laurus/src/vector/index/hnsw/reader.rs
+++ b/laurus/src/vector/index/hnsw/reader.rs
@@ -15,7 +15,6 @@ use crate::vector::index::format::{
 use crate::vector::index::hnsw::graph::OrdinalHnswGraph;
 use crate::vector::index::quantized_io::quantized_record_payload_size;
 use crate::vector::index::quantized_storage::QuantizedVectorPool;
-use crate::vector::index::rerank_sidecar::read_sidecar;
 use crate::vector::index::rerank_storage::RerankStoragePool;
 use crate::vector::reader::{ValidationReport, VectorIndexMetadata, VectorStats};
 use crate::vector::reader::{VectorIndexReader, VectorIterator};
@@ -923,55 +922,20 @@ impl HnswIndexReader {
             }
         };
 
-        // Stage 2 rerank sidecar (Issue #481). Loaded eagerly into a
-        // RerankStoragePool when (a) a `<file_name>.f32` sidecar exists
-        // and (b) we are in Eager loading mode. Lazy mode skips the
-        // sidecar to honor its memory-savings promise — Stage 2 segments
-        // opened in Lazy mode silently degrade to Stage 1 (no rerank).
-        // The pool's vector positions are paired with `vector_ids` (the
-        // same order as the LVS1 segment), giving an identity mapping.
-        let rerank_storage = match storage.loading_mode() {
-            crate::storage::LoadingMode::Eager => {
-                let sidecar_name = format!("{}.f32", file_name);
-                if storage.file_exists(&sidecar_name) {
-                    let mut sidecar_in = storage.open_input(&sidecar_name)?;
-                    let sidecar_size = sidecar_in.size()?;
-                    let (header, payload) = read_sidecar(&mut sidecar_in, sidecar_size)?;
-                    if header.dim as usize != dimension {
-                        return Err(LaurusError::InvalidOperation(format!(
-                            "rerank sidecar dim mismatch: LVS1 segment uses {dimension}, \
-                             sidecar uses {}",
-                            header.dim
-                        )));
-                    }
-                    if header.vector_count as usize != vector_ids.len() {
-                        return Err(LaurusError::InvalidOperation(format!(
-                            "rerank sidecar vector_count mismatch: LVS1 segment has {} vectors, \
-                             sidecar has {}",
-                            vector_ids.len(),
-                            header.vector_count
-                        )));
-                    }
-                    // Transient rehydration for the sidecar's String-shaped
-                    // assignment input (eager-only path; nothing retained).
-                    let assignment: Vec<(u64, String)> = vector_ids
-                        .iter()
-                        .map(|&(id, fid)| (id, field_dict[fid as usize].to_string()))
-                        .collect();
-                    let pool = RerankStoragePool::from_sidecar_payload(
-                        header.storage_kind,
-                        dimension,
-                        header.vector_count as usize,
-                        payload,
-                        &assignment,
-                    )?;
-                    Some(Arc::new(pool))
-                } else {
-                    None
-                }
-            }
-            crate::storage::LoadingMode::Lazy => None,
-        };
+        // Stage 2 rerank sidecar (Issue #481), via the shared loader
+        // (#650 PR-2 / #554): loads whenever the sidecar exists,
+        // regardless of loading mode — the old Eager-only gate here never
+        // fired behind the engine (PrefixedStorage misreported Eager until
+        // #554 made it delegate), so "rerank works on mmap" is the
+        // shipped, tested behavior. The pool's vector positions pair with
+        // `vector_ids` (the same order as the LVS1 segment).
+        let rerank_storage = crate::vector::index::rerank_sidecar::load_rerank_sidecar(
+            storage.as_ref(),
+            &file_name,
+            dimension,
+            &vector_ids,
+            &field_dict,
+        )?;
 
         Ok(Self {
             vectors,

--- a/laurus/src/vector/index/rerank_sidecar.rs
+++ b/laurus/src/vector/index/rerank_sidecar.rs
@@ -475,11 +475,19 @@ pub fn read_sidecar<R: Read>(
 /// [`crate::vector::index::rerank_storage::RerankStoragePool`]
 /// (Issue #481; shared across HNSW/Flat/IVF readers by #650 PR-2 / #932).
 ///
-/// Lenient-if-absent: returns `Ok(None)` when no sidecar file exists or
-/// when `storage` is in Lazy loading mode (the sidecar is skipped to honor
-/// Lazy's memory-savings promise — Stage 2 segments opened Lazy silently
-/// degrade to Stage 1). A present sidecar whose `dim`/`vector_count`
-/// disagree with the segment fails loudly.
+/// Lenient-if-absent: returns `Ok(None)` when no sidecar file exists.
+/// A present sidecar whose `dim`/`vector_count` disagree with the segment
+/// fails loudly.
+///
+/// The sidecar loads regardless of the storage's loading mode. An
+/// Eager-only gate used to sit here "to honor Lazy's memory-savings
+/// promise", but it never actually fired behind the engine: the engine
+/// wraps every store in `PrefixedStorage`, which misreported the trait
+/// default `Eager` until #554 made it delegate — so the shipped, tested
+/// behavior has always been "rerank works on mmap", and honoring the
+/// corrected mode would have silently degraded Stage 2 to Stage 1 in the
+/// default production configuration. Buffering the sidecar is the
+/// documented cost of opting a field into `rerank_storage` (#481).
 ///
 /// The pool's positions pair with `vector_ids` (the segment's record
 /// order, which the writer also used for the sidecar payload), giving an
@@ -506,9 +514,6 @@ pub(crate) fn load_rerank_sidecar(
     vector_ids: &[(u64, u16)],
     field_dict: &[std::sync::Arc<str>],
 ) -> Result<Option<std::sync::Arc<crate::vector::index::rerank_storage::RerankStoragePool>>> {
-    if !matches!(storage.loading_mode(), crate::storage::LoadingMode::Eager) {
-        return Ok(None);
-    }
     let sidecar_name = format!("{file_name}.f32");
     if !storage.file_exists(&sidecar_name) {
         return Ok(None);

--- a/laurus/tests/compound_segment_test.rs
+++ b/laurus/tests/compound_segment_test.rs
@@ -1,0 +1,268 @@
+//! #554 — compound segment containers, end to end.
+//!
+//! A segment flushed with `use_compound` writes ONE `.cfs` container
+//! instead of loose per-part files; readers detect the layout per
+//! segment, so loose and compound segments coexist in one index. The
+//! round-trip matrix runs the four read paths with distinct access
+//! patterns — postings (offset seeks), BKD trees (absolute seeks +
+//! re-open per query), stored documents and doc values (sequential) —
+//! over every storage backend, because the windowed views translate
+//! seeks differently per backend.
+
+use std::sync::Arc;
+
+use laurus::lexical::index::LexicalIndex;
+use laurus::lexical::index::inverted::InvertedIndex;
+use laurus::lexical::{
+    InvertedIndexConfig, LexicalSearchRequest, NumericRangeQuery, NumericType, TermQuery,
+};
+use laurus::storage::Storage;
+use laurus::storage::file::{FileStorage, FileStorageConfig};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document};
+use tempfile::TempDir;
+
+fn compound_config() -> InvertedIndexConfig {
+    InvertedIndexConfig {
+        use_compound: true,
+        ..Default::default()
+    }
+}
+
+fn doc(body: &str, rank: i64) -> Document {
+    Document::builder()
+        .add_field("body", DataValue::Text(body.into()))
+        .add_field("rank", DataValue::Int64(rank))
+        .build()
+}
+
+/// Commit two segments (3 + 1 docs) through an index and return it.
+fn build_index(storage: Arc<dyn Storage>) -> InvertedIndex {
+    let index = InvertedIndex::create(storage, compound_config()).unwrap();
+    let mut writer = index.writer().unwrap();
+    for rank in 1..=3i64 {
+        writer
+            .upsert_document(rank as u64, doc(&format!("alpha doc{rank}"), rank))
+            .unwrap();
+    }
+    writer.commit().unwrap();
+    writer.upsert_document(4, doc("alpha doc4", 40)).unwrap();
+    writer.commit().unwrap();
+    index
+}
+
+/// The four read paths against a compound index.
+fn assert_round_trip(index: &InvertedIndex, storage: &Arc<dyn Storage>) {
+    let searcher = index.searcher().unwrap();
+
+    // Postings (offset-seeking reads inside the `.post` window).
+    let hits = searcher
+        .search(LexicalSearchRequest::new(Box::new(TermQuery::new(
+            "body", "alpha",
+        ))))
+        .unwrap();
+    assert_eq!(hits.hits.len(), 4, "postings through the container");
+
+    // BKD (absolute seeks, re-opened per query through the facade).
+    let hits = searcher
+        .search(LexicalSearchRequest::new(Box::new(NumericRangeQuery::new(
+            "rank",
+            NumericType::Integer,
+            Some(2.0),
+            Some(3.0),
+            true,
+            true,
+        ))))
+        .unwrap();
+    assert_eq!(hits.hits.len(), 2, "BKD range through the container");
+
+    // Stored documents (sequential window read).
+    let one = searcher
+        .search(LexicalSearchRequest::new(Box::new(TermQuery::new(
+            "body", "doc4",
+        ))))
+        .unwrap();
+    assert_eq!(one.hits.len(), 1);
+    let stored = one.hits[0]
+        .document
+        .as_ref()
+        .expect("stored document must be readable through the container");
+    assert_eq!(stored.fields.get("rank"), Some(&DataValue::Int64(40)));
+
+    // Layout: one container per segment, zero loose part files.
+    let files = storage.list_files().unwrap();
+    let containers = files.iter().filter(|f| f.ends_with(".cfs")).count();
+    assert_eq!(containers, 2, "one container per committed segment");
+    for suffix in [".post", ".dict", ".docs", ".lens", ".fstats", ".dv", ".bkd"] {
+        assert!(
+            !files.iter().any(|f| f.ends_with(suffix)),
+            "no loose {suffix} may exist next to the containers: {files:?}"
+        );
+    }
+}
+
+#[test]
+fn round_trip_on_memory_storage() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index = build_index(storage.clone());
+    assert_round_trip(&index, &storage);
+}
+
+#[test]
+fn round_trip_on_mmap_file_storage() {
+    let dir = TempDir::new().unwrap();
+    let config = FileStorageConfig::new(dir.path());
+    assert!(config.use_mmap, "mmap must be the default under test");
+    let storage: Arc<dyn Storage> = Arc::new(FileStorage::new(dir.path(), config).unwrap());
+    let index = build_index(storage.clone());
+    assert_round_trip(&index, &storage);
+}
+
+#[test]
+fn round_trip_on_buffered_file_storage() {
+    let dir = TempDir::new().unwrap();
+    let config = FileStorageConfig {
+        use_mmap: false,
+        ..FileStorageConfig::new(dir.path())
+    };
+    let storage: Arc<dyn Storage> = Arc::new(FileStorage::new(dir.path(), config).unwrap());
+    let index = build_index(storage.clone());
+    assert_round_trip(&index, &storage);
+}
+
+/// Reopening reads compound segments cold (fresh facades, fresh windows).
+#[test]
+fn compound_segments_survive_a_reopen() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index = build_index(storage.clone());
+    drop(index);
+
+    let reopened = InvertedIndex::open(storage.clone(), compound_config()).unwrap();
+    assert_round_trip(&reopened, &storage);
+}
+
+/// BLOCKER-1 (#554 review): a merge of compound sources must preserve
+/// every numeric point. The merge engine used to enumerate `.bkd` files
+/// by listing raw storage — inside a container it finds none, and the
+/// merged segment silently drops all points (`verify_after_merge` only
+/// checks doc_count).
+#[test]
+fn merge_of_compound_sources_preserves_points() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index = build_index(storage.clone());
+
+    index.optimize().unwrap();
+
+    let searcher = index.searcher().unwrap();
+    let hits = searcher
+        .search(LexicalSearchRequest::new(Box::new(NumericRangeQuery::new(
+            "rank",
+            NumericType::Integer,
+            Some(1.0),
+            Some(40.0),
+            true,
+            true,
+        ))))
+        .unwrap();
+    assert_eq!(
+        hits.hits.len(),
+        4,
+        "every numeric point must survive a merge of compound sources"
+    );
+
+    // The merged output is itself a container…
+    let merged_cfs = storage
+        .list_files()
+        .unwrap()
+        .into_iter()
+        .find(|f| f.starts_with("merged_") && f.ends_with(".cfs"))
+        .expect("the merged segment must use the compound layout too");
+
+    // …and it must physically CARRY the BKD part. The query assertion
+    // above is not sufficient on its own: numeric range queries fall back
+    // to a scan when a segment has no BKD tree, so a merge that silently
+    // dropped the points would still answer correctly (just slowly) — the
+    // part table is the ground truth.
+    let mut input = storage.open_input(&merged_cfs).unwrap();
+    let mut bytes = Vec::new();
+    std::io::Read::read_to_end(&mut input, &mut bytes).unwrap();
+    assert!(
+        bytes.windows(b"rank.bkd".len()).any(|w| w == b"rank.bkd"),
+        "the merged container must carry the rank BKD part"
+    );
+}
+
+/// Loose (pre-#554) and compound segments coexist in one index.
+#[test]
+fn loose_and_compound_segments_coexist() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+
+    // Segment 1: loose layout (the pre-#554 default).
+    let index = InvertedIndex::create(storage.clone(), InvertedIndexConfig::default()).unwrap();
+    let mut writer = index.writer().unwrap();
+    writer.upsert_document(1, doc("alpha loose", 1)).unwrap();
+    writer.commit().unwrap();
+    drop(writer);
+    drop(index);
+
+    // Segment 2: compound layout, same directory.
+    let index = InvertedIndex::open(storage.clone(), compound_config()).unwrap();
+    let mut writer = index.writer().unwrap();
+    writer.upsert_document(2, doc("alpha packed", 2)).unwrap();
+    writer.commit().unwrap();
+
+    let searcher = index.searcher().unwrap();
+    let hits = searcher
+        .search(LexicalSearchRequest::new(Box::new(TermQuery::new(
+            "body", "alpha",
+        ))))
+        .unwrap();
+    assert_eq!(hits.hits.len(), 2, "both layouts must serve the same query");
+
+    let files = storage.list_files().unwrap();
+    assert!(files.iter().any(|f| f.ends_with(".post")), "loose segment");
+    assert!(
+        files.iter().any(|f| f.ends_with(".cfs")),
+        "compound segment"
+    );
+}
+
+/// Deletions on a compound segment: the loose `.delmap` next to the
+/// container must be found and applied — the facade's passthrough half.
+#[test]
+fn deletion_on_a_compound_segment_is_applied() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index = InvertedIndex::create(storage.clone(), compound_config()).unwrap();
+    let mut writer = index.writer().unwrap();
+    writer.upsert_document(1, doc("alpha original", 1)).unwrap();
+    writer.commit().unwrap();
+
+    // Overwrite: marks a deletion in the sealed compound segment.
+    writer.upsert_document(1, doc("alpha replaced", 1)).unwrap();
+    writer.commit().unwrap();
+
+    let searcher = index.searcher().unwrap();
+    let hits = searcher
+        .search(LexicalSearchRequest::new(Box::new(TermQuery::new(
+            "body", "original",
+        ))))
+        .unwrap();
+    assert!(
+        hits.hits.is_empty(),
+        "the superseded version must be filtered via the loose .delmap"
+    );
+    let hits = searcher
+        .search(LexicalSearchRequest::new(Box::new(TermQuery::new(
+            "body", "replaced",
+        ))))
+        .unwrap();
+    assert_eq!(hits.hits.len(), 1);
+    assert!(
+        storage
+            .list_files()
+            .unwrap()
+            .iter()
+            .any(|f| f.ends_with(".delmap")),
+        "the deletion bitmap stays a loose file next to the container"
+    );
+}


### PR DESCRIPTION
## Summary

First half of #554 (PR A of 2). Adds the Lucene-CFS-style **compound segment container** — behavior-invariant: `use_compound` defaults to false everywhere and PR B flips it. A flush currently issues one create + one fsync per data file (six fixed parts + one `.bkd` per numeric/geo field; measured: 11 creates / 5 syncs per commit); a compound flush will issue **one create + one fsync total**.

Design went through a mechanics deep-dive and an adversarial review (3 BLOCKER findings, all addressed here — details on the issue: [investigation](https://github.com/mosuka/laurus/issues/554#issuecomment-5407078142) / [plan](https://github.com/mosuka/laurus/issues/554#issuecomment-5409875375) / [PR A report](https://github.com/mosuka/laurus/issues/554#issuecomment-5411191435)).

## What's in here

- **`compound.rs`**: the self-describing `.cfs` format; `CompoundSegmentWriter` (one fsync in `finish`); `PartOutput` — a base-translating `StorageOutput` over one shared handle, translating seeks in **both directions** (`StructWriter` adopts seek return values as its counter; `BKDWriter` persists stream positions its reader interprets part-relative), with no-op close/sync and lengths from the logical high-water mark; `CompoundSegmentStorage` — a **table-then-passthrough** facade (passthrough is load-bearing: the `.delmap` probe treats a missing file as "no deletions"); windowed `PartInput`s clamping `Read`/`as_slice`/`size()`/`Seek`.
- `write_segment_files` orchestrates through a `PartSink` serving both layouts; `DocValuesWriter::write_to_output` split; the `list_files`-based path enumeration is gone.
- `SegmentReader::open` detects the layout per segment (loose segments keep working forever) and exposes `bkd_field_names()`; **the merge engine enumerates BKD fields through the reader** — the review's BLOCKER: a raw `list_files` scan finds nothing inside a container and the first merge silently drops every numeric/geo point.
- **`PrefixedStorage::loading_mode()` now delegates** — and that exposed a dormant Eager-only gate on the f32 rerank sidecar that had never fired behind the engine (the misreported `Eager` kept it asleep). "Rerank works on mmap" is the shipped, tested behavior, so the gate is removed and the HNSW inline copy unified onto the shared loader.

## Verification

- 6 unit + 7 integration tests: a **round-trip matrix** (postings / BKD / stored docs, zero-loose-files assert) over MemoryStorage, mmap FileStorage and buffered FileStorage; cold reopen; a compound-source merge asserting the merged container **physically carries** the BKD part; loose/compound coexistence; deletions via the loose `.delmap`.
- **Non-inert per element**, with a lesson worth reading in the report: numeric range queries silently fall back to a scan when a segment lacks a BKD tree, so two of the four negation proofs had to move from query-level asserts to structural/unit-level probes before they turned red.
- `cargo test --workspace --no-fail-fast`: zero failures. Clippy (CI-identical): exit 0. fmt clean.

PR B: default flip + `LAURUS_NO_COMPOUND` escape + the corrected deterministic gate (creates matching `{segment}.` == 1 AND flush_and_sync == 1 per flush) + test migration + docs.

Refs #554
