### PR TITLE
fix(scripts): stop full-workspace build in bump-up-version.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,7 +2803,7 @@ checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "laurus"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-cli"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-mcp"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -2900,7 +2900,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-nodejs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "laurus",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-php"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "ext-php-rs",
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-python"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "laurus",
@@ -2934,7 +2934,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-ruby"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "chrono",
  "laurus",
@@ -2944,7 +2944,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-server"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -2967,7 +2967,7 @@ dependencies = [
 
 [[package]]
 name = "laurus-wasm"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Unified search library for lexical, vector, and semantic retrieval"
@@ -32,9 +32,9 @@ axum = "0.8.9"
 base64 = "0.23.1"
 chrono = { version = "0.4.45", features = ["serde"] }
 dialoguer = "0.12.0"
-laurus = { version = "0.13.0", path = "laurus", default-features = false }
-laurus-mcp = { version = "0.13.0", path = "laurus-mcp" }
-laurus-server = { version = "0.13.0", path = "laurus-server" }
+laurus = { version = "0.13.1", path = "laurus", default-features = false }
+laurus-mcp = { version = "0.13.1", path = "laurus-mcp" }
+laurus-server = { version = "0.13.1", path = "laurus-server" }
 prost = "0.14.4"
 rmcp = { version = "3.1.2", features = ["server", "transport-io"] }
 rustyline = "18.0.1"

--- a/docs/ja/src/laurus-cli/installation.md
+++ b/docs/ja/src/laurus-cli/installation.md
@@ -18,7 +18,7 @@
 | `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | 動的 | `.zip` |
 
 ```bash
-VERSION=v0.12.1
+VERSION=v0.13.1
 TARGET=x86_64-unknown-linux-musl
 curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
 tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"

--- a/docs/src/laurus-cli/installation.md
+++ b/docs/src/laurus-cli/installation.md
@@ -18,7 +18,7 @@ prebuilt `laurus` binaries for the following targets, all built with
 | `aarch64-pc-windows-msvc` | Windows arm64 | MSVC | dynamic | `.zip` |
 
 ```bash
-VERSION=v0.12.1
+VERSION=v0.13.1
 TARGET=x86_64-unknown-linux-musl
 curl -fsSL -O "https://github.com/mosuka/laurus/releases/download/${VERSION}/laurus-${VERSION}-${TARGET}.tar.gz"
 tar -xzf "laurus-${VERSION}-${TARGET}.tar.gz"

--- a/scripts/bump-up-version.sh
+++ b/scripts/bump-up-version.sh
@@ -82,8 +82,17 @@ sed_inplace \
 rm -f Cargo.toml.bak
 
 # --- 2. Cargo.lock: regenerate so every workspace member reflects it ---
-echo "==> Regenerating Cargo.lock (cargo build --workspace, this takes a while)"
-cargo build --workspace --no-default-features >/dev/null
+#
+# `cargo check -p laurus-cli` is enough: Cargo.lock is resolved for the
+# whole workspace regardless of which single member is checked, so every
+# local crate's version gets updated in the lockfile without actually
+# compiling anything else. Building the *whole* workspace here would also
+# try to link laurus-ruby/laurus-php, whose cdylibs only get the linker
+# flags they need (dynamic Ruby/PHP symbol lookup) when driven through
+# their own tooling (`bundle exec rake compile`, or an explicit RUSTFLAGS
+# for PHP) — a bare `cargo build`/`cargo check` on those crates fails.
+echo "==> Regenerating Cargo.lock (cargo check -p laurus-cli)"
+cargo check -p laurus-cli --no-default-features >/dev/null
 
 # --- 3. Documented install examples (major.minor only, no patch) ---
 DOC_FILES=(


### PR DESCRIPTION
## Summary

Running `./scripts/bump-up-version.sh 0.13.1` failed with a macOS linker error:

```
ld: symbol(s) not found for architecture arm64
"_rb_eRangeError", referenced from: ...
```

- **Root cause**: step 2 of the script regenerated `Cargo.lock` by running `cargo build --workspace --no-default-features`, which attempts to fully compile *and link* every workspace member — including `laurus-ruby` (magnus/rb-sys) and `laurus-php` (ext-php-rs), whose native-extension cdylibs only get correctly linked on macOS when driven through their own tooling (`bundle exec rake compile` for Ruby — where the `rb_sys` gem sets up its "stable API" shim and the required linker flags; explicit `RUSTFLAGS` for PHP, as the Makefile already does). A bare `cargo build`/`cargo check` on `laurus-ruby` fails outside that flow, even with a correctly-resolved Ruby toolchain on `PATH`.
- **Fix**: replaced the full workspace build with `cargo check -p laurus-cli --no-default-features`. Cargo.lock is resolved for the whole workspace regardless of which single member is checked, so every local crate's version is still updated in the lockfile — verified byte-identical to what the previous full `cargo build --workspace` produced — without ever attempting to compile the native-extension crates.
- Also bumped the version to 0.13.1 using the now-fixed script, and updated `laurus-cli`'s install docs, whose `VERSION=v0.12.1` download example had been left stale since the 0.13.0 bump (that version's tag was deleted after its release never completed, so v0.12.1 is still the latest actually-published release right now).

## Test plan

- [x] `./scripts/bump-up-version.sh 0.13.1` completes successfully end-to-end
- [x] `git diff -- Cargo.lock` after the fix is byte-identical to the diff produced by a full `cargo build --workspace` (verified locally before applying the fix)
- [x] `cargo check -p laurus-cli --no-default-features` and `cargo check --workspace --exclude laurus-ruby --exclude laurus-php --exclude laurus-python --exclude laurus-nodejs --exclude laurus-wasm --no-default-features` both pass with the bumped version