### PR TITLE
fix(ci): read Node.js version from .nvmrc instead of hardcoded "22"

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -341,7 +341,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-        node: ["22"]
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - name: Run checkout
@@ -354,7 +353,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ".nvmrc"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -521,7 +521,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-        node: ["22"]
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - name: Run checkout
@@ -534,7 +533,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ".nvmrc"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -342,7 +342,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-        node: ["22"]
     runs-on: ${{ matrix.platform.runner }}
     steps:
       - name: Run checkout
@@ -355,7 +354,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: ${{ matrix.node }}
+          node-version-file: ".nvmrc"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -777,7 +776,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
 
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@v1
@@ -1124,7 +1123,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Download all Node.js artifacts
@@ -1215,7 +1214,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install toolchain


### PR DESCRIPTION
## Summary

Fixes #1069: the `v0.13.0` release run's `Test laurus-nodejs` job fails in `npm install` with `Cannot read properties of null (reading 'edgesOut')`, blocking every downstream release job (Build/Publish). The same failure reproduces on `regression.yml`'s latest `main` push.

## Root cause

PR #401 bumped `laurus-nodejs/package.json`'s `engines.node` to `>=24.15.0` and pinned `.nvmrc` to `24.15.0`, but `release.yml`, `regression.yml`, and `periodic.yml` all still hardcoded Node.js `"22"` for their `laurus-nodejs` jobs -- four occurrences in `release.yml` (the test matrix plus three `Set up Node.js` steps in the Build/Publish jobs) and one each in `regression.yml`/`periodic.yml`. Node 22 is now below what the package declares as supported, and resolving `@napi-rs/cli`'s platform-specific `optionalDependencies` under it appears to trip an npm/arborist edge case that crashes `npm install` outright.

## Fix

Replace every hardcoded `node-version: "22"` (and the now-redundant `node: ["22"]` matrix dimension that only existed to thread that value through) with `node-version-file: ".nvmrc"`, making `.nvmrc` the single source of truth so this can't drift again the next time it's bumped.

## Verification

Could not run `actionlint` (not installed) or execute the workflows locally -- GitHub Actions is the only way to verify `node-version-file` resolves as expected. Verified all three edited YAML files still parse correctly (`ruby -ryaml`, since `PyYAML` wasn't available in this environment). Will need a green run on this PR (and a re-run of the blocked `v0.13.0` release) to confirm end-to-end.

Closes #1069
