### PR TITLE
fix(engine): make the delete-then-add upsert atomic per document id

### DIFF
--- a/laurus/benches/lexical_indexing_bench.rs
+++ b/laurus/benches/lexical_indexing_bench.rs
@@ -430,6 +430,84 @@ fn bench_multi_segment_commit(c: &mut Criterion) {
     group.finish();
 }
 
+/// Thread counts swept by `ingest/concurrent`.
+fn concurrency_levels() -> Vec<usize> {
+    let cores = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(4);
+    // Include one level past the core count: the interesting question is
+    // whether added threads help, plateau, or actively hurt.
+    [1usize, 2, 4, 8, 16]
+        .into_iter()
+        .filter(|&t| t <= (cores * 2).max(2))
+        .collect()
+}
+
+/// `add_document` × N spread over T threads sharing one `Engine` (#546).
+///
+/// This is the ceiling probe for parallel ingestion. Today the lexical
+/// writer sits behind a single mutex in `LexicalStore` that is held across
+/// tokenization, so the expected shape is flat-or-worse as T rises — the
+/// baseline every later phase is measured against.
+///
+/// `iter_custom` rather than `iter`: the work has to be timed around a
+/// `thread::scope`, and the per-iteration engine setup must stay outside
+/// the measured span.
+fn bench_concurrent_ingest(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let mut group = c.benchmark_group("ingest/concurrent");
+    group.sample_size(SAMPLE_SIZE_SLOW);
+
+    // One corpus size only: the sweep of interest is T, not N, and the
+    // cross product would make the bench unusably slow.
+    const DOCS: usize = 2_000;
+
+    for t in concurrency_levels() {
+        group.throughput(Throughput::Elements(DOCS as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(t), &t, |b, &t| {
+            b.iter_custom(|iters| {
+                let mut total = std::time::Duration::ZERO;
+                for _ in 0..iters {
+                    let engine = Arc::new(rt.block_on(build_empty_engine()).unwrap());
+                    let docs = build_documents(DOCS);
+                    // Contiguous slices per thread: every document is
+                    // ingested exactly once, by exactly one thread.
+                    let per_thread = DOCS.div_ceil(t);
+                    let chunks: Vec<Vec<(String, Document)>> =
+                        docs.chunks(per_thread).map(<[_]>::to_vec).collect();
+
+                    let start = std::time::Instant::now();
+                    std::thread::scope(|scope| {
+                        for chunk in chunks {
+                            let engine = Arc::clone(&engine);
+                            scope.spawn(move || {
+                                // Each thread drives its own current-thread
+                                // runtime, so the measurement reflects the
+                                // engine's own serialization rather than a
+                                // shared executor's scheduling.
+                                let rt = tokio::runtime::Builder::new_current_thread()
+                                    .enable_all()
+                                    .build()
+                                    .unwrap();
+                                rt.block_on(async {
+                                    for (id, doc) in chunk {
+                                        engine.add_document(&id, doc).await.unwrap();
+                                    }
+                                });
+                            });
+                        }
+                    });
+                    rt.block_on(engine.commit()).unwrap();
+                    total += start.elapsed();
+                }
+                total
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_add_documents,
@@ -437,5 +515,6 @@ criterion_group!(
     bench_bulk_ingest,
     bench_bulk_ingest_batch_api,
     bench_multi_segment_commit,
+    bench_concurrent_ingest,
 );
 criterion_main!(benches);

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -355,6 +355,11 @@ impl Drop for CommitTimer {
     }
 }
 
+/// Number of shards in [`Engine::id_locks`]. Fixed rather than derived from
+/// the core count so behavior is identical everywhere; a power of two keeps
+/// the hash-to-shard mapping cheap and even.
+const ID_LOCK_SHARDS: usize = 64;
+
 /// Unified Engine that manages both Lexical and Vector indices.
 ///
 /// This engine acts as a facade, coordinating document ingestion and search
@@ -407,6 +412,20 @@ pub struct Engine {
     /// record appended by a mutation racing the commit is preserved instead of
     /// being wiped by the truncate. `Arc` so the [`CommitTimer`] shares it.
     applied_seq: Arc<AtomicU64>,
+    /// Per-external-id serialization for the delete-then-add upsert (#1049).
+    ///
+    /// [`Self::index_internal`] deletes any existing versions of an id and
+    /// then indexes the new one; every step takes the underlying store locks
+    /// separately, so without this two threads upserting the same id both
+    /// find-and-delete, then both add, and the id ends up with several live
+    /// versions. Sharded by hash so only genuine same-id contention
+    /// serializes — distinct ids keep ingesting in parallel.
+    ///
+    /// A `tokio::sync::Mutex` because the guard is held across `await`
+    /// points. It is the OUTERMOST lock wherever it is taken, so it cannot
+    /// invert against the lexical writer → searcher order that
+    /// [`LexicalStore::find_doc_ids_by_term`] maintains.
+    id_locks: Arc<Vec<tokio::sync::Mutex<()>>>,
     /// Background WAL flush timer for a [`WalSyncPolicy::Group`] configured with
     /// a `max_interval`. `None` when no interval is set. Held only to keep the
     /// timer thread alive for the engine's lifetime; dropping the engine stops
@@ -814,6 +833,14 @@ impl Engine {
         // DynamicFieldPolicy to add / coerce / drop user fields.
         self.apply_dynamic_schema(&mut doc).await?;
 
+        // Serialize everything that follows against other mutations of this
+        // same id (#1049). The delete and the add below take the store locks
+        // separately, so without this guard two concurrent upserts of one id
+        // both delete-then-add and leave two live versions. Held across the
+        // whole sequence, including the WAL append, so the log's record order
+        // for an id matches the order the stores applied them in.
+        let _id_guard = self.id_lock(id).lock().await;
+
         if !as_chunk {
             self.delete_documents_internal(id).await?;
         }
@@ -1071,6 +1098,11 @@ impl Engine {
     /// Returns an error if the WAL write, lexical deletion, or vector
     /// deletion fails for any matched document.
     pub async fn delete_documents(&self, id: &str) -> Result<()> {
+        // Same-id serialization as the upsert path (#1049): without it a
+        // delete can interleave between a concurrent upsert's own delete and
+        // its add, so the upsert's new version outlives the delete that was
+        // acknowledged after it.
+        let _id_guard = self.id_lock(id).lock().await;
         self.delete_documents_internal(id).await?;
         // Re-assert per-record durability: a concurrent batch may hold a WAL
         // sync-deferral scope, which would otherwise leave these acknowledged
@@ -1092,6 +1124,23 @@ impl Engine {
     ///
     /// Returns an error if the WAL write, lexical deletion, or vector
     /// deletion fails for any matched document.
+    /// The shard serializing mutations of `id` (#1049).
+    ///
+    /// # Parameters
+    ///
+    /// - `id` - The external document identifier to map to a shard.
+    ///
+    /// # Returns
+    ///
+    /// The [`tokio::sync::Mutex`] guarding every mutation of this id.
+    fn id_lock(&self, id: &str) -> &tokio::sync::Mutex<()> {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = ahash::AHasher::default();
+        id.hash(&mut hasher);
+        // ID_LOCK_SHARDS is a power of two, so the mask is exact.
+        &self.id_locks[hasher.finish() as usize & (ID_LOCK_SHARDS - 1)]
+    }
+
     async fn delete_documents_internal(&self, id: &str) -> Result<()> {
         let doc_ids = self.lexical.find_doc_ids_by_term("_id", id)?;
         for doc_id in doc_ids {
@@ -2766,6 +2815,11 @@ impl EngineBuilder {
             commit_policy: self.commit_policy,
             docs_since_commit,
             applied_seq,
+            id_locks: Arc::new(
+                (0..ID_LOCK_SHARDS)
+                    .map(|_| tokio::sync::Mutex::new(()))
+                    .collect(),
+            ),
             #[cfg(not(target_arch = "wasm32"))]
             _wal_flush_timer: wal_flush_timer,
             #[cfg(not(target_arch = "wasm32"))]

--- a/laurus/tests/concurrent_ingest_test.rs
+++ b/laurus/tests/concurrent_ingest_test.rs
@@ -1,0 +1,305 @@
+//! Correctness of ingestion driven from several threads at once (#546).
+//!
+//! Today the lexical writer sits behind a single mutex in `LexicalStore`,
+//! so concurrent `put_document` / `add_document` calls are serialized and
+//! these tests pass by construction. They exist because the DWPT work
+//! removes that serialization: every invariant asserted here is one that
+//! per-thread ingestion can break silently — a document indexed but not
+//! findable, an update that leaves both versions live, counters that
+//! drift from the documents actually present, or WAL state that replays
+//! to something different from what was acknowledged.
+//!
+//! Each test therefore asserts an *observable* property, never an
+//! implementation detail, so it keeps its meaning across the refactor.
+
+use std::sync::Arc;
+
+use laurus::lexical::TextOption;
+use laurus::storage::Storage;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::{DataValue, Document, Engine, FieldOption, Schema};
+
+/// Threads used by the concurrent tests. Fixed rather than derived from
+/// the host's core count so a CI runner and a workstation exercise the
+/// same interleaving pressure.
+const THREADS: usize = 8;
+/// Documents per thread.
+const PER_THREAD: usize = 50;
+
+fn schema() -> Schema {
+    Schema::builder()
+        .add_field("title", FieldOption::Text(TextOption::default()))
+        .add_field("owner", FieldOption::Text(TextOption::default()))
+        .build()
+}
+
+fn doc(title: &str, owner: &str) -> Document {
+    Document::builder()
+        .add_field("title", DataValue::Text(title.into()))
+        .add_field("owner", DataValue::Text(owner.into()))
+        .build()
+}
+
+/// Run `body` on `THREADS` OS threads, each with its own current-thread
+/// runtime, and wait for all of them.
+///
+/// Deliberately not `tokio::spawn` on a shared multi-thread runtime: the
+/// point is to have genuinely concurrent callers of the engine, not tasks
+/// that a single executor may end up running one after another.
+fn in_parallel<F>(body: F)
+where
+    F: Fn(usize) + Send + Sync,
+{
+    let body = &body;
+    std::thread::scope(|scope| {
+        for t in 0..THREADS {
+            scope.spawn(move || body(t));
+        }
+    });
+}
+
+/// Every document ingested concurrently must be present exactly once.
+///
+/// The failure this guards against is the one that stays invisible to
+/// `document_count`: a document that was accepted, counted, and yet is not
+/// retrievable — or is retrievable twice.
+#[test]
+fn concurrent_ingest_keeps_every_document_exactly_once() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let setup = tokio::runtime::Runtime::new().unwrap();
+    let engine = Arc::new(setup.block_on(Engine::new(storage, schema())).unwrap());
+
+    {
+        let engine = Arc::clone(&engine);
+        in_parallel(move |t| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                for i in 0..PER_THREAD {
+                    let id = format!("t{t}-d{i}");
+                    engine
+                        .put_document(&id, doc(&format!("title {t} {i}"), &format!("owner{t}")))
+                        .await
+                        .unwrap();
+                }
+            });
+        });
+    }
+
+    setup.block_on(engine.commit()).unwrap();
+
+    let total = THREADS * PER_THREAD;
+    let stats = engine.stats().unwrap();
+    assert_eq!(
+        stats.document_count, total as u64,
+        "the engine must count every concurrently ingested document"
+    );
+
+    // Counters agreeing is not enough: each document must actually be
+    // retrievable, and exactly once.
+    setup.block_on(async {
+        for t in 0..THREADS {
+            for i in 0..PER_THREAD {
+                let id = format!("t{t}-d{i}");
+                let docs = engine.get_documents(&id).await.unwrap();
+                assert_eq!(docs.len(), 1, "{id} must resolve to exactly one document");
+            }
+        }
+    });
+}
+
+/// Concurrent updates of the same ids must leave exactly one version each.
+///
+/// `put_document` is delete-then-add. Per-thread ingestion is where that
+/// can go wrong quietly: if a thread cannot see a document another thread
+/// has buffered, its update adds a second live copy instead of replacing
+/// the first, and the duplicate only shows up as an extra search hit.
+#[test]
+fn concurrent_updates_leave_exactly_one_version_per_id() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let setup = tokio::runtime::Runtime::new().unwrap();
+    let engine = Arc::new(setup.block_on(Engine::new(storage, schema())).unwrap());
+
+    // Seed one version of every id, committed.
+    setup.block_on(async {
+        for i in 0..PER_THREAD {
+            engine
+                .put_document(&format!("shared-{i}"), doc("original", "seed"))
+                .await
+                .unwrap();
+        }
+        engine.commit().await.unwrap();
+    });
+
+    // Every thread rewrites every id: each id ends up with one winner,
+    // whichever thread got there last.
+    {
+        let engine = Arc::clone(&engine);
+        in_parallel(move |t| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                for i in 0..PER_THREAD {
+                    engine
+                        .put_document(
+                            &format!("shared-{i}"),
+                            doc(&format!("rewritten by {t}"), &format!("owner{t}")),
+                        )
+                        .await
+                        .unwrap();
+                }
+            });
+        });
+    }
+
+    setup.block_on(engine.commit()).unwrap();
+
+    setup.block_on(async {
+        for i in 0..PER_THREAD {
+            let id = format!("shared-{i}");
+            let docs = engine.get_documents(&id).await.unwrap();
+            assert_eq!(
+                docs.len(),
+                1,
+                "{id} must have exactly one live version after concurrent updates"
+            );
+        }
+    });
+
+    let stats = engine.stats().unwrap();
+    assert_eq!(
+        stats.document_count, PER_THREAD as u64,
+        "concurrent updates must not inflate the document count"
+    );
+}
+
+/// Documents ingested concurrently and never committed must all come back
+/// after a reopen.
+///
+/// This is the crash-shaped invariant. Per-thread ingestion aggregates a
+/// WAL checkpoint across writers, and taking the maximum rather than the
+/// minimum would silently drop the records of whichever writer lagged —
+/// visible only after a restart, never on the happy path.
+#[test]
+fn uncommitted_concurrent_ingest_survives_a_reopen() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let total = THREADS * PER_THREAD;
+
+    {
+        let setup = tokio::runtime::Runtime::new().unwrap();
+        let engine = Arc::new(
+            setup
+                .block_on(Engine::new(storage.clone(), schema()))
+                .unwrap(),
+        );
+        let ingest = Arc::clone(&engine);
+        in_parallel(move |t| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                for i in 0..PER_THREAD {
+                    ingest
+                        .put_document(&format!("t{t}-d{i}"), doc("durable", &format!("owner{t}")))
+                        .await
+                        .unwrap();
+                }
+            });
+        });
+        // Dropped without commit: durability must come from the WAL alone.
+    }
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let reopened = rt.block_on(Engine::new(storage, schema())).unwrap();
+    rt.block_on(reopened.commit()).unwrap();
+
+    let stats = reopened.stats().unwrap();
+    assert_eq!(
+        stats.document_count, total as u64,
+        "every acknowledged document must replay from the WAL after a reopen"
+    );
+    rt.block_on(async {
+        for t in 0..THREADS {
+            for i in 0..PER_THREAD {
+                let id = format!("t{t}-d{i}");
+                let docs = reopened.get_documents(&id).await.unwrap();
+                assert_eq!(docs.len(), 1, "{id} must survive the reopen");
+            }
+        }
+    });
+}
+
+/// Concurrent deletes must remove exactly the targeted documents.
+///
+/// Deletions are group-committed and the writer resolves a document to its
+/// segment by doc-id range. Per-thread ingestion makes those ranges
+/// overlap, at which point a delete can be attributed to a segment that
+/// never held the document — inflating the deleted count while leaving the
+/// real one alive.
+#[test]
+fn concurrent_deletes_remove_exactly_their_targets() {
+    let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let setup = tokio::runtime::Runtime::new().unwrap();
+    let engine = Arc::new(setup.block_on(Engine::new(storage, schema())).unwrap());
+
+    setup.block_on(async {
+        for t in 0..THREADS {
+            for i in 0..PER_THREAD {
+                engine
+                    .put_document(&format!("t{t}-d{i}"), doc("target", &format!("owner{t}")))
+                    .await
+                    .unwrap();
+            }
+        }
+        engine.commit().await.unwrap();
+    });
+
+    // Each thread deletes only its own even-numbered documents.
+    {
+        let engine = Arc::clone(&engine);
+        in_parallel(move |t| {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                for i in (0..PER_THREAD).step_by(2) {
+                    engine
+                        .delete_documents(&format!("t{t}-d{i}"))
+                        .await
+                        .unwrap();
+                }
+            });
+        });
+    }
+
+    setup.block_on(engine.commit()).unwrap();
+
+    setup.block_on(async {
+        for t in 0..THREADS {
+            for i in 0..PER_THREAD {
+                let id = format!("t{t}-d{i}");
+                let docs = engine.get_documents(&id).await.unwrap();
+                let expected = usize::from(i % 2 != 0);
+                assert_eq!(
+                    docs.len(),
+                    expected,
+                    "{id} must be {} after the concurrent deletes",
+                    if expected == 0 { "gone" } else { "present" }
+                );
+            }
+        }
+    });
+
+    let survivors = (THREADS * PER_THREAD - THREADS * PER_THREAD.div_ceil(2)) as u64;
+    let stats = engine.stats().unwrap();
+    assert_eq!(
+        stats.document_count, survivors,
+        "the count must match the documents that actually survived"
+    );
+}


### PR DESCRIPTION
## Summary

`Engine::put_document` is an upsert — delete every existing version of the external id, then index the new one — but the two halves took the store locks separately, so concurrent upserts of the same id both survived. A new test reproduces **5 live versions of one id across 8 threads** on `main`.

Concurrency is not out of scope for this path: `index_internal` already reasons about it, and its `applied_seq.fetch_max` is commented as keeping the high-water mark monotonic "under concurrent writers".

The fix serializes **per external id**, not globally: 64 shards of `tokio::sync::Mutex` selected by hashing the id, with the guard held across the delete, the WAL append and both stores' index updates. The public delete path takes the same lock, which also closes the delete-versus-upsert window. Distinct ids keep ingesting in parallel.

## Also: the #546 Phase A scaffold, which is what found this

- `ingest/concurrent/{T}` sweeps T ∈ {1,2,4,8,16} over one shared `Engine`
- `laurus/tests/concurrent_ingest_test.rs` asserts observable invariants only, so the tests keep their meaning through the DWPT refactor

**The baseline it establishes**: 2,000 documents take 99.3 ms at T=1 and 100.8 ms at T=16. Sixteen threads buy nothing — complete serialization behind the writer mutex. (An earlier pass reported an apparent 2x *degradation* at T=16; that was measurement contamination, corrected by re-running A/B/A on an idle host.)

## Test plan

- RED proof: `concurrent_updates_leave_exactly_one_version_per_id` fails on `main` with 5 live versions
- Inert proof: removing the id lock in `index_internal` turns exactly that test red again, leaving the other three green
- Throughput, measured A/B/A with a null pair: no measurable change at T=4/8/16 (within 1%, the null pair's own spread being 0.5%). T=2 showed +12% on the first pass and did not reproduce — repeats gave 88.24 ms and 91.58 ms against a no-fix range of 88.88–92.18 ms, so the initial sample was an outlier
- `cargo test --workspace --no-fail-fast` all green; CI-identical clippy clean; `cargo fmt --all --check` clean

Closes #1049
Refs #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)
