### PR TITLE
fix(ci): use Python 3.11 for build-wheel's Set up Python step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -735,10 +735,15 @@ jobs:
       - name: Run checkout
         uses: actions/checkout@v7
 
+      # 3.11, not 3.10: Windows ARM64 has no official Python 3.10 build
+      # (actions/setup-python's manifest only carries win32/arm64 from
+      # 3.11.0 onward). Any interpreter >= the abi3-py310 floor works here
+      # regardless of platform -- maturin builds the same cp310-abi3 wheel
+      # no matter which newer Python's headers it reads at build time.
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Build wheel
         uses: PyO3/maturin-action@v1


### PR DESCRIPTION
## Summary

The `v0.13.1` release run failed at `build-wheel`'s `Set up Python` step on `windows-11-arm`:

```
The version '3.10' with architecture 'arm64' was not found for Windows Enterprise.
```

Because `strategy.fail-fast` defaults to `true`, this single matrix leg failing canceled every other `build-wheel` platform too.

## Root cause

`actions/setup-python`'s version manifest only has Windows ARM64 (`win32`/`arm64`) builds starting at Python 3.11.0 — there is no 3.10 build for that platform. `build-wheel`'s `Set up Python` step (added in #1072) hardcoded `python-version: "3.10"` for all six platforms without checking this.

## Fix

Bump the pinned version to `3.11`. This doesn't change the produced wheel's ABI tag: with `abi3-py310` enabled in `laurus-python/Cargo.toml`, maturin builds the same `cp310-abi3` wheel regardless of which >=3.10 interpreter's headers it reads at build time.

## Test plan

- [x] Confirmed via `actions/python-versions`' manifest that Python 3.10 has no win32/arm64 build, while 3.11.0+ does
- [ ] Verified by the next `release.yml` run once this is merged and a new tag is cut (this specific failure can't be reproduced locally, since it's a GitHub-hosted-runner Python availability gap, not a build/code issue)