### PR TITLE
perf(lexical): keep binary payloads out of DocValues

### DIFF
--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -497,10 +497,13 @@ impl InvertedIndexWriter {
             self.next_doc_id = doc_id + 1;
         }
 
-        // Add field values to DocValues
+        // Add field values to DocValues, skipping payloads no consumer of
+        // DocValues can use (#1047).
         for (field_name, value) in &analyzed_doc.stored_fields {
-            self.doc_values_writer
-                .add_value(doc_id, field_name, value.clone());
+            if Self::is_doc_values_candidate(value) {
+                self.doc_values_writer
+                    .add_value(doc_id, field_name, value.clone());
+            }
         }
 
         // Add to inverted index
@@ -925,6 +928,24 @@ impl InvertedIndexWriter {
     }
 
     /// Check if we should flush the current segment.
+    /// Whether a stored value is worth a DocValues column (#1047).
+    ///
+    /// DocValues serves sorting and faceting only. Sorting cannot order
+    /// `Bytes` or `Vector` values — [`sort_type_rank`] gives each variant a
+    /// single rank with no inner comparison, so every value of such a field
+    /// compares equal — and faceting reads the stored document when a column
+    /// is absent. Copying these payloads into a second on-disk structure
+    /// therefore doubles what the segment writes and buys nothing; a
+    /// thumbnail or an embedding is often the largest value in the document.
+    ///
+    /// [`sort_type_rank`]: crate::lexical::query::collector
+    fn is_doc_values_candidate(value: &crate::data::DataValue) -> bool {
+        !matches!(
+            value,
+            crate::data::DataValue::Bytes(_, _) | crate::data::DataValue::Vector(_)
+        )
+    }
+
     /// Estimate the heap an [`AnalyzedDocument`] occupies while buffered.
     ///
     /// Deliberately an estimate, not an exact accounting: it exists to keep
@@ -1940,10 +1961,13 @@ impl InvertedIndexWriter {
         // Re-add all buffered analyzed docs
         let buffered_snapshot = self.buffered_docs.clone();
         for (id, analyzed_doc) in buffered_snapshot {
-            // Re-add stored fields to DocValues
+            // Re-add stored fields to DocValues, under the same filter as
+            // the ingest path (#1047) so a rebuild cannot reintroduce them.
             for (field_name, value) in &analyzed_doc.stored_fields {
-                self.doc_values_writer
-                    .add_value(id, field_name, value.clone());
+                if Self::is_doc_values_candidate(value) {
+                    self.doc_values_writer
+                        .add_value(id, field_name, value.clone());
+                }
             }
 
             // Re-add postings
@@ -2454,6 +2478,99 @@ mod tests {
         assert!(
             three_d > one_d,
             "3D points must estimate above 1D points, got {three_d} vs {one_d}"
+        );
+    }
+
+    /// #1047 gate: the DocValues payload must not scale with binary
+    /// stored fields.
+    #[test]
+    fn doc_values_payload_does_not_scale_with_binary_fields() {
+        let build = |payload: usize| -> usize {
+            let storage = Arc::new(crate::storage::memory::MemoryStorage::new(
+                crate::storage::memory::MemoryStorageConfig::default(),
+            ));
+            let mut writer =
+                InvertedIndexWriter::new(storage, InvertedIndexWriterConfig::default()).unwrap();
+            for i in 0..20u64 {
+                let doc = Document::builder()
+                    .add_field("title", crate::data::DataValue::Text(format!("doc {i}")))
+                    .add_field(
+                        "blob",
+                        crate::data::DataValue::Bytes(vec![7u8; payload], None),
+                    )
+                    .build();
+                writer.upsert_document(i, doc).unwrap();
+            }
+            let mut out: Vec<u8> = Vec::new();
+            writer.doc_values_writer.write_to_output(&mut out).unwrap();
+            out.len()
+        };
+
+        let small = build(64);
+        let large = build(16 * 1024);
+        assert_eq!(
+            small, large,
+            "the DocValues payload must be identical regardless of binary field size, \
+             got {small} vs {large}"
+        );
+    }
+
+    /// #1047: binary payloads must not be copied into DocValues.
+    ///
+    /// DocValues exists to serve sorting and faceting. Neither can do
+    /// anything with a `Bytes` or `Vector` value — `sort_type_rank` gives
+    /// every such value the same rank with no inner comparison, and facet
+    /// values are read from the stored document when a column is absent —
+    /// so copying multi-kilobyte payloads into a second on-disk structure
+    /// buys nothing and doubles what the segment writes.
+    ///
+    /// Asserted on the serialized DocValues payload rather than on writer
+    /// internals: bytes on disk are what this is about.
+    #[test]
+    fn binary_payloads_are_kept_out_of_doc_values() {
+        let storage = Arc::new(crate::storage::memory::MemoryStorage::new(
+            crate::storage::memory::MemoryStorageConfig::default(),
+        ));
+        let mut writer =
+            InvertedIndexWriter::new(storage, InvertedIndexWriterConfig::default()).unwrap();
+
+        const PAYLOAD: usize = 32 * 1024;
+        let doc = Document::builder()
+            .add_field("title", crate::data::DataValue::Text("sortable".into()))
+            .add_field(
+                "thumbnail",
+                crate::data::DataValue::Bytes(vec![7u8; PAYLOAD], None),
+            )
+            .add_field(
+                "embedding",
+                crate::data::DataValue::Vector(vec![0.5f32; 4096]),
+            )
+            .build();
+        writer.add_document(doc).unwrap();
+
+        let mut serialized: Vec<u8> = Vec::new();
+        writer
+            .doc_values_writer
+            .write_to_output(&mut serialized)
+            .unwrap();
+
+        let names = String::from_utf8_lossy(&serialized).to_string();
+        assert!(
+            names.contains("title"),
+            "a sortable field must still get a DocValues column"
+        );
+        assert!(
+            !names.contains("thumbnail"),
+            "a Bytes payload must not be copied into DocValues"
+        );
+        assert!(
+            !names.contains("embedding"),
+            "a Vector payload must not be copied into DocValues"
+        );
+        assert!(
+            serialized.len() < PAYLOAD,
+            "the DocValues payload must not carry the binary blob: {} bytes",
+            serialized.len()
         );
     }
 


### PR DESCRIPTION
## Summary

First of two PRs for #1047. Every stored field value was copied into the DocValues column store as well as the stored-documents part, with no way to opt a field out. This removes the copy for the values no consumer of DocValues can use.

DocValues exists to serve sorting and faceting. Sorting cannot order a `Bytes` or `Vector` value — `sort_type_rank` (`collector.rs:336-352`) gives each variant a single rank with no inner comparison, so every value of such a field compares equal. Faceting reads the stored document whenever a column is absent (`facet.rs:296-305`), so it sees the same values either way. A thumbnail or an embedding is often the largest value in a document, and it was being written twice.

Both feed sites are gated: the ingest path, and the rebuild that runs after a deletion — missing the second would let the payloads back in on the next rebuild.

No API change, no format change, no binding impact.

## Test plan

- `binary_payloads_are_kept_out_of_doc_values` inspects the serialized DocValues payload: `title` present, `thumbnail` and `embedding` absent, total length below the payload size.
- `doc_values_payload_does_not_scale_with_binary_fields` is the real gate — the serialized payload is byte-for-byte **identical** for a 64-byte and a 16 KiB binary field. Bytes on disk are what this issue is about, so that is what the gate measures.

RED proven before the change (the payload contained `thumbnail`). Inert-proven after: disabling the exclusion turns exactly these two red while the three #557 estimator tests in the same module stay green, so the components are separable.

`cargo fmt --all --check` clean; `cargo test --workspace --no-fail-fast` all green; CI-identical clippy clean.

## Two things deliberately not here

**The per-field `doc_values` flag** is the follow-up. It has to default to `true` for back-compat, so it does not reduce anything on its own — it is a knob, and it needs the item below landed with it.

**The sort-side stored-document fallback** was planned for this PR and is not in it. I could not demonstrate it running: a test built on a mixed-type field produced the same ordering with the fallback disabled as with it enabled, which means the test was not exercising the path I believed it was. Rather than ship code I cannot show is reached, it moves to PR-2, where `doc_values: false` makes a stored, genuinely sortable field without a column constructible — and therefore testable — through the ordinary search path.

## Known unproven consequence

A `Bytes` value in a sort field now resolves to `Null` (rank 0) instead of `Bytes` (rank 7), so in a field holding mixed types those documents land elsewhere relative to documents of other types. Sorting on such a field carries no information either way, but I could not construct a test exercising the difference, so this is stated rather than demonstrated. PR-2's fallback restores the previous ordering.

Refs #1047

🤖 Generated with [Claude Code](https://claude.com/claude-code)
