### PR TITLE
feat(engine): persist schema.toml from the core Engine

### DIFF
--- a/docs/ja/src/concepts/schema_and_fields.md
+++ b/docs/ja/src/concepts/schema_and_fields.md
@@ -407,7 +407,11 @@ let updated_schema = engine.delete_field("category").await?;
 
 ### 共通の注意事項
 
-返却された `Schema` は呼び出し側で永続化する必要があります（例: `schema.toml` への書き出し）。
+`Engine::builder().persist_schema_with(hook)` でスキーマ永続化フックを設定していれば、
+`add_field`/`delete_field` は返却前に自らそのフックを呼び出してスキーマを永続化します
+（`laurus-cli` と `laurus-server` はどちらもこのフックで `schema.toml` への書き出しを
+行っています）。フックを設定していない場合は、従来どおり返却された `Schema` を
+呼び出し側で永続化する必要があります（例: `schema.toml` への書き出し）。
 
 ## スキーマ設計のヒント
 

--- a/docs/src/concepts/schema_and_fields.md
+++ b/docs/src/concepts/schema_and_fields.md
@@ -410,8 +410,14 @@ let updated_schema = engine.add_field(
 ```
 
 Existing documents are unaffected—they simply have no value for the new
-field. The returned `Schema` should be persisted (e.g., to `schema.toml`)
-by the caller.
+field.
+
+If a schema-persist hook was configured via
+`Engine::builder().persist_schema_with(hook)`, `add_field`/`delete_field`
+call it themselves before returning, persisting the schema on the
+caller's behalf (both `laurus-cli` and `laurus-server` configure this
+hook to write `schema.toml`). Otherwise, as before, the returned `Schema`
+should be persisted (e.g., to `schema.toml`) by the caller.
 
 ### Removing a Field
 

--- a/laurus-cli/src/commands/add.rs
+++ b/laurus-cli/src/commands/add.rs
@@ -15,8 +15,10 @@ use crate::json_doc::parse_document_json;
 
 /// Execute the `add field` command.
 ///
-/// Opens the index at `index_dir`, parses the field option JSON, calls
-/// [`Engine::add_field`], and writes the updated schema to disk.
+/// Opens the index at `index_dir`, parses the field option JSON, and calls
+/// [`Engine::add_field`], which persists the updated schema itself (the
+/// engine returned by [`context::open_index`] is configured with a
+/// schema-persist hook — see Issue #1078).
 ///
 /// # Arguments
 ///
@@ -38,12 +40,10 @@ pub async fn run_field(name: &str, field_option_json: &str, index_dir: &Path) ->
     let field_option: FieldOption =
         serde_json::from_str(field_option_json).context("Failed to parse field option JSON")?;
 
-    let updated_schema = engine
+    engine
         .add_field(name, field_option)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    context::save_schema(index_dir, &updated_schema)?;
 
     println!("Field '{name}' added successfully.");
     Ok(())

--- a/laurus-cli/src/commands/delete.rs
+++ b/laurus-cli/src/commands/delete.rs
@@ -13,9 +13,11 @@ use crate::context;
 
 /// Execute the `delete field` command.
 ///
-/// Opens the index at `index_dir`, calls [`Engine::delete_field`], and writes
-/// the updated schema to disk. Existing data in the index is not deleted;
-/// the field simply becomes inaccessible for future indexing and searching.
+/// Opens the index at `index_dir` and calls [`Engine::delete_field`], which
+/// persists the updated schema itself (the engine returned by
+/// [`context::open_index`] is configured with a schema-persist hook — see
+/// Issue #1078). Existing data in the index is not deleted; the field
+/// simply becomes inaccessible for future indexing and searching.
 ///
 /// # Arguments
 ///
@@ -31,12 +33,10 @@ use crate::context;
 pub async fn run_field(name: &str, index_dir: &Path) -> Result<()> {
     let engine = context::open_index(index_dir).await?;
 
-    let updated_schema = engine
+    engine
         .delete_field(name)
         .await
         .map_err(|e| anyhow::anyhow!("{e}"))?;
-
-    context::save_schema(index_dir, &updated_schema)?;
 
     println!("Field '{name}' deleted successfully.");
     Ok(())

--- a/laurus-cli/src/commands/repl.rs
+++ b/laurus-cli/src/commands/repl.rs
@@ -123,7 +123,7 @@ pub async fn run(index_dir: &Path, format: OutputFormat) -> Result<()> {
                     eprintln!("{NO_INDEX_MSG}");
                     continue;
                 };
-                handle_add(eng, index_dir, parts[1], parts.get(2).copied()).await
+                handle_add(eng, parts[1], parts.get(2).copied()).await
             }
             "put" => {
                 if parts.len() < 2 {
@@ -156,7 +156,7 @@ pub async fn run(index_dir: &Path, format: OutputFormat) -> Result<()> {
                     eprintln!("{NO_INDEX_MSG}");
                     continue;
                 };
-                handle_delete(eng, index_dir, parts[1], parts.get(2).copied()).await
+                handle_delete(eng, parts[1], parts.get(2).copied()).await
             }
             "commit" => {
                 let Some(ref eng) = engine else {
@@ -315,12 +315,7 @@ async fn handle_search(engine: &Engine, query_str: &str, format: OutputFormat) -
 }
 
 /// Handle `add field ...` and `add doc ...` commands.
-async fn handle_add(
-    engine: &Engine,
-    index_dir: &Path,
-    resource: &str,
-    rest: Option<&str>,
-) -> Result<()> {
+async fn handle_add(engine: &Engine, resource: &str, rest: Option<&str>) -> Result<()> {
     match resource {
         "field" => {
             let rest = rest.context("Usage: add field <name> <json>")?;
@@ -329,11 +324,10 @@ async fn handle_add(
                 .context("Usage: add field <name> <json>")?;
             let field_option: FieldOption =
                 serde_json::from_str(json_str).context("Failed to parse field option JSON")?;
-            let updated_schema = engine
+            engine
                 .add_field(name, field_option)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
-            context::save_schema(index_dir, &updated_schema)?;
             println!("Field '{name}' added.");
             Ok(())
         }
@@ -415,20 +409,14 @@ async fn handle_get(
 }
 
 /// Handle `delete field ...` and `delete docs ...` commands.
-async fn handle_delete(
-    engine: &Engine,
-    index_dir: &Path,
-    resource: &str,
-    rest: Option<&str>,
-) -> Result<()> {
+async fn handle_delete(engine: &Engine, resource: &str, rest: Option<&str>) -> Result<()> {
     match resource {
         "field" => {
             let name = rest.context("Usage: delete field <name>")?;
-            let updated_schema = engine
+            engine
                 .delete_field(name)
                 .await
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
-            context::save_schema(index_dir, &updated_schema)?;
             println!("Field '{name}' deleted.");
             Ok(())
         }

--- a/laurus-cli/src/context.rs
+++ b/laurus-cli/src/context.rs
@@ -5,16 +5,28 @@
 //! used by the various CLI subcommands to obtain an [`Engine`] instance.
 
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
 use laurus::storage::file::FileStorageConfig;
-use laurus::{CommitPolicy, Engine, Schema, StorageConfig, StorageFactory};
+use laurus::{CommitPolicy, Engine, LaurusError, Schema, StorageConfig, StorageFactory};
 
 /// File name used to persist the schema inside the index directory.
 const SCHEMA_FILE: &str = "schema.toml";
 
 /// Subdirectory name used for the storage backend within the index directory.
 const STORE_DIR: &str = "store";
+
+/// Build a [`laurus::SchemaPersistHook`] that writes `schema.toml` inside
+/// `index_dir` (Issue #1078).
+///
+/// Attached to every [`Engine`] this module builds, so
+/// [`Engine::add_field`]/[`Engine::delete_field`] persist the schema
+/// themselves instead of relying on each call site to do it.
+fn schema_persist_hook(index_dir: &Path) -> laurus::SchemaPersistHook {
+    let index_dir = index_dir.to_path_buf();
+    Arc::new(move |schema| save_schema(&index_dir, schema).map_err(LaurusError::from))
+}
 
 /// Create a new index in the given index directory from a schema TOML file.
 ///
@@ -131,7 +143,10 @@ async fn init_index(index_dir: &Path, schema: Schema) -> Result<()> {
     // Create the storage and engine to initialize the index structure.
     let storage_config = StorageConfig::File(FileStorageConfig::new(&store_path));
     let storage = StorageFactory::create(storage_config)?;
-    let _engine = Engine::new(storage, schema).await?;
+    let _engine = Engine::builder(storage, schema)
+        .persist_schema_with(schema_persist_hook(index_dir))
+        .build()
+        .await?;
 
     Ok(())
 }
@@ -208,6 +223,7 @@ pub async fn open_index_with_commit_policy(
     };
     let engine = Engine::builder(storage, schema)
         .commit_policy(commit_policy)
+        .persist_schema_with(schema_persist_hook(index_dir))
         .build()
         .await?;
 
@@ -247,4 +263,67 @@ pub fn save_schema(index_dir: &Path, schema: &Schema) -> Result<()> {
     let schema_dest = index_dir.join(SCHEMA_FILE);
     std::fs::write(&schema_dest, &schema_toml).context("Failed to write schema file")?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Issue #1078: `add_field`/`delete_field` must persist `schema.toml`
+    /// themselves via the hook this module attaches, so a dynamic schema
+    /// change survives closing and reopening the index (simulating a
+    /// process restart) without any call site needing to call
+    /// `save_schema` explicitly.
+    #[tokio::test]
+    async fn dynamic_field_add_survives_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        create_index_from_schema(dir.path(), Schema::new())
+            .await
+            .unwrap();
+
+        {
+            let engine = open_index(dir.path()).await.unwrap();
+            engine
+                .add_field(
+                    "title",
+                    laurus::FieldOption::Text(laurus::TextOption::default()),
+                )
+                .await
+                .unwrap();
+            // No explicit `save_schema` call here — the point of this test.
+        }
+
+        // Reopen as a fresh process would, and confirm the change survived.
+        let reopened_schema = read_schema(dir.path()).unwrap();
+        assert!(
+            reopened_schema.fields.contains_key("title"),
+            "add_field should have persisted schema.toml via the engine's hook"
+        );
+
+        let engine = open_index(dir.path()).await.unwrap();
+        assert!(engine.schema().fields.contains_key("title"));
+    }
+
+    #[tokio::test]
+    async fn dynamic_field_delete_survives_reopen() {
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                laurus::FieldOption::Text(laurus::TextOption::default()),
+            )
+            .build();
+        let dir = tempfile::tempdir().unwrap();
+        create_index_from_schema(dir.path(), schema).await.unwrap();
+
+        {
+            let engine = open_index(dir.path()).await.unwrap();
+            engine.delete_field("title").await.unwrap();
+        }
+
+        let reopened_schema = read_schema(dir.path()).unwrap();
+        assert!(
+            !reopened_schema.fields.contains_key("title"),
+            "delete_field should have persisted schema.toml via the engine's hook"
+        );
+    }
 }

--- a/laurus-server/src/context.rs
+++ b/laurus-server/src/context.rs
@@ -6,16 +6,30 @@
 //! * `store/`      – the underlying storage directory managed by [`Engine`].
 
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, bail};
 use laurus::storage::file::FileStorageConfig;
-use laurus::{CommitPolicy, Engine, Schema, StorageConfig, StorageFactory, WalSyncPolicy};
+use laurus::{
+    CommitPolicy, Engine, LaurusError, Schema, StorageConfig, StorageFactory, WalSyncPolicy,
+};
 
 /// Filename used to persist the index schema inside the data directory.
 const SCHEMA_FILE: &str = "schema.toml";
 
 /// Subdirectory name for the underlying storage inside the data directory.
 const STORE_DIR: &str = "store";
+
+/// Build a [`laurus::SchemaPersistHook`] that writes `schema.toml` inside
+/// `data_dir` (Issue #1078).
+///
+/// Attached to every [`Engine`] this module builds, so
+/// [`Engine::add_field`]/[`Engine::delete_field`] persist the schema
+/// themselves instead of relying on the gRPC handlers to do it.
+fn schema_persist_hook(data_dir: &Path) -> laurus::SchemaPersistHook {
+    let data_dir = data_dir.to_path_buf();
+    Arc::new(move |schema| save_schema(&data_dir, schema).map_err(LaurusError::from))
+}
 
 /// Create a new index at the given data directory with the provided schema.
 ///
@@ -67,6 +81,7 @@ pub async fn create_index(
     let engine = Engine::builder(storage, schema.clone())
         .wal_sync_policy(wal_policy)
         .commit_policy(commit_policy)
+        .persist_schema_with(schema_persist_hook(data_dir))
         .build()
         .await?;
 
@@ -116,6 +131,7 @@ pub async fn open_index(
     let engine = Engine::builder(storage, schema)
         .wal_sync_policy(wal_policy)
         .commit_policy(commit_policy)
+        .persist_schema_with(schema_persist_hook(data_dir))
         .build()
         .await?;
 

--- a/laurus-server/src/service/index.rs
+++ b/laurus-server/src/service/index.rs
@@ -133,8 +133,6 @@ impl IndexServiceTrait for IndexService {
             .await
             .map_err(error::to_status)?;
 
-        context::save_schema(&self.data_dir, &updated_schema).map_err(error::anyhow_to_status)?;
-
         tracing::info!("Field '{}' added to index", name);
         let proto_schema = schema_convert::to_proto(&updated_schema);
         Ok(Response::new(AddFieldResponse {
@@ -159,8 +157,6 @@ impl IndexServiceTrait for IndexService {
             .ok_or_else(|| Status::failed_precondition("No index is open"))?;
 
         let updated_schema = engine.delete_field(&name).await.map_err(error::to_status)?;
-
-        context::save_schema(&self.data_dir, &updated_schema).map_err(error::anyhow_to_status)?;
 
         tracing::info!("Field '{}' deleted from index", name);
         let proto_schema = schema_convert::to_proto(&updated_schema);

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -32,6 +32,17 @@ use crate::vector::store::config::VectorIndexConfig;
 
 use self::schema::Schema;
 
+/// Callback invoked to persist a [`Schema`] snapshot outside the engine's own
+/// [`Storage`] (Issue #1078).
+///
+/// The engine's `storage` only ever covers its `store/` subdirectory —
+/// `schema.toml` conventionally lives one level up, alongside it, and where
+/// (or whether) to write it is a decision that belongs to the caller, not the
+/// engine. Set via [`EngineBuilder::persist_schema_with`]; when set,
+/// [`Engine::add_field`] and [`Engine::delete_field`] invoke it with the
+/// updated schema instead of leaving persistence to the caller.
+pub type SchemaPersistHook = Arc<dyn Fn(&Schema) -> Result<()> + Send + Sync>;
+
 /// Policy controlling when the engine automatically runs the commit ladder
 /// during ingestion (Issue #890).
 ///
@@ -438,6 +449,9 @@ pub struct Engine {
     /// Absent on `wasm32` (no background threads — `Interval` is a no-op).
     #[cfg(not(target_arch = "wasm32"))]
     _commit_timer: Option<CommitTimer>,
+    /// Optional callback that persists the schema outside the engine's own
+    /// storage (Issue #1078). See [`SchemaPersistHook`].
+    schema_persist_hook: Option<SchemaPersistHook>,
 }
 
 use crate::engine::search::{FusionAlgorithm, SearchResult};
@@ -1327,6 +1341,19 @@ impl Engine {
         )
     }
 
+    /// Persist the current schema via the configured hook, if any (Issue #1078).
+    ///
+    /// No-op when [`EngineBuilder::persist_schema_with`] was not called
+    /// (the caller remains responsible for persisting the schema itself, as
+    /// before). Called by [`Self::add_field`] and [`Self::delete_field`]
+    /// after they update the in-memory schema.
+    fn persist_schema(&self, schema: &Schema) -> Result<()> {
+        if let Some(hook) = &self.schema_persist_hook {
+            hook(schema)?;
+        }
+        Ok(())
+    }
+
     /// Dynamically add a new field to the engine at runtime.
     ///
     /// This method registers the field in both the engine schema and the
@@ -1345,8 +1372,11 @@ impl Engine {
     ///
     /// # Returns
     ///
-    /// Returns the updated [`Schema`] on success. The caller is responsible
-    /// for persisting it (e.g., writing `schema.toml`).
+    /// Returns the updated [`Schema`] on success. If
+    /// [`EngineBuilder::persist_schema_with`] was configured, the returned
+    /// schema has already been persisted via that hook; otherwise the
+    /// caller remains responsible for persisting it (e.g., writing
+    /// `schema.toml`).
     ///
     /// # Errors
     ///
@@ -1354,6 +1384,8 @@ impl Engine {
     /// - A field with the same name already exists.
     /// - The field references an unknown analyzer or embedder.
     /// - The underlying store rejects the field.
+    /// - A configured schema-persist hook fails (the in-memory schema has
+    ///   already been updated at that point; this is not rolled back).
     pub async fn add_field(&self, name: &str, option: schema::FieldOption) -> Result<Schema> {
         // 1a. Reject reserved field names (e.g. `_`-prefixed except `_id`).
         schema::validate_field_name(name)?;
@@ -1435,7 +1467,9 @@ impl Engine {
             schema.fields.insert(name.to_string(), option);
         }
 
-        Ok(self.schema.read().clone())
+        let updated = self.schema.read().clone();
+        self.persist_schema(&updated)?;
+        Ok(updated)
     }
 
     /// Dynamically remove a field from the engine schema at runtime.
@@ -1459,13 +1493,18 @@ impl Engine {
     ///
     /// # Returns
     ///
-    /// The updated [`Schema`] after the field has been removed.
+    /// The updated [`Schema`] after the field has been removed. If
+    /// [`EngineBuilder::persist_schema_with`] was configured, it has
+    /// already been persisted via that hook; otherwise the caller remains
+    /// responsible for persisting it.
     ///
     /// # Errors
     ///
     /// Returns an error if:
     /// - No field with the given name exists in the schema.
     /// - The underlying store rejects the deletion.
+    /// - A configured schema-persist hook fails (the in-memory schema has
+    ///   already been updated at that point; this is not rolled back).
     pub async fn delete_field(&self, name: &str) -> Result<Schema> {
         // 1. Check that the field exists.
         let option = {
@@ -1493,7 +1532,9 @@ impl Engine {
             schema.default_fields.retain(|f| f != name);
         }
 
-        Ok(self.schema.read().clone())
+        let updated = self.schema.read().clone();
+        self.persist_schema(&updated)?;
+        Ok(updated)
     }
 
     /// Resolve a [`LexicalSearchQuery`] into a concrete [`Query`] object.
@@ -2619,6 +2660,7 @@ pub struct EngineBuilder {
     embedding_cache_capacity: Option<usize>,
     wal_sync_policy: WalSyncPolicy,
     commit_policy: CommitPolicy,
+    schema_persist_hook: Option<SchemaPersistHook>,
 }
 
 impl EngineBuilder {
@@ -2633,7 +2675,29 @@ impl EngineBuilder {
             embedding_cache_capacity: None,
             wal_sync_policy: WalSyncPolicy::default(),
             commit_policy: CommitPolicy::default(),
+            schema_persist_hook: None,
         }
+    }
+
+    /// Register a callback that persists the schema whenever
+    /// [`Engine::add_field`] or [`Engine::delete_field`] changes it
+    /// (Issue #1078).
+    ///
+    /// Without this, callers are responsible for persisting the `Schema`
+    /// those methods return (e.g. writing `schema.toml`) themselves, and
+    /// forgetting to do so silently loses the change on the next restart.
+    /// `laurus-cli` and `laurus-server` both set this to write
+    /// `<index_dir>/schema.toml`.
+    ///
+    /// # Arguments
+    ///
+    /// * `hook` - Called with the updated schema after each successful
+    ///   `add_field`/`delete_field`. An error from the hook is propagated to
+    ///   the caller of `add_field`/`delete_field`; the in-memory schema has
+    ///   already been updated by that point (this does not roll back).
+    pub fn persist_schema_with(mut self, hook: SchemaPersistHook) -> Self {
+        self.schema_persist_hook = Some(hook);
+        self
     }
 
     /// Set the analyzer for text fields.
@@ -2824,6 +2888,7 @@ impl EngineBuilder {
             _wal_flush_timer: wal_flush_timer,
             #[cfg(not(target_arch = "wasm32"))]
             _commit_timer: commit_timer,
+            schema_persist_hook: self.schema_persist_hook,
         };
 
         engine.recover().await?;
@@ -3359,6 +3424,121 @@ mod tests {
 
         let result = engine.delete_field("nonexistent").await;
         assert!(result.is_err(), "Deleting a nonexistent field should fail");
+    }
+
+    /// Issue #1078: `add_field`/`delete_field` invoke the configured
+    /// schema-persist hook with the up-to-date schema, and propagate its
+    /// error (rather than silently swallowing it) when it fails.
+    #[tokio::test]
+    async fn test_add_field_invokes_schema_persist_hook() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::new();
+
+        let persisted: Arc<parking_lot::Mutex<Vec<Schema>>> =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let persisted_clone = Arc::clone(&persisted);
+
+        let engine = Engine::builder(storage, schema)
+            .persist_schema_with(Arc::new(move |schema: &Schema| {
+                persisted_clone.lock().push(schema.clone());
+                Ok(())
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        engine
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .await
+            .unwrap();
+
+        let calls = persisted.lock();
+        assert_eq!(calls.len(), 1, "hook should be called exactly once");
+        assert!(calls[0].fields.contains_key("title"));
+    }
+
+    #[tokio::test]
+    async fn test_delete_field_invokes_schema_persist_hook() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .build();
+
+        let persisted: Arc<parking_lot::Mutex<Vec<Schema>>> =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let persisted_clone = Arc::clone(&persisted);
+
+        let engine = Engine::builder(storage, schema)
+            .persist_schema_with(Arc::new(move |schema: &Schema| {
+                persisted_clone.lock().push(schema.clone());
+                Ok(())
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        engine.delete_field("title").await.unwrap();
+
+        let calls = persisted.lock();
+        assert_eq!(calls.len(), 1, "hook should be called exactly once");
+        assert!(!calls[0].fields.contains_key("title"));
+    }
+
+    #[tokio::test]
+    async fn test_add_field_without_hook_does_not_persist() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::new();
+
+        // No `persist_schema_with` configured: this is the pre-#1078
+        // behavior, preserved for callers that persist the schema
+        // themselves.
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        let updated = engine
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .await
+            .unwrap();
+        assert!(updated.fields.contains_key("title"));
+    }
+
+    #[tokio::test]
+    async fn test_add_field_propagates_schema_persist_hook_error() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::new();
+
+        let engine = Engine::builder(storage, schema)
+            .persist_schema_with(Arc::new(|_schema: &Schema| {
+                Err(crate::error::LaurusError::invalid_argument(
+                    "simulated persistence failure",
+                ))
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        let result = engine
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "a failing schema-persist hook must fail add_field"
+        );
+
+        // The in-memory schema was already updated before the hook ran
+        // (this phase does not add rollback — see #1077).
+        assert!(engine.schema().fields.contains_key("title"));
     }
 
     #[tokio::test]

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -88,6 +88,7 @@ pub use engine::Engine;
 pub use engine::EngineBuilder;
 pub use engine::EngineStats;
 pub use engine::PqCodebookInfo;
+pub use engine::SchemaPersistHook;
 pub use engine::json_document::json_to_document;
 pub use engine::query::UnifiedQueryParser;
 pub use engine::schema::analyzer::{


### PR DESCRIPTION
## Summary

- `Engine` only ever holds a `Storage` scoped to its `store/` subdirectory — `schema.toml` lives one level up, and persisting it after `add_field`/`delete_field` was left entirely to the caller. `laurus-cli` and `laurus-server` each duplicated the same persistence logic, and forgetting to call it silently loses a dynamic schema change on the next restart.
- Adds `EngineBuilder::persist_schema_with(hook)` to register a `SchemaPersistHook`; `Engine::add_field`/`delete_field` now call it themselves after updating the in-memory schema (no-op when unset, preserving prior behavior for direct `laurus` crate users).
- Wires the hook into every `Engine::builder(...)` call in `laurus-cli`/`laurus-server` (create and open paths) and removes the now-redundant explicit `save_schema`/`context::save_schema` calls at each CLI command / gRPC handler.
- Updates `docs/{ja/,}src/concepts/schema_and_fields.md` to reflect the new behavior.

Phase 0 of #1077 (dynamic field type/option changes via `update_field`) — this is a prerequisite, since schema/index consistency is the whole point of that feature. The 5 language bindings (python/nodejs/wasm/ruby/php) don't expose `add_field`/`delete_field`, so no changes were needed there.

Closes #1078

## Test plan

- [x] `cargo build`/`clippy --all-targets -- -D warnings`/`fmt --check` clean on `laurus`, `laurus-cli`, `laurus-server`, `laurus-mcp` (the 4 affected crates; `laurus-php`/`laurus-python` fail to build workspace-wide due to a pre-existing, unrelated FFI linker error also present on `main`)
- [x] `cargo test -p laurus`: 202 lib + 125 doctests passing, incl. 4 new unit tests (hook invoked on both `add_field`/`delete_field`, hook error propagates, omitting the hook preserves pre-#1078 behavior)
- [x] `cargo test -p laurus-cli`: 34 passing, incl. 2 new E2E tests that close and reopen an index (simulating a process restart) to directly demonstrate a dynamic field change now survives without the caller calling `save_schema` itself
- [x] `cargo test -p laurus-server`: 50 lib + 2 grpc E2E passing
- [x] `cargo test -p laurus-mcp`: 14 passing
- [x] `markdownlint-cli2` clean on both changed docs files