### PR TITLE
fix(lexical): size the flush budget from the document, not a constant

### DIFF
--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -915,6 +915,52 @@ mod tests {
         assert!(files.iter().any(|f| f.contains("segment_000000")));
     }
 
+    /// #557: the flush memory budget must account for a document's actual
+    /// buffered size, not a flat per-document constant.
+    ///
+    /// `estimate_memory_usage` charged 1 KB per document plus 256 bytes per
+    /// distinct term, so a document carrying thousands of BKD points — a
+    /// multi-valued numeric or geo field — slipped past `max_buffer_memory`
+    /// entirely. The repeated values keep the term vocabulary small and
+    /// constant, so the term half of the old estimate cannot compensate:
+    /// only the point/term *instances* grow, and those were uncounted.
+    #[test]
+    fn flush_budget_counts_multi_valued_point_data() {
+        let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+        let config = InvertedIndexWriterConfig {
+            // Effectively disable the count trigger so only the memory
+            // budget can fire.
+            max_buffered_docs: 100_000,
+            max_buffer_memory: 1024 * 1024,
+            ..Default::default()
+        };
+
+        let mut writer = InvertedIndexWriter::new(storage, config).unwrap();
+
+        // Each document carries 2000 points drawn from a 100-value
+        // vocabulary: ~64 KB of real point data per document, while the
+        // distinct-term count stays pinned at 100 for the whole run.
+        let values: Vec<i64> = (0..2000).map(|i| i % 100).collect();
+        for _ in 0..40 {
+            let doc = Document::builder()
+                .add_field(
+                    "readings",
+                    crate::data::DataValue::Int64Array(values.clone()),
+                )
+                .build();
+            writer.add_document(doc).unwrap();
+        }
+
+        // 40 documents x ~64 KB is far past the 1 MB budget, so the writer
+        // must have flushed at least once instead of buffering all of them.
+        assert!(
+            writer.stats().segments_created >= 1,
+            "the memory budget must fire on point-heavy documents: \
+             {} docs still buffered, no segment flushed",
+            writer.pending_docs()
+        );
+    }
+
     #[test]
     fn test_commit() {
         let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -138,6 +138,11 @@ pub struct InvertedIndexWriter {
 
     /// Buffered analyzed documents with their assigned doc IDs.
     buffered_docs: Vec<(u64, AnalyzedDocument)>,
+    /// Running estimate of the heap `buffered_docs` occupies (#557).
+    ///
+    /// Maintained incrementally because `should_flush` consults it on every
+    /// document; walking the buffer instead would make ingestion quadratic.
+    buffered_bytes: usize,
 
     /// Whether [`Self::inverted_index`] / [`Self::doc_values_writer`] are stale
     /// relative to [`Self::buffered_docs`] and need a rebuild before flush.
@@ -406,6 +411,7 @@ impl InvertedIndexWriter {
             config,
             inverted_index: TermPostingIndex::new(),
             buffered_docs: Vec::new(),
+            buffered_bytes: 0,
             index_dirty: false,
             buffered_doc_ids: AHashSet::new(),
             doc_values_writer,
@@ -501,6 +507,7 @@ impl InvertedIndexWriter {
         self.add_analyzed_document_to_index(doc_id, &analyzed_doc)?;
 
         // Buffer the document with its assigned ID
+        self.track_buffered(&analyzed_doc);
         self.buffered_docs.push((doc_id, analyzed_doc));
         self.buffered_doc_ids.insert(doc_id);
         self.stats.docs_added += 1;
@@ -918,17 +925,82 @@ impl InvertedIndexWriter {
     }
 
     /// Check if we should flush the current segment.
+    /// Estimate the heap an [`AnalyzedDocument`] occupies while buffered.
+    ///
+    /// Deliberately an estimate, not an exact accounting: it exists to keep
+    /// `max_buffer_memory` proportional to what a document actually costs, so
+    /// point-heavy or text-heavy documents cannot slip past the flush budget
+    /// (#557). The three terms that scale with document content are counted —
+    /// BKD points, analyzed terms, and stored values — plus a small constant
+    /// for the per-field map entries.
+    fn estimate_analyzed_size(doc: &AnalyzedDocument) -> usize {
+        /// Per-field overhead: the name plus its slot in each of the maps.
+        const FIELD_OVERHEAD: usize = 64;
+
+        let mut bytes = 0usize;
+
+        for (name, points) in &doc.point_values {
+            // A point is a `Vec<f64>`: its header plus `dims` doubles.
+            let dims = points.first().map_or(0, Vec::len);
+            let per_point = std::mem::size_of::<Vec<f64>>() + dims * std::mem::size_of::<f64>();
+            bytes += FIELD_OVERHEAD + name.len() + points.len() * per_point;
+        }
+
+        for (name, terms) in &doc.field_terms {
+            bytes +=
+                FIELD_OVERHEAD + name.len() + terms.len() * std::mem::size_of::<AnalyzedTerm>();
+            // The term strings themselves live on the heap.
+            bytes += terms.iter().map(|t| t.term.len()).sum::<usize>();
+        }
+
+        for (name, value) in &doc.stored_fields {
+            bytes += FIELD_OVERHEAD + name.len() + Self::estimate_value_size(value);
+        }
+
+        bytes
+    }
+
+    /// Estimate the heap a stored [`DataValue`] occupies.
+    fn estimate_value_size(value: &crate::data::DataValue) -> usize {
+        use crate::data::DataValue;
+
+        let inline = std::mem::size_of::<DataValue>();
+        let heap = match value {
+            DataValue::Text(s) => s.len(),
+            DataValue::Bytes(b, mime) => b.len() + mime.as_ref().map_or(0, String::len),
+            DataValue::Vector(v) => v.len() * std::mem::size_of::<f32>(),
+            DataValue::Int64Array(v) => v.len() * std::mem::size_of::<i64>(),
+            DataValue::Float64Array(v) => v.len() * std::mem::size_of::<f64>(),
+            // The remaining variants are fixed-size and already covered by
+            // `size_of::<DataValue>()`.
+            _ => 0,
+        };
+        inline + heap
+    }
+
     fn should_flush(&self) -> bool {
         self.buffered_docs.len() >= self.config.max_buffered_docs
             || self.estimate_memory_usage() >= self.config.max_buffer_memory
     }
 
     /// Estimate current memory usage.
+    ///
+    /// The buffered-document half is a running total maintained by
+    /// [`Self::track_buffered`] and the removal path, not a walk of
+    /// `buffered_docs`: this runs from [`Self::should_flush`] on every
+    /// document, so recomputing it would make ingestion quadratic.
     fn estimate_memory_usage(&self) -> usize {
-        // Rough estimation
-        let doc_memory = self.buffered_docs.len() * 1024; // 1KB per doc estimate
-        let index_memory = self.inverted_index.term_count() as usize * 256; // 256 bytes per term estimate
-        doc_memory + index_memory
+        // 256 bytes per distinct term covers the in-memory posting index,
+        // whose size tracks the vocabulary rather than the document count.
+        let index_memory = self.inverted_index.term_count() as usize * 256;
+        self.buffered_bytes + index_memory
+    }
+
+    /// Add `doc`'s estimated footprint to the buffered total.
+    fn track_buffered(&mut self, doc: &AnalyzedDocument) {
+        self.buffered_bytes = self
+            .buffered_bytes
+            .saturating_add(Self::estimate_analyzed_size(doc));
     }
 
     /// Flush the current segment to disk.
@@ -981,6 +1053,7 @@ impl InvertedIndexWriter {
 
         // Clear buffers
         self.buffered_docs.clear();
+        self.buffered_bytes = 0;
         self.buffered_doc_ids.clear();
         self.index_dirty = false;
         self.inverted_index = TermPostingIndex::new();
@@ -1070,6 +1143,7 @@ impl InvertedIndexWriter {
         let paths = self.write_segment_files(segment_name)?;
         self.extend_segment_cache(segment_name);
         self.buffered_docs.clear();
+        self.buffered_bytes = 0;
         self.buffered_doc_ids.clear();
         self.index_dirty = false;
         self.inverted_index = TermPostingIndex::new();
@@ -1742,6 +1816,7 @@ impl InvertedIndexWriter {
 
         // Clear all buffers
         self.buffered_docs.clear();
+        self.buffered_bytes = 0;
         self.buffered_doc_ids.clear();
         self.index_dirty = false;
         self.inverted_index = TermPostingIndex::new();
@@ -1828,6 +1903,17 @@ impl InvertedIndexWriter {
         // buffer is O(M)+O(N) instead of O(M·N) (Issue #828). Until the rebuild,
         // the in-memory index still holds this doc's postings; the NRT lookups
         // filter them out via `buffered_doc_ids`.
+        // Drop the removed documents' footprint from the running total
+        // before they go (#557). Summed over every match, because `retain`
+        // below removes all of them, and computed first so the immutable
+        // borrow ends before `buffered_bytes` is written.
+        let removed_bytes: usize = self
+            .buffered_docs
+            .iter()
+            .filter(|(id, _)| *id == doc_id)
+            .map(|(_, doc)| Self::estimate_analyzed_size(doc))
+            .sum();
+        self.buffered_bytes = self.buffered_bytes.saturating_sub(removed_bytes);
         self.buffered_docs.retain(|(id, _)| *id != doc_id);
         self.index_dirty = true;
 
@@ -2318,5 +2404,84 @@ impl PartSink<'_> {
                 Ok(vec![container])
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::data::DataValue;
+
+    /// An `AnalyzedDocument` carrying only `point_values`.
+    fn doc_with_points(count: usize, dims: usize) -> AnalyzedDocument {
+        let mut point_values = AHashMap::new();
+        point_values.insert(
+            "coords".to_string(),
+            (0..count).map(|i| vec![i as f64; dims]).collect(),
+        );
+        AnalyzedDocument {
+            field_terms: AHashMap::new(),
+            stored_fields: AHashMap::new(),
+            field_lengths: AHashMap::new(),
+            point_values,
+        }
+    }
+
+    /// #557: the size estimate must scale with the number of BKD points.
+    ///
+    /// Probed on a document with *no* terms and *no* stored fields, because
+    /// every field type that produces points also produces terms — so an
+    /// end-to-end test is satisfied by the term half alone and would pass
+    /// even with the point accounting removed.
+    #[test]
+    fn size_estimate_scales_with_point_count() {
+        let few = InvertedIndexWriter::estimate_analyzed_size(&doc_with_points(10, 2));
+        let many = InvertedIndexWriter::estimate_analyzed_size(&doc_with_points(1000, 2));
+
+        assert!(
+            many > few * 50,
+            "1000 points must estimate far above 10 points, got {many} vs {few}"
+        );
+    }
+
+    /// #557: dimensionality is part of a point's cost — a 3D point holds
+    /// more doubles than a 1D one.
+    #[test]
+    fn size_estimate_scales_with_point_dimensionality() {
+        let one_d = InvertedIndexWriter::estimate_analyzed_size(&doc_with_points(1000, 1));
+        let three_d = InvertedIndexWriter::estimate_analyzed_size(&doc_with_points(1000, 3));
+
+        assert!(
+            three_d > one_d,
+            "3D points must estimate above 1D points, got {three_d} vs {one_d}"
+        );
+    }
+
+    /// #557: stored values count too. A `Bytes` field is the clean probe —
+    /// it is stored but never lexically indexed, so it contributes no terms
+    /// and no points.
+    #[test]
+    fn size_estimate_scales_with_stored_payload() {
+        let mut small = AnalyzedDocument {
+            field_terms: AHashMap::new(),
+            stored_fields: AHashMap::new(),
+            field_lengths: AHashMap::new(),
+            point_values: AHashMap::new(),
+        };
+        let mut large = small.clone();
+        small
+            .stored_fields
+            .insert("blob".to_string(), DataValue::Bytes(vec![0u8; 16], None));
+        large.stored_fields.insert(
+            "blob".to_string(),
+            DataValue::Bytes(vec![0u8; 64 * 1024], None),
+        );
+
+        let small_estimate = InvertedIndexWriter::estimate_analyzed_size(&small);
+        let large_estimate = InvertedIndexWriter::estimate_analyzed_size(&large);
+        assert!(
+            large_estimate > small_estimate + 60_000,
+            "a 64 KiB payload must dominate the estimate, got {large_estimate} vs {small_estimate}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the S-sized half of #557. `estimate_memory_usage` was a flat 1 KB per buffered document plus 256 bytes per distinct term — it never looked at how large a document actually is, so `max_buffer_memory` (64 MB by default) could not bound a buffer of point-heavy, term-heavy or payload-heavy documents. Only the `max_buffered_docs` count trigger held it back.

The issue describes this as BKD points being uncounted. They are, but so are analyzed terms and stored values: the omission is all three.

- `estimate_analyzed_size` now estimates what scales with document content — a point costs its `Vec<f64>` header plus `dims` doubles, a term its struct plus the term string, a stored value the heap its variant owns.
- The buffered total is a **running counter**, not a recomputation: `should_flush` consults the estimate once per document, so walking the buffer there would trade an unbounded buffer for a quadratic one. Incremented on push, decremented on removal (summed over every match, since `retain` drops them all), reset on flush and rollback.

## Test plan

- End-to-end (`flush_budget_counts_multi_valued_point_data`): the count trigger disabled, a 1 MB budget, 40 documents each carrying 2,000 point values. Before the fix all 40 stay buffered and nothing flushes.
- Three unit tests drive `estimate_analyzed_size` directly on `AnalyzedDocument`s carrying points **without** terms or stored fields — a shape the analyzer cannot produce, since every point-producing field type also emits terms.

That second shape is load-bearing, not belt-and-braces: negating only the point accounting leaves the end-to-end test **green**, because `Int64Array` emits one term per element and the term half satisfies the budget on its own. The end-to-end test alone would have been a vacuous guard for the point half.

Inert proofs:

- revert the whole estimate to the flat 1 KB constant → the end-to-end test goes red
- negate only the point accounting → the two point unit tests go red, the stored-payload one stays green

`cargo fmt --all --check` clean; `cargo test --workspace --no-fail-fast` all green; CI-identical clippy clean.

## Left open

`Refs #557` rather than `Closes`: the offline-sort rewrite (the L half) stays open, as does the finding from the re-triage that merge sets `max_buffered_docs: usize::MAX` / `max_buffer_memory: usize::MAX` deliberately and so holds a whole segment in memory. That one is unaffected here — the budget it disables is exactly the budget this repairs — and is worth splitting into its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
