### PR TITLE
feat(python): support custom analyzer definitions and TOML schema loading in laurus-python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,7 +2927,9 @@ dependencies = [
  "chrono",
  "laurus",
  "pyo3",
+ "serde_json",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -210,6 +210,12 @@ class Schema:
 | Method | Description |
 | :--- | :--- |
 | `add_embedder(name, config)` | Register a named embedder definition. `config` is a dict with a `"type"` key (see below). |
+| `add_analyzer(name, tokenizer, *, char_filters=None, token_filters=None)` | Register a custom analyzer definition. `tokenizer` is required; `char_filters`/`token_filters` are optional lists of dicts. Each dict uses the same `{"type": "..."}` shape as the schema TOML/JSON format (see below). Semantic validity (e.g. a malformed regex) is checked when the schema is used to build an `Index`, not here. |
+| `analyzer_names()` | Return the names of custom analyzers registered via `add_analyzer` or loaded from TOML. |
+| `Schema.from_toml(toml_str)` *(static)* | Parse a schema from a TOML string, in the same format `laurus-cli create index --schema` accepts. |
+| `Schema.from_toml_file(path)` *(static)* | Load a schema from a TOML file (`path` accepts `str` or `os.PathLike`). |
+| `to_toml()` | Serialize this schema to a TOML string in the same format `laurus-cli` accepts. |
+| `to_toml_file(path)` | Write this schema to a TOML file. |
 | `set_default_fields(fields)` | Set default search fields (list of strings). |
 | `set_dynamic_field_policy(policy)` | Set how undeclared fields are handled. `policy` is `"strict"`, `"dynamic"` (default), or `"ignore"`. See notes below. |
 | `dynamic_field_policy()` | Return the current policy as a lowercase string. |
@@ -238,6 +244,59 @@ the full behaviour matrix.
 | `"candle_bert"` | `"model"` | `embeddings-candle` |
 | `"candle_clip"` | `"model"` | `embeddings-multimodal` |
 | `"openai"` | `"model"` | `embeddings-openai` |
+
+### Analyzer components
+
+Used by `add_analyzer(name, tokenizer, *, char_filters=None, token_filters=None)`
+and by the `[analyzers.<name>]` TOML section. `tokenizer` is a single dict;
+`char_filters`/`token_filters` are lists of dicts, applied in list order.
+
+**Tokenizers** (`tokenizer`, exactly one):
+
+| `"type"` | Required keys | Optional keys |
+| :--- | :--- | :--- |
+| `"whitespace"` | -- | -- |
+| `"unicode_word"` | -- | -- |
+| `"regex"` | -- | `"pattern"` (default `\w+`), `"gaps"` (default `false`) |
+| `"ngram"` | `"min_gram"`, `"max_gram"` | -- |
+| `"lindera"` | `"mode"`, `"dict"` | `"user_dict"` |
+| `"whole"` | -- | -- |
+
+**Char filters** (`char_filters`, applied to raw text before tokenization):
+
+| `"type"` | Required keys | Optional keys |
+| :--- | :--- | :--- |
+| `"unicode_normalization"` | `"form"` (`"nfc"`/`"nfd"`/`"nfkc"`/`"nfkd"`) | -- |
+| `"pattern_replace"` | `"pattern"`, `"replacement"` | -- |
+| `"mapping"` | `"mapping"` (dict of string replacements) | -- |
+| `"japanese_iteration_mark"` | -- | `"kanji"` (default `true`), `"kana"` (default `true`) |
+
+**Token filters** (`token_filters`, applied to the token stream after tokenization):
+
+| `"type"` | Required keys | Optional keys |
+| :--- | :--- | :--- |
+| `"lowercase"` | -- | -- |
+| `"stop"` | -- | `"words"` (default: English stop words) |
+| `"stem"` | -- | `"stem_type"` (`"porter"`/`"simple"`/`"identity"`) |
+| `"boost"` | `"boost"` | -- |
+| `"limit"` | `"limit"` | -- |
+| `"strip"` | -- | -- |
+| `"remove_empty"` | -- | -- |
+| `"flatten_graph"` | -- | -- |
+
+```python
+schema = laurus.Schema()
+schema.add_analyzer(
+    "ja_ipadic",
+    {"type": "lindera", "mode": "normal", "dict": "/var/lib/lindera/ipadic"},
+    char_filters=[
+        {"type": "unicode_normalization", "form": "nfkc"},
+        {"type": "japanese_iteration_mark"},
+    ],
+    token_filters=[{"type": "lowercase"}],
+)
+schema.add_text_field("title", analyzer="ja_ipadic")
+```
 
 ### Distance metrics
 

--- a/laurus-python/Cargo.toml
+++ b/laurus-python/Cargo.toml
@@ -26,3 +26,5 @@ laurus = { workspace = true, features = ["native"] }
 pyo3 = { version = "0.29.2", features = ["extension-module"] }
 tokio = { workspace = true }
 chrono = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }

--- a/laurus-python/src/convert.rs
+++ b/laurus-python/src/convert.rs
@@ -2,9 +2,9 @@
 
 use chrono::{DateTime, Utc};
 use laurus::{DataValue, Document};
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString};
+use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyInt, PyList, PyString, PyTuple};
 
 /// Convert a Python `dict` to a [`Document`].
 pub fn dict_to_document(py: Python, dict: &Bound<PyDict>) -> PyResult<Document> {
@@ -138,4 +138,99 @@ pub fn data_value_to_py(py: Python, value: &DataValue) -> PyResult<Py<PyAny>> {
         DataValue::Int64Array(arr) => Ok(arr.clone().into_pyobject(py)?.unbind().into_any()),
         DataValue::Float64Array(arr) => Ok(arr.clone().into_pyobject(py)?.unbind().into_any()),
     }
+}
+
+/// Maximum nesting depth accepted by [`py_to_json_value`].
+///
+/// Guards against a self-referential container (e.g. `d = {}; d["x"] = d`)
+/// blowing the Rust call stack, which would abort the process rather than
+/// raise a Python exception.
+const MAX_JSON_VALUE_DEPTH: usize = 32;
+
+/// Convert an arbitrary Python object into a [`serde_json::Value`].
+///
+/// Used to bridge Python `dict`/`list` literals (e.g. the `tokenizer` /
+/// `char_filters` / `token_filters` arguments of `Schema.add_analyzer`)
+/// into serde-deserializable JSON so they can be decoded with exactly the
+/// same semantics (field defaults, `snake_case` variant names, etc.) as the
+/// TOML schema format.
+///
+/// Type mapping:
+/// - `None`         → `Value::Null`
+/// - `bool`         → `Value::Bool`  (must be checked before int)
+/// - `int`          → `Value::Number` (rejected if it fits neither `i64` nor `u64`)
+/// - `float`        → `Value::Number` (rejected if NaN or infinite)
+/// - `str`          → `Value::String`
+/// - `list`/`tuple` → `Value::Array`
+/// - `dict`         → `Value::Object` (keys must be `str`)
+///
+/// Any other type, or nesting deeper than [`MAX_JSON_VALUE_DEPTH`], is
+/// rejected with a `ValueError`/`TypeError`.
+pub fn py_to_json_value(obj: &Bound<PyAny>) -> PyResult<serde_json::Value> {
+    py_to_json_value_inner(obj, 0)
+}
+
+fn py_to_json_value_inner(obj: &Bound<PyAny>, depth: usize) -> PyResult<serde_json::Value> {
+    if depth > MAX_JSON_VALUE_DEPTH {
+        return Err(PyValueError::new_err(format!(
+            "value is nested too deeply (max depth: {MAX_JSON_VALUE_DEPTH})"
+        )));
+    }
+    if obj.is_none() {
+        return Ok(serde_json::Value::Null);
+    }
+    // bool must come before int because Python bool is a subclass of int.
+    if obj.is_instance_of::<PyBool>() {
+        let b: bool = obj.extract()?;
+        return Ok(serde_json::Value::Bool(b));
+    }
+    if obj.is_instance_of::<PyInt>() {
+        // Try i64 first, then fall back to u64 for large unsigned values;
+        // anything wider than that has no lossless serde_json representation.
+        if let Ok(i) = obj.extract::<i64>() {
+            return Ok(serde_json::Value::Number(i.into()));
+        }
+        let u: u64 = obj.extract().map_err(|_| {
+            PyValueError::new_err("integer is too large to represent in a schema value")
+        })?;
+        return Ok(serde_json::Value::Number(u.into()));
+    }
+    if obj.is_instance_of::<PyFloat>() {
+        let f: f64 = obj.extract()?;
+        let n = serde_json::Number::from_f64(f)
+            .ok_or_else(|| PyValueError::new_err("float value must be finite (not NaN or inf)"))?;
+        return Ok(serde_json::Value::Number(n));
+    }
+    if obj.is_instance_of::<PyString>() {
+        let s: String = obj.extract()?;
+        return Ok(serde_json::Value::String(s));
+    }
+    if obj.is_instance_of::<PyList>() || obj.is_instance_of::<PyTuple>() {
+        let items: Vec<serde_json::Value> = obj
+            .try_iter()?
+            .map(|item| py_to_json_value_inner(&item?, depth + 1))
+            .collect::<PyResult<_>>()?;
+        return Ok(serde_json::Value::Array(items));
+    }
+    if obj.is_instance_of::<PyDict>() {
+        let dict = obj.cast::<PyDict>()?;
+        let mut map = serde_json::Map::with_capacity(dict.len());
+        for (key, value) in dict.iter() {
+            let key: String = key.extract().map_err(|_| {
+                PyTypeError::new_err(format!(
+                    "dict keys must be str, got {}",
+                    key.get_type()
+                        .name()
+                        .map(|n| n.to_string())
+                        .unwrap_or_default()
+                ))
+            })?;
+            map.insert(key, py_to_json_value_inner(&value, depth + 1)?);
+        }
+        return Ok(serde_json::Value::Object(map));
+    }
+    Err(PyValueError::new_err(format!(
+        "Cannot convert Python value of type {} to a schema value",
+        obj.get_type().name()?
+    )))
 }

--- a/laurus-python/src/errors.rs
+++ b/laurus-python/src/errors.rs
@@ -1,5 +1,8 @@
 //! Error conversion between Laurus errors and Python exceptions.
 
+use std::io;
+use std::path::Path;
+
 use laurus::LaurusError;
 use pyo3::PyErr;
 use pyo3::exceptions::{PyIOError, PyRuntimeError, PyValueError};
@@ -13,4 +16,15 @@ pub fn laurus_err(err: LaurusError) -> PyErr {
         LaurusError::Field(m) => PyValueError::new_err(format!("Field error: {m}")),
         other => PyRuntimeError::new_err(other.to_string()),
     }
+}
+
+/// Wrap a filesystem I/O error with the path that caused it, then convert
+/// it via PyO3's built-in `io::Error` -> Python exception mapping (which
+/// picks `FileNotFoundError`/`PermissionError`/etc. based on `e.kind()`).
+///
+/// Intentionally does NOT go through [`laurus_err`]: `LaurusError::Io`
+/// always maps to the generic `OSError`, which would prevent callers from
+/// writing `except FileNotFoundError:` for a missing file.
+pub fn io_err_with_path(path: &Path, e: io::Error) -> PyErr {
+    io::Error::new(e.kind(), format!("{}: {e}", path.display())).into()
 }

--- a/laurus-python/src/schema.rs
+++ b/laurus-python/src/schema.rs
@@ -1,16 +1,21 @@
 //! Python wrapper for the Laurus [`Schema`] type.
 
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use laurus::{
-    AnalyzerSpec, BooleanOption, BuiltinAnalyzerSpec, BytesOption, DateTimeOption, DistanceMetric,
-    DynamicFieldPolicy, EmbedderDefinition, FieldOption, FlatOption, FloatOption, Geo3dOption,
-    GeoOption, HnswOption, IntegerOption, IvfOption, QuantizationMethod, RerankStorageKind, Schema,
-    TextOption,
+    AnalyzerDefinition, AnalyzerSpec, BooleanOption, BuiltinAnalyzerSpec, BytesOption,
+    CharFilterConfig, DateTimeOption, DistanceMetric, DynamicFieldPolicy, EmbedderDefinition,
+    FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption, IntegerOption,
+    IvfOption, QuantizationMethod, RerankStorageKind, Schema, TextOption, TokenFilterConfig,
+    TokenizerConfig,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
+
+use crate::convert::py_to_json_value;
+use crate::errors::io_err_with_path;
 
 /// Convert a Python analyzer reference into an [`AnalyzerSpec`].
 ///
@@ -62,6 +67,47 @@ fn analyzer_spec_from_py(py: Python<'_>, obj: Py<PyAny>) -> PyResult<AnalyzerSpe
     Err(PyValueError::new_err(
         "analyzer must be a str or a dict (e.g. {'language': 'japanese', 'dict': '/path'})",
     ))
+}
+
+/// Convert a Python dict into a [`TokenizerConfig`], using the same
+/// `{"type": "..."}`-tagged shape as the schema TOML/JSON format.
+fn tokenizer_from_py(obj: &Bound<PyAny>) -> PyResult<TokenizerConfig> {
+    let value = py_to_json_value(obj)?;
+    serde_json::from_value(value)
+        .map_err(|e| PyValueError::new_err(format!("invalid tokenizer: {e}")))
+}
+
+/// Convert a Python dict into a [`CharFilterConfig`].
+fn char_filter_from_py(obj: &Bound<PyAny>, index: usize) -> PyResult<CharFilterConfig> {
+    let value = py_to_json_value(obj)?;
+    serde_json::from_value(value)
+        .map_err(|e| PyValueError::new_err(format!("invalid char_filters[{index}]: {e}")))
+}
+
+/// Convert a Python dict into a [`TokenFilterConfig`].
+fn token_filter_from_py(obj: &Bound<PyAny>, index: usize) -> PyResult<TokenFilterConfig> {
+    let value = py_to_json_value(obj)?;
+    serde_json::from_value(value)
+        .map_err(|e| PyValueError::new_err(format!("invalid token_filters[{index}]: {e}")))
+}
+
+/// Convert an optional Python list of dicts into a `Vec<T>`, defaulting to
+/// an empty vector when `None` (mirroring the core's `#[serde(default)]`
+/// on `AnalyzerDefinition::char_filters`/`token_filters`).
+fn filter_list_from_py<T>(
+    obj: Option<&Bound<PyAny>>,
+    label: &str,
+    convert: impl Fn(&Bound<PyAny>, usize) -> PyResult<T>,
+) -> PyResult<Vec<T>> {
+    let Some(obj) = obj else {
+        return Ok(Vec::new());
+    };
+    let seq = obj
+        .try_iter()
+        .map_err(|_| PyValueError::new_err(format!("{label} must be a list of dicts")))?;
+    seq.enumerate()
+        .map(|(i, item)| convert(&item?, i))
+        .collect()
 }
 
 /// Parse a distance metric string into [`DistanceMetric`].
@@ -489,6 +535,151 @@ impl PySchema {
         };
 
         self.inner.embedders.insert(name.to_string(), definition);
+        Ok(())
+    }
+
+    /// Register a custom analyzer definition composed of a tokenizer and
+    /// optional char/token filter chains.
+    ///
+    /// Each of `tokenizer`, `char_filters`, and `token_filters` uses the
+    /// same `{"type": "..."}`-tagged dict shape as the schema TOML/JSON
+    /// format (see [`Schema.from_toml`]), so a definition can be copied
+    /// verbatim between a `schema.toml` file and Python code.
+    ///
+    /// | tokenizer type   | required keys                | optional keys  |
+    /// |-------------------|-------------------------------|-----------------|
+    /// | `"whitespace"`    | —                              | —               |
+    /// | `"unicode_word"`  | —                              | —               |
+    /// | `"regex"`         | —                              | `pattern`, `gaps` |
+    /// | `"ngram"`         | `min_gram`, `max_gram`         | —               |
+    /// | `"lindera"`       | `mode`, `dict`                 | `user_dict`     |
+    /// | `"whole"`         | —                              | —               |
+    ///
+    /// | char filter type              | required keys           |
+    /// |----------------------------------|-------------------------|
+    /// | `"unicode_normalization"`        | `form`                  |
+    /// | `"pattern_replace"`              | `pattern`, `replacement` |
+    /// | `"mapping"`                      | `mapping`               |
+    /// | `"japanese_iteration_mark"`      | — (optional `kanji`, `kana`) |
+    ///
+    /// | token filter type   | required keys | optional keys |
+    /// |-----------------------|----------------|-----------------|
+    /// | `"lowercase"`          | —              | —               |
+    /// | `"stop"`               | —              | `words`         |
+    /// | `"stem"`               | —              | `stem_type`     |
+    /// | `"boost"`              | `boost`        | —               |
+    /// | `"limit"`              | `limit`        | —               |
+    /// | `"strip"`              | —              | —               |
+    /// | `"remove_empty"`       | —              | —               |
+    /// | `"flatten_graph"`      | —              | —               |
+    ///
+    /// Args:
+    ///     name: Unique analyzer name, referenced from
+    ///         ``add_text_field(analyzer=...)``.
+    ///     tokenizer: Dict describing the tokenizer, e.g.
+    ///         ``{"type": "ngram", "min_gram": 2, "max_gram": 3}``.
+    ///     char_filters: Optional list of dicts applied to raw text before
+    ///         tokenization (default: none).
+    ///     token_filters: Optional list of dicts applied to the token
+    ///         stream after tokenization (default: none).
+    ///
+    /// Raises:
+    ///     ValueError: if any component has an unknown ``type`` or is
+    ///         missing a required key.
+    ///
+    /// Note:
+    ///     Semantic validity (e.g. a malformed regex pattern, or
+    ///     ``min_gram > max_gram``) is not checked here; it is validated
+    ///     when the analyzer is compiled, which happens when a
+    ///     ``laurus.Index`` is built from this schema.
+    ///
+    /// Example:
+    ///     ```python
+    ///     schema.add_analyzer(
+    ///         "ja_ipadic",
+    ///         {"type": "lindera", "mode": "normal", "dict": "/var/lib/lindera/ipadic"},
+    ///         char_filters=[
+    ///             {"type": "unicode_normalization", "form": "nfkc"},
+    ///             {"type": "japanese_iteration_mark"},
+    ///         ],
+    ///         token_filters=[{"type": "lowercase"}],
+    ///     )
+    ///     schema.add_text_field("title", analyzer="ja_ipadic")
+    ///     ```
+    #[pyo3(signature = (name, tokenizer, *, char_filters=None, token_filters=None))]
+    pub fn add_analyzer(
+        &mut self,
+        name: &str,
+        tokenizer: &Bound<PyAny>,
+        char_filters: Option<&Bound<PyAny>>,
+        token_filters: Option<&Bound<PyAny>>,
+    ) -> PyResult<()> {
+        let definition = AnalyzerDefinition {
+            char_filters: filter_list_from_py(char_filters, "char_filters", char_filter_from_py)?,
+            tokenizer: tokenizer_from_py(tokenizer)?,
+            token_filters: filter_list_from_py(
+                token_filters,
+                "token_filters",
+                token_filter_from_py,
+            )?,
+        };
+        self.inner.analyzers.insert(name.to_string(), definition);
+        Ok(())
+    }
+
+    /// Return the names of custom analyzers registered in this schema, via
+    /// [`Schema.add_analyzer`] or loaded from TOML.
+    pub fn analyzer_names(&self) -> Vec<String> {
+        self.inner.analyzers.keys().cloned().collect()
+    }
+
+    /// Parse a schema from a TOML string, using the same format accepted
+    /// by ``laurus-cli create index --schema``.
+    ///
+    /// Raises:
+    ///     ValueError: if the TOML is malformed or does not match the
+    ///         schema shape.
+    #[staticmethod]
+    pub fn from_toml(toml_str: &str) -> PyResult<Self> {
+        let inner: Schema = toml::from_str(toml_str).map_err(|e| {
+            PyValueError::new_err(format!("invalid schema TOML: {}", e.to_string().trim_end()))
+        })?;
+        Ok(Self { inner })
+    }
+
+    /// Load a schema from a TOML file, e.g. one written by
+    /// ``laurus-cli create index --schema`` or by
+    /// [`Schema.to_toml_file`].
+    ///
+    /// Args:
+    ///     path: Filesystem path (``str`` or ``os.PathLike``).
+    ///
+    /// Raises:
+    ///     FileNotFoundError: if the file does not exist.
+    ///     ValueError: if the file's contents are not valid schema TOML.
+    #[staticmethod]
+    pub fn from_toml_file(path: PathBuf) -> PyResult<Self> {
+        let content = std::fs::read_to_string(&path).map_err(|e| io_err_with_path(&path, e))?;
+        Self::from_toml(&content)
+    }
+
+    /// Serialize this schema to a TOML string, in the same format
+    /// ``laurus-cli create index --schema`` accepts — so an index created
+    /// from Python can also be opened with ``laurus-cli``.
+    ///
+    /// Note:
+    ///     Table order in the output is not stable across calls (the
+    ///     underlying maps are unordered); compare parsed structures
+    ///     rather than raw text when round-tripping.
+    pub fn to_toml(&self) -> PyResult<String> {
+        toml::to_string_pretty(&self.inner)
+            .map_err(|e| PyValueError::new_err(format!("failed to serialize schema to TOML: {e}")))
+    }
+
+    /// Write this schema to a TOML file (see [`Schema.to_toml`]).
+    pub fn to_toml_file(&self, path: PathBuf) -> PyResult<()> {
+        let content = self.to_toml()?;
+        std::fs::write(&path, content).map_err(|e| io_err_with_path(&path, e))?;
         Ok(())
     }
 

--- a/laurus-python/tests/test_schema_analyzer.py
+++ b/laurus-python/tests/test_schema_analyzer.py
@@ -1,0 +1,248 @@
+"""Tests for `Schema.add_analyzer` and TOML schema loading/saving (Issue #1057).
+
+These deliberately avoid the Lindera tokenizer: this repository ships no
+Lindera dictionary, and `embedded://*` dictionary URIs are only resolvable
+from `laurus`'s own dev-dependency test builds, not from `laurus-python`.
+`whitespace`/`ngram`/`regex` tokenizers exercise the same code paths
+(`add_analyzer`'s dict-to-core-enum conversion, and the TOML
+serialize/deserialize round trip) without that dependency.
+
+Each behavioural test proves the analyzer actually reached the query
+engine (a deterministic search-result difference), not just that
+`add_analyzer`/`from_toml` didn't raise.
+"""
+
+import pathlib
+
+import pytest
+import laurus
+
+
+# ---------------------------------------------------------------------------
+# add_analyzer: behavioural — the analyzer actually takes effect
+# ---------------------------------------------------------------------------
+
+
+def test_ngram_tokenizer_enables_substring_match():
+    schema = laurus.Schema()
+    schema.add_analyzer("ngram3", {"type": "ngram", "min_gram": 3, "max_gram": 3})
+    schema.add_text_field("title", analyzer="ngram3")
+    schema.add_text_field("plain")  # default "standard" analyzer: whole-word tokens
+
+    idx = laurus.Index(schema=schema)
+    idx.put_document("doc1", {"title": "hello", "plain": "hello"})
+    idx.commit()
+
+    # "ell" is a substring of "hello", only reachable via 3-grams (hel/ell/llo).
+    assert len(idx.search("title:ell", limit=5)) == 1
+    assert len(idx.search("plain:ell", limit=5)) == 0
+
+
+def test_token_filters_apply_lowercase():
+    schema = laurus.Schema()
+    schema.add_analyzer("ws", {"type": "whitespace"})
+    schema.add_analyzer("ws_lower", {"type": "whitespace"}, token_filters=[{"type": "lowercase"}])
+    schema.add_text_field("raw", analyzer="ws")
+    schema.add_text_field("lower", analyzer="ws_lower")
+
+    idx = laurus.Index(schema=schema)
+    idx.put_document("doc1", {"raw": "HELLO World", "lower": "HELLO World"})
+    idx.commit()
+
+    # Without a lowercase filter, neither the indexed token nor the query
+    # term is folded, so an all-lowercase query term can't match "HELLO".
+    assert len(idx.search("raw:hello", limit=5)) == 0
+    # With the filter applied on both sides (index + query time), it matches.
+    assert len(idx.search("lower:hello", limit=5)) == 1
+
+
+def test_char_filters_apply_pattern_replace():
+    schema = laurus.Schema()
+    schema.add_analyzer("dash", {"type": "whitespace"})
+    schema.add_analyzer(
+        "dash_split",
+        {"type": "whitespace"},
+        char_filters=[{"type": "pattern_replace", "pattern": "-", "replacement": " "}],
+    )
+    schema.add_text_field("raw", analyzer="dash")
+    schema.add_text_field("split", analyzer="dash_split")
+
+    idx = laurus.Index(schema=schema)
+    idx.put_document("doc1", {"raw": "state-of-the-art", "split": "state-of-the-art"})
+    idx.commit()
+
+    # Whitespace alone doesn't split on hyphens, so "art" is never its own token.
+    assert len(idx.search("raw:art", limit=5)) == 0
+    # The char filter turns hyphens into spaces before tokenization.
+    assert len(idx.search("split:art", limit=5)) == 1
+
+
+def test_add_analyzer_defaults_to_no_filters():
+    schema = laurus.Schema()
+    schema.add_analyzer("ws", {"type": "whitespace"})  # char_filters/token_filters omitted
+    assert schema.analyzer_names() == ["ws"]
+
+
+# ---------------------------------------------------------------------------
+# add_analyzer: error surface
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_tokenizer_type_rejected():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError, match="tokenizer"):
+        schema.add_analyzer("bad", {"type": "kuromoji"})
+
+
+def test_missing_required_tokenizer_field_rejected():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError, match="tokenizer"):
+        schema.add_analyzer("bad", {"type": "ngram", "min_gram": 2})  # missing max_gram
+
+
+def test_unknown_char_filter_type_rejected():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError, match=r"char_filters\[0\]"):
+        schema.add_analyzer(
+            "bad", {"type": "whitespace"}, char_filters=[{"type": "unknown_filter"}]
+        )
+
+
+def test_negative_limit_rejected():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError, match=r"token_filters\[0\]"):
+        schema.add_analyzer(
+            "bad", {"type": "whitespace"}, token_filters=[{"type": "limit", "limit": -1}]
+        )
+
+
+def test_boost_accepts_python_int():
+    schema = laurus.Schema()
+    # boost is f32 in the core; a Python int must not be rejected.
+    schema.add_analyzer(
+        "b", {"type": "whitespace"}, token_filters=[{"type": "boost", "boost": 2}]
+    )
+    assert schema.analyzer_names() == ["b"]
+
+
+def test_bool_not_coerced_to_int():
+    schema = laurus.Schema()
+    # gaps is bool in the core; must accept a Python bool (not misread as int).
+    schema.add_analyzer("r", {"type": "regex", "pattern": r"\w+", "gaps": True})
+    assert schema.analyzer_names() == ["r"]
+
+
+def test_non_str_mapping_key_rejected():
+    schema = laurus.Schema()
+    with pytest.raises(TypeError):
+        schema.add_analyzer(
+            "m",
+            {"type": "whitespace"},
+            char_filters=[{"type": "mapping", "mapping": {1: "a"}}],
+        )
+
+
+def test_tokenizer_must_be_dict_not_string():
+    schema = laurus.Schema()
+    with pytest.raises(ValueError, match="tokenizer"):
+        schema.add_analyzer("bad", "whitespace")
+
+
+# ---------------------------------------------------------------------------
+# from_toml / from_toml_file
+# ---------------------------------------------------------------------------
+
+SCHEMA_TOML = """
+default_fields = ["title"]
+
+[analyzers.ngram3]
+tokenizer = { type = "ngram", min_gram = 3, max_gram = 3 }
+
+[fields.title.Text]
+indexed = true
+stored = true
+term_vectors = false
+analyzer = "ngram3"
+"""
+
+
+def test_from_toml_then_search():
+    schema = laurus.Schema.from_toml(SCHEMA_TOML)
+    assert schema.field_names() == ["title"]
+    assert schema.analyzer_names() == ["ngram3"]
+
+    idx = laurus.Index(schema=schema)
+    idx.put_document("doc1", {"title": "hello"})
+    idx.commit()
+    assert len(idx.search("title:ell", limit=5)) == 1
+
+
+def test_from_toml_file_accepts_path_and_str(tmp_path):
+    p = tmp_path / "schema.toml"
+    p.write_text(SCHEMA_TOML)
+
+    from_path = laurus.Schema.from_toml_file(p)
+    from_str = laurus.Schema.from_toml_file(str(p))
+    assert from_path.field_names() == from_str.field_names() == ["title"]
+
+
+def test_from_toml_file_missing_raises_file_not_found(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        laurus.Schema.from_toml_file(tmp_path / "does_not_exist.toml")
+
+
+def test_from_toml_parse_error_raises_value_error():
+    with pytest.raises(ValueError, match="TOML"):
+        laurus.Schema.from_toml("not = [valid")
+
+
+def test_from_toml_file_repo_fixture():
+    """Sanity check against a real fixture used elsewhere in the repo."""
+    fixture = pathlib.Path(__file__).resolve().parents[2] / "resources" / "schema.toml"
+    if not fixture.exists():
+        pytest.skip("resources/schema.toml not present in this checkout")
+    schema = laurus.Schema.from_toml_file(fixture)
+    assert schema.field_names()
+
+
+# ---------------------------------------------------------------------------
+# to_toml / to_toml_file: round trip
+# ---------------------------------------------------------------------------
+
+
+def test_to_toml_then_from_toml_round_trip():
+    schema = laurus.Schema()
+    schema.add_analyzer(
+        "ngram3",
+        {"type": "ngram", "min_gram": 3, "max_gram": 3},
+        char_filters=[{"type": "unicode_normalization", "form": "nfkc"}],
+        token_filters=[{"type": "lowercase"}],
+    )
+    schema.add_text_field("title", analyzer="ngram3")
+    schema.set_default_fields(["title"])
+
+    toml_str = schema.to_toml()
+    restored = laurus.Schema.from_toml(toml_str)
+
+    # Compare parsed structure, not raw text: the underlying maps are
+    # unordered, so table order in the TOML text is not stable.
+    assert restored.field_names() == schema.field_names()
+    assert restored.analyzer_names() == schema.analyzer_names()
+
+    idx = laurus.Index(schema=restored)
+    idx.put_document("doc1", {"title": "hello"})
+    idx.commit()
+    assert len(idx.search("title:ell", limit=5)) == 1
+
+
+def test_to_toml_file_then_from_toml_file_round_trip(tmp_path):
+    schema = laurus.Schema()
+    schema.add_analyzer("ws", {"type": "whitespace"})
+    schema.add_text_field("title", analyzer="ws")
+
+    p = tmp_path / "schema.toml"
+    schema.to_toml_file(p)
+    restored = laurus.Schema.from_toml_file(p)
+
+    assert restored.field_names() == schema.field_names()
+    assert restored.analyzer_names() == schema.analyzer_names()


### PR DESCRIPTION
## Summary

Adds custom analyzer registration and TOML schema loading/saving to `laurus-python`'s `Schema` class, closing the gap described in #1057: there was no way to compose a custom analyzer (char filters + tokenizer + token filters) from Python, and no way to load/save the same TOML format `laurus-cli create index --schema` uses.

- `Schema.add_analyzer(name, tokenizer, *, char_filters=None, token_filters=None)` — registers a custom `AnalyzerDefinition`. Each argument uses the same `{"type": "..."}`-tagged dict shape as the schema TOML/JSON format, converted through a new `py_to_json_value` → `serde_json::from_value` bridge rather than hand-matching each of the core's 18 tokenizer/char-filter/token-filter variants, so new core variants never silently go unsupported.
- `Schema.from_toml(toml_str)` / `Schema.from_toml_file(path)` — parse a schema from TOML, via the exact same `toml::from_str::<Schema>()` call `laurus-cli` already uses.
- `Schema.to_toml()` / `Schema.to_toml_file(path)` — the reverse direction, so a schema built in Python can be handed to `laurus-cli`.
- `Schema.analyzer_names()` — read accessor (there was previously no way to observe `schema.analyzers` from Python at all).

### API shape — one change from the issue's proposal

The issue proposed `add_analyzer(name, char_filters, tokenizer, token_filters)` with all four required. Implemented instead as `add_analyzer(name, tokenizer, *, char_filters=None, token_filters=None)`:

- The core `AnalyzerDefinition` only requires `tokenizer`; `char_filters`/`token_filters` are `#[serde(default)]`, and TOML already accepts a bare `tokenizer` with no filters. Requiring all four in Python would be strictly worse than TOML, undermining the parity goal.
- Python requires required params before optional ones, so keeping `tokenizer` required forces this reordering.
- Matches the existing convention in this file: `add_text_field`/`add_hnsw_field`/`add_ivf_field` are all `(name, <required>, *, <optional keyword-only>)`.
- `char_filters`/`token_filters` are kept keyword-only rather than positional-optional, since they're adjacent same-typed `list[dict]` params — a positional swap between them would silently build a valid-but-wrong schema instead of raising `TypeError`.

Full investigation and design rationale are in the issue comments.

## Changes

- `laurus-python/Cargo.toml`: add `serde_json`/`toml` (already in `[workspace.dependencies]`, same as `laurus-cli`).
- `laurus-python/src/convert.rs`: new `py_to_json_value` recursive Python→JSON helper (bool checked before int since Python `bool` subclasses `int`; non-str dict keys rejected; NaN/±inf rejected explicitly rather than letting `serde_json` panic; recursion depth capped against self-referential containers).
- `laurus-python/src/errors.rs`: new `io_err_with_path` helper — wraps an `io::Error` with its path while preserving `e.kind()`, so PyO3's built-in mapping still produces `FileNotFoundError`/`PermissionError`/etc. (bypassing `laurus_err`, which maps all IO errors to a generic `OSError`).
- `laurus-python/src/schema.rs`: `add_analyzer`, `analyzer_names`, `from_toml`, `from_toml_file`, `to_toml`, `to_toml_file`. Each analyzer component is deserialized individually (not the whole `AnalyzerDefinition` at once) so error messages can be prefixed with which part failed, e.g. `invalid char_filters[1]: unknown variant ...`. Semantic validation (a malformed regex, `min_gram > max_gram`) is deferred to `Index` construction, consistent with `from_toml`'s existing behavior.
- `laurus-python/tests/test_schema_analyzer.py` (new, 16 tests): behavioral tests proving the analyzer actually took effect (e.g. an `ngram` tokenizer enabling a substring match a `whitespace` tokenizer wouldn't, a `lowercase` token filter changing case-insensitive matching, a `pattern_replace` char filter splitting tokens differently), error-path tests, and TOML round-trip tests. Uses only `whitespace`/`ngram`/`regex` tokenizers — this repo ships no Lindera dictionary for tests to use.
- `docs/src/laurus-python/api_reference.md`: adds the new methods to the API tables, and a new "Analyzer components" reference table (tokenizer/char-filter/token-filter `"type"` values and their keys). Line 190 already referenced `add_analyzer` as if it existed — this PR makes that true.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p laurus-python --all-targets -- -D warnings`
- [x] `make test-laurus-python` — 82 passed (16 new)
- [x] Manual bidirectional CLI parity check against a real on-disk index (not covered by the above, since it spans the `laurus-cli` and `laurus-python` binaries together):
  - Built a schema with `add_analyzer` in Python, wrote it with `to_toml_file`, indexed a document, and confirmed `laurus-cli search` (opening the same on-disk index) returns it via the custom analyzer (case-insensitive match).
  - Created a schema + index with `laurus-cli create index --schema` / `put doc` / `commit`, then loaded it in Python with `Schema.from_toml_file` and confirmed `Index.search` returns the same document via the custom `ngram` analyzer.

## Out of scope (follow-up issues will be filed)

- Auto-loading `schema.toml` when opening `Index(path=...)` — touches the core `Engine`'s intentional choice not to persist schema itself. This also surfaced a separate, pre-existing structural mismatch worth its own issue: `laurus-cli` expects `<index_dir>/schema.toml` + `<index_dir>/store/`, while `laurus.Index(path=...)` writes directly under the given path — so today, pointing both at the same literal directory does not "just work" without knowing this convention.
- Non-deterministic table ordering in `to_toml()` output (core's `analyzers`/`fields`/`embedders` are `HashMap`, not `BTreeMap`).
- A shared `Schema::from_toml` helper in the core crate + refactoring `laurus-cli` to use it — kept out to avoid touching the CLI's existing behavior.
- Equivalent APIs for other language bindings (laurus-ruby/laurus-nodejs/laurus-wasm).

Closes #1057
