### PR TITLE
feat(engine): add change classification and metadata-only update_field

### DIFF
--- a/laurus-cli/src/commands/create.rs
+++ b/laurus-cli/src/commands/create.rs
@@ -281,6 +281,7 @@ pub fn build_schema_interactive() -> Result<Schema> {
         fields,
         default_fields,
         dynamic_field_policy: Default::default(),
+        pending_reindex: Default::default(),
     })
 }
 

--- a/laurus-server/proto/laurus/v1/index.proto
+++ b/laurus-server/proto/laurus/v1/index.proto
@@ -32,6 +32,11 @@ message Schema {
   // Policy controlling how fields not declared in `fields` are handled
   // during document ingestion. Defaults to DYNAMIC.
   DynamicFieldPolicy dynamic_field_policy = 5;
+  // Fields whose option was changed via UpdateField with a destructive
+  // classification (dimension/embedder/distance change, or a change to a
+  // non-stored field) and therefore no longer have valid on-disk data
+  // matching the current schema. See laurus::Schema::pending_reindex.
+  repeated string pending_reindex = 6;
 }
 
 // Policy for handling undeclared fields during document ingestion.

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -39,6 +39,7 @@ pub fn to_proto(schema: &Schema) -> v1::Schema {
         analyzers,
         embedders,
         dynamic_field_policy: dynamic_field_policy_to_proto(&schema.dynamic_field_policy) as i32,
+        pending_reindex: schema.pending_reindex.iter().cloned().collect(),
     }
 }
 
@@ -64,6 +65,7 @@ pub fn from_proto(proto: &v1::Schema) -> Result<Schema, String> {
         fields,
         default_fields: proto.default_fields.clone(),
         dynamic_field_policy: dynamic_field_policy_from_proto(proto.dynamic_field_policy),
+        pending_reindex: proto.pending_reindex.iter().cloned().collect(),
     })
 }
 

--- a/laurus-server/src/gateway/convert.rs
+++ b/laurus-server/src/gateway/convert.rs
@@ -209,6 +209,9 @@ pub fn json_to_proto_schema(json: &Value) -> Result<v1::Schema, String> {
         analyzers,
         embedders,
         dynamic_field_policy,
+        // Not user-supplied at schema-creation time: only `UpdateField`
+        // populates this (Issue #1079).
+        pending_reindex: Vec::new(),
     })
 }
 
@@ -279,6 +282,16 @@ pub fn proto_schema_to_json(schema: &v1::Schema) -> Value {
     }
     if let Some(name) = proto_dynamic_field_policy_to_json(schema.dynamic_field_policy) {
         result["dynamic_field_policy"] = Value::String(name.to_string());
+    }
+    if !schema.pending_reindex.is_empty() {
+        result["pending_reindex"] = Value::Array(
+            schema
+                .pending_reindex
+                .iter()
+                .cloned()
+                .map(Value::String)
+                .collect(),
+        );
     }
     result
 }

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -43,6 +43,34 @@ use self::schema::Schema;
 /// updated schema instead of leaving persistence to the caller.
 pub type SchemaPersistHook = Arc<dyn Fn(&Schema) -> Result<()> + Send + Sync>;
 
+/// Options for [`Engine::update_field`] (Issue #1079).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UpdateFieldOptions {
+    /// Reserved for Issues #1080/#1081: once vector- and lexical-field
+    /// rebuilding are implemented, this will need to be `true` to actually
+    /// rebuild a [`schema::FieldChangeKind::Reindex`]-classified field from
+    /// its existing data (mirroring Typesense's opt-in reindex step, rather
+    /// than silently doing potentially expensive work on every call).
+    /// Currently has no effect: this phase rejects every `Reindex`/
+    /// `Destructive` change regardless of this flag.
+    pub reindex: bool,
+    /// When `true`, classify the change and report the outcome without
+    /// applying anything — not even a
+    /// [`schema::FieldChangeKind::MetadataOnly`] change.
+    pub dry_run: bool,
+}
+
+/// The outcome of a call to [`Engine::update_field`] (Issue #1079).
+#[derive(Debug, Clone)]
+pub struct UpdateFieldOutcome {
+    /// How the requested change was classified.
+    pub classification: schema::FieldChangeKind,
+    /// The schema as it stands after the call. Unchanged from before the
+    /// call when [`UpdateFieldOptions::dry_run`] was `true`, or when the
+    /// change was rejected.
+    pub schema: Schema,
+}
+
 /// Policy controlling when the engine automatically runs the commit ladder
 /// during ingestion (Issue #890).
 ///
@@ -437,6 +465,17 @@ pub struct Engine {
     /// invert against the lexical writer → searcher order that
     /// [`LexicalStore::find_doc_ids_by_term`] maintains.
     id_locks: Arc<Vec<tokio::sync::Mutex<()>>>,
+    /// Guards ingestion against a concurrent [`Self::update_field`] (Issue
+    /// #1079). Ingestion (`index_internal`, `delete_documents`) takes a
+    /// read lock — any number of writers can ingest concurrently — while
+    /// `update_field` takes a write lock, so a schema change never races a
+    /// document that assumes the old field option.
+    ///
+    /// A `tokio::sync::RwLock` because the guard must be held across
+    /// `await` points (a `parking_lot::RwLock` guard is not `Send` across
+    /// one). Taken *after* an [`Self::id_lock`] guard wherever both are
+    /// held, since `id_locks` is documented as the outermost lock.
+    schema_change_lock: tokio::sync::RwLock<()>,
     /// Background WAL flush timer for a [`WalSyncPolicy::Group`] configured with
     /// a `max_interval`. `None` when no interval is set. Held only to keep the
     /// timer thread alive for the engine's lifetime; dropping the engine stops
@@ -854,6 +893,11 @@ impl Engine {
         // whole sequence, including the WAL append, so the log's record order
         // for an id matches the order the stores applied them in.
         let _id_guard = self.id_lock(id).lock().await;
+        // Block a concurrent `update_field` from swapping the field option
+        // this document was just coerced against (Issue #1079). Taken after
+        // `_id_guard` (the outermost lock) and held for the rest of this
+        // mutation, including the internal delete below.
+        let _schema_guard = self.schema_change_lock.read().await;
 
         if !as_chunk {
             self.delete_documents_internal(id).await?;
@@ -1117,6 +1161,9 @@ impl Engine {
         // its add, so the upsert's new version outlives the delete that was
         // acknowledged after it.
         let _id_guard = self.id_lock(id).lock().await;
+        // See `index_internal`'s comment on `schema_change_lock` (Issue
+        // #1079).
+        let _schema_guard = self.schema_change_lock.read().await;
         self.delete_documents_internal(id).await?;
         // Re-assert per-record durability: a concurrent batch may hold a WAL
         // sync-deferral scope, which would otherwise leave these acknowledged
@@ -1535,6 +1582,106 @@ impl Engine {
         let updated = self.schema.read().clone();
         self.persist_schema(&updated)?;
         Ok(updated)
+    }
+
+    /// Dynamically change an existing field's type or options at runtime
+    /// (Issue #1077/#1079).
+    ///
+    /// Unlike [`Self::add_field`]/[`Self::delete_field`], a field option
+    /// change may or may not require existing on-disk data to be rebuilt.
+    /// [`schema::classify_change`] decides which:
+    ///
+    /// - [`FieldChangeKind::MetadataOnly`](schema::FieldChangeKind::MetadataOnly):
+    ///   applied immediately; no existing data is touched.
+    /// - [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex) /
+    ///   [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive):
+    ///   rejected in this phase — rebuilding vector fields (Issue #1080)
+    ///   and lexical fields (Issue #1081) is not yet implemented. `opts.reindex`
+    ///   is reserved for when those land and has no effect yet.
+    ///
+    /// Blocks concurrently with ingestion via an internal write lock (see
+    /// [`Engine`]'s `schema_change_lock`), so a document is never coerced
+    /// against a field option that is being replaced mid-write.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The name of the field to update. Must already exist.
+    /// * `option` - The new field configuration.
+    /// * `opts` - See [`UpdateFieldOptions`].
+    ///
+    /// # Returns
+    ///
+    /// The classification the change was given, and the schema as it
+    /// stands after the call (unchanged from before the call when
+    /// `opts.dry_run` was `true`, or when the change was rejected).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - No field with the given name exists in the schema.
+    /// - The change is classified as [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex)
+    ///   or [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive)
+    ///   (not yet implemented in this phase).
+    /// - A configured schema-persist hook fails (the in-memory schema has
+    ///   already been updated at that point; this is not rolled back).
+    pub async fn update_field(
+        &self,
+        name: &str,
+        option: schema::FieldOption,
+        opts: UpdateFieldOptions,
+    ) -> Result<UpdateFieldOutcome> {
+        // Block ingestion for the duration of the classification + apply so
+        // a document is never coerced against a field option this call is
+        // in the middle of replacing.
+        let _schema_guard = self.schema_change_lock.write().await;
+
+        let old_option = {
+            let schema = self.schema.read();
+            schema.fields.get(name).cloned().ok_or_else(|| {
+                crate::error::LaurusError::invalid_argument(format!(
+                    "Field '{name}' does not exist in the schema"
+                ))
+            })?
+        };
+
+        let classification = schema::classify_change(&old_option, &option);
+
+        if opts.dry_run {
+            return Ok(UpdateFieldOutcome {
+                classification,
+                schema: self.schema.read().clone(),
+            });
+        }
+
+        match classification {
+            schema::FieldChangeKind::MetadataOnly => {
+                {
+                    let mut schema = self.schema.write();
+                    schema.fields.insert(name.to_string(), option);
+                }
+                let updated = self.schema.read().clone();
+                self.persist_schema(&updated)?;
+                Ok(UpdateFieldOutcome {
+                    classification,
+                    schema: updated,
+                })
+            }
+            schema::FieldChangeKind::Reindex => {
+                Err(crate::error::LaurusError::not_implemented(format!(
+                    "updating field '{name}' requires rebuilding existing data, which is not \
+                     yet implemented (see https://github.com/mosuka/laurus/issues/1080 for \
+                     vector fields or https://github.com/mosuka/laurus/issues/1081 for lexical \
+                     fields)"
+                )))
+            }
+            schema::FieldChangeKind::Destructive => {
+                Err(crate::error::LaurusError::not_implemented(format!(
+                    "updating field '{name}' would discard its existing data, which is not yet \
+                     implemented (see https://github.com/mosuka/laurus/issues/1080 for vector \
+                     fields or https://github.com/mosuka/laurus/issues/1081 for lexical fields)"
+                )))
+            }
+        }
     }
 
     /// Resolve a [`LexicalSearchQuery`] into a concrete [`Query`] object.
@@ -2884,6 +3031,7 @@ impl EngineBuilder {
                     .map(|_| tokio::sync::Mutex::new(()))
                     .collect(),
             ),
+            schema_change_lock: tokio::sync::RwLock::new(()),
             #[cfg(not(target_arch = "wasm32"))]
             _wal_flush_timer: wal_flush_timer,
             #[cfg(not(target_arch = "wasm32"))]
@@ -3539,6 +3687,172 @@ mod tests {
         // The in-memory schema was already updated before the hook ran
         // (this phase does not add rollback — see #1077).
         assert!(engine.schema().fields.contains_key("title"));
+    }
+
+    /// Issue #1079: a `MetadataOnly`-classified change (here, an HNSW
+    /// field's `default_ef_search`) is applied and persisted.
+    #[tokio::test]
+    async fn test_update_field_applies_metadata_only_change() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "embedding",
+                schema::FieldOption::Hnsw(
+                    crate::vector::core::field::HnswOption::default().dimension(4),
+                ),
+            )
+            .build();
+
+        let persisted: Arc<parking_lot::Mutex<Vec<Schema>>> =
+            Arc::new(parking_lot::Mutex::new(Vec::new()));
+        let persisted_clone = Arc::clone(&persisted);
+
+        let engine = Engine::builder(storage, schema)
+            .persist_schema_with(Arc::new(move |schema: &Schema| {
+                persisted_clone.lock().push(schema.clone());
+                Ok(())
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        let mut new_option = crate::vector::core::field::HnswOption::default().dimension(4);
+        new_option.default_ef_search = Some(64);
+
+        let outcome = engine
+            .update_field(
+                "embedding",
+                schema::FieldOption::Hnsw(new_option),
+                UpdateFieldOptions::default(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome.classification,
+            schema::FieldChangeKind::MetadataOnly
+        );
+        match outcome.schema.fields.get("embedding") {
+            Some(schema::FieldOption::Hnsw(opt)) => {
+                assert_eq!(opt.default_ef_search, Some(64));
+            }
+            other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+        }
+        // The hook was invoked with the updated schema.
+        assert_eq!(persisted.lock().len(), 1);
+    }
+
+    /// Issue #1079: a `Reindex`-classified change (here, an analyzer swap)
+    /// is rejected in this phase, and does not mutate the schema.
+    #[tokio::test]
+    async fn test_update_field_rejects_reindex_change() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        let new_option = schema::FieldOption::Text(
+            crate::lexical::core::field::TextOption::default().analyzer("english"),
+        );
+        let result = engine
+            .update_field("title", new_option, UpdateFieldOptions::default())
+            .await;
+
+        assert!(result.is_err(), "a Reindex change must be rejected");
+        // The schema is untouched: still the original (analyzer: None) option.
+        match engine.schema().fields.get("title") {
+            Some(schema::FieldOption::Text(opt)) => assert!(opt.analyzer.is_none()),
+            other => panic!("expected FieldOption::Text, got {other:?}"),
+        }
+    }
+
+    /// Issue #1079: a `Destructive`-classified change (here, a dimension
+    /// change) is rejected in this phase, and does not mutate the schema.
+    #[tokio::test]
+    async fn test_update_field_rejects_destructive_change() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "embedding",
+                schema::FieldOption::Hnsw(
+                    crate::vector::core::field::HnswOption::default().dimension(4),
+                ),
+            )
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        let new_option = schema::FieldOption::Hnsw(
+            crate::vector::core::field::HnswOption::default().dimension(8),
+        );
+        let result = engine
+            .update_field("embedding", new_option, UpdateFieldOptions::default())
+            .await;
+
+        assert!(result.is_err(), "a Destructive change must be rejected");
+        match engine.schema().fields.get("embedding") {
+            Some(schema::FieldOption::Hnsw(opt)) => assert_eq!(opt.dimension, 4),
+            other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+        }
+    }
+
+    /// Issue #1079: `dry_run: true` reports the classification without
+    /// mutating the schema, even for a `MetadataOnly` change.
+    #[tokio::test]
+    async fn test_update_field_dry_run_does_not_mutate() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "embedding",
+                schema::FieldOption::Hnsw(
+                    crate::vector::core::field::HnswOption::default().dimension(4),
+                ),
+            )
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        let mut new_option = crate::vector::core::field::HnswOption::default().dimension(4);
+        new_option.default_ef_search = Some(64);
+
+        let outcome = engine
+            .update_field(
+                "embedding",
+                schema::FieldOption::Hnsw(new_option),
+                UpdateFieldOptions {
+                    dry_run: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            outcome.classification,
+            schema::FieldChangeKind::MetadataOnly
+        );
+        // Not applied: the schema still has the original (unset) value.
+        match engine.schema().fields.get("embedding") {
+            Some(schema::FieldOption::Hnsw(opt)) => assert_eq!(opt.default_ef_search, None),
+            other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_update_field_nonexistent_rejected() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let engine = Engine::new(storage, Schema::new()).await.unwrap();
+
+        let result = engine
+            .update_field(
+                "nonexistent",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+                UpdateFieldOptions::default(),
+            )
+            .await;
+        assert!(result.is_err(), "updating a nonexistent field should fail");
     }
 
     #[tokio::test]

--- a/laurus/src/engine/schema.rs
+++ b/laurus/src/engine/schema.rs
@@ -2,7 +2,7 @@ pub mod analyzer;
 pub mod embedder;
 
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use self::analyzer::AnalyzerDefinition;
 use self::embedder::EmbedderDefinition;
@@ -138,6 +138,23 @@ pub struct Schema {
     /// Defaults to [`DynamicFieldPolicy::Dynamic`].
     #[serde(default)]
     pub dynamic_field_policy: DynamicFieldPolicy,
+    /// Fields whose `FieldOption` was changed via [`Engine::update_field`]
+    /// with a [`FieldChangeKind::Destructive`] classification, and which
+    /// therefore no longer have valid on-disk data matching the current
+    /// schema (Issue #1079).
+    ///
+    /// This is a visibility mechanism, not an enforcement one: unlike Solr
+    /// (which silently allows a schema and its index to drift apart, see
+    /// #1077's investigation), laurus records every destructive change
+    /// here so `GetSchema`/`laurus get schema` can surface it instead of
+    /// leaving the inconsistency undiscoverable. A field is added when a
+    /// destructive [`FieldChangeKind`] is applied and is expected to be
+    /// removed once the field has been rebuilt (rebuilding itself is out
+    /// of scope for this phase — see #1080/#1081).
+    ///
+    /// [`Engine::update_field`]: crate::engine::Engine::update_field
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub pending_reindex: BTreeSet<String>,
 }
 
 impl Schema {
@@ -148,6 +165,7 @@ impl Schema {
             fields: HashMap::new(),
             default_fields: Vec::new(),
             dynamic_field_policy: DynamicFieldPolicy::default(),
+            pending_reindex: BTreeSet::new(),
         }
     }
 
@@ -291,6 +309,220 @@ impl FieldOption {
     }
 }
 
+/// The impact of changing a field's [`FieldOption`] via
+/// [`Engine::update_field`](crate::engine::Engine::update_field) (Issue #1079).
+///
+/// Ordered from least to most disruptive (the derived [`Ord`] follows
+/// declaration order): when several parameters change at once, the overall
+/// classification is the most severe of the individual per-parameter
+/// classifications — see [`classify_change`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FieldChangeKind {
+    /// Only a schema-level setting changes; no existing on-disk data needs
+    /// to be touched. For example, an HNSW field's `default_ef_search` is
+    /// read only when a searcher is constructed, never persisted to a
+    /// segment.
+    MetadataOnly,
+    /// Existing on-disk data must be rebuilt, but the values needed to do
+    /// so are still available (the document store's stored fields, or —
+    /// for vector fields — the raw vectors already on disk).
+    Reindex,
+    /// The change cannot be applied from existing on-disk data at all.
+    /// Applying it discards the field's existing data (e.g. a dimension
+    /// change, or any change to a field that is not `stored`).
+    Destructive,
+}
+
+/// Classify a field option change from `old` to `new` (Issue #1079).
+///
+/// This is the core policy decision behind
+/// [`Engine::update_field`](crate::engine::Engine::update_field): it never
+/// touches storage and never fails, so it can be used both to decide how to
+/// apply a change and, with `dry_run`, to report the impact of a
+/// not-yet-applied one.
+///
+/// # Cross-type changes
+///
+/// Changing between two lexical variants (e.g. `Text` -> `Integer`) is a
+/// [`FieldChangeKind::Reindex`] — analysis just needs to run again over the
+/// stored values. Changing between two vector variants (e.g. `Hnsw` ->
+/// `Flat`) is likewise a [`FieldChangeKind::Reindex`] in principle (the raw
+/// vectors on disk are the same regardless of index algorithm), escalated
+/// to [`FieldChangeKind::Destructive`] if `dimension`, `distance`, or
+/// `embedder` also changed. Changing between a lexical and a vector variant
+/// is always [`FieldChangeKind::Destructive`]: the two subsystems have no
+/// shared "rebuild from existing data" path (vector fields are always
+/// stored as raw vectors; lexical fields honor `stored` independently).
+pub fn classify_change(old: &FieldOption, new: &FieldOption) -> FieldChangeKind {
+    match (old, new) {
+        (FieldOption::Text(o), FieldOption::Text(n)) => classify_text(o, n),
+        (FieldOption::Integer(o), FieldOption::Integer(n)) => {
+            classify_numeric_lexical(o.indexed, n.indexed, o.multi_valued, n.multi_valued)
+        }
+        (FieldOption::Float(o), FieldOption::Float(n)) => {
+            classify_numeric_lexical(o.indexed, n.indexed, o.multi_valued, n.multi_valued)
+        }
+        (FieldOption::Boolean(o), FieldOption::Boolean(n)) => {
+            classify_indexed_only(o.indexed, n.indexed)
+        }
+        (FieldOption::DateTime(o), FieldOption::DateTime(n)) => {
+            classify_indexed_only(o.indexed, n.indexed)
+        }
+        (FieldOption::Geo(o), FieldOption::Geo(n)) => classify_indexed_only(o.indexed, n.indexed),
+        (FieldOption::Geo3d(o), FieldOption::Geo3d(n)) => {
+            classify_indexed_only(o.indexed, n.indexed)
+        }
+        // `stored` changes (for every lexical variant, including Bytes) are
+        // always metadata-only: they only affect documents ingested after
+        // the change, never data already on disk.
+        (FieldOption::Bytes(_), FieldOption::Bytes(_)) => FieldChangeKind::MetadataOnly,
+
+        (FieldOption::Hnsw(o), FieldOption::Hnsw(n)) => {
+            classify_vector_common(old, new).max(classify_hnsw_specific(o, n))
+        }
+        (FieldOption::Flat(o), FieldOption::Flat(n)) => {
+            classify_vector_common(old, new).max(classify_flat_specific(o, n))
+        }
+        (FieldOption::Ivf(o), FieldOption::Ivf(n)) => {
+            classify_vector_common(old, new).max(classify_ivf_specific(o, n))
+        }
+
+        (o, n) if o.is_lexical() && n.is_lexical() => FieldChangeKind::Reindex,
+        (o, n) if o.is_vector() && n.is_vector() => {
+            classify_vector_common(o, n).max(FieldChangeKind::Reindex)
+        }
+        _ => FieldChangeKind::Destructive,
+    }
+}
+
+/// Shared classification for `indexed`-only lexical options (Boolean,
+/// DateTime, Geo, Geo3d).
+///
+/// Only the `false -> true` transition requires a reindex: documents
+/// ingested while the field was `indexed: false` have no postings to
+/// search, so turning indexing on only takes effect for documents ingested
+/// afterward unless the field is rebuilt. The reverse direction
+/// (`true -> false`) leaves existing postings in place (the query parser
+/// does not consult `indexed` — see `laurus/src/lexical/index/inverted/writer.rs`,
+/// which is the only place `indexed` is read, at document-ingestion time),
+/// so it is metadata-only, matching the same limitation `delete_field`
+/// already has (Issue #1077's investigation).
+fn classify_indexed_only(old_indexed: bool, new_indexed: bool) -> FieldChangeKind {
+    if !old_indexed && new_indexed {
+        FieldChangeKind::Reindex
+    } else {
+        FieldChangeKind::MetadataOnly
+    }
+}
+
+/// Classification for `TextOption`: `indexed` follows
+/// [`classify_indexed_only`]; an `analyzer` change always requires a
+/// reindex, since existing postings were built with the old analyzer.
+fn classify_text(old: &TextOption, new: &TextOption) -> FieldChangeKind {
+    let mut kind = classify_indexed_only(old.indexed, new.indexed);
+    if old.analyzer != new.analyzer {
+        kind = kind.max(FieldChangeKind::Reindex);
+    }
+    kind
+}
+
+/// Classification shared by `IntegerOption`/`FloatOption`: `indexed`
+/// follows [`classify_indexed_only`]. `multi_valued: false -> true` is
+/// metadata-only (existing single values are still valid single-element
+/// matches under "any match" semantics); the reverse could leave stale
+/// multi-value postings misread as single-valued, so it conservatively
+/// requires a reindex.
+fn classify_numeric_lexical(
+    old_indexed: bool,
+    new_indexed: bool,
+    old_multi_valued: bool,
+    new_multi_valued: bool,
+) -> FieldChangeKind {
+    let mut kind = classify_indexed_only(old_indexed, new_indexed);
+    if old_multi_valued && !new_multi_valued {
+        kind = kind.max(FieldChangeKind::Reindex);
+    }
+    kind
+}
+
+/// Classification for the parameters shared by every vector variant
+/// (`dimension`, `distance`, `embedder`), regardless of whether `old`/`new`
+/// are the same variant.
+///
+/// All three are [`FieldChangeKind::Destructive`]: `dimension` makes
+/// existing vectors the wrong shape; `embedder` changes what a document's
+/// raw input should have produced (the stored vectors were produced by the
+/// old embedder); `distance` is deceptively simple but
+/// `laurus/src/vector/index/config.rs` normalizes stored vectors when
+/// `distance == Cosine`, so a naive rebuild under a new distance would
+/// misinterpret already-normalized vectors.
+///
+/// # Panics
+///
+/// Panics if `old` or `new` is not a vector `FieldOption` — callers must
+/// only invoke this after matching on a vector variant.
+fn classify_vector_common(old: &FieldOption, new: &FieldOption) -> FieldChangeKind {
+    let old_v = old
+        .to_vector()
+        .expect("classify_vector_common: `old` must be a vector FieldOption");
+    let new_v = new
+        .to_vector()
+        .expect("classify_vector_common: `new` must be a vector FieldOption");
+    if old_v.dimension() != new_v.dimension()
+        || old_v.distance() != new_v.distance()
+        || old.embedder_name() != new.embedder_name()
+    {
+        FieldChangeKind::Destructive
+    } else {
+        FieldChangeKind::MetadataOnly
+    }
+}
+
+/// Classification for HNSW-specific parameters. `default_ef_search` and
+/// `base_weight` are metadata-only (read only at query/searcher-construction
+/// time) and need no check. `m`/`ef_construction`/`quantizer`/
+/// `rerank_storage`/`pq_codebook_path` all require rebuilding the graph
+/// from the raw vectors already on disk.
+fn classify_hnsw_specific(old: &HnswOption, new: &HnswOption) -> FieldChangeKind {
+    let mut kind = FieldChangeKind::MetadataOnly;
+    if old.m != new.m
+        || old.ef_construction != new.ef_construction
+        || old.quantizer != new.quantizer
+        || old.rerank_storage != new.rerank_storage
+        || old.pq_codebook_path != new.pq_codebook_path
+    {
+        kind = kind.max(FieldChangeKind::Reindex);
+    }
+    kind
+}
+
+/// Classification for Flat-specific parameters. `base_weight` is
+/// metadata-only; `quantizer`/`rerank_storage` require rebuilding from the
+/// raw vectors already on disk.
+fn classify_flat_specific(old: &FlatOption, new: &FlatOption) -> FieldChangeKind {
+    if old.quantizer != new.quantizer || old.rerank_storage != new.rerank_storage {
+        FieldChangeKind::Reindex
+    } else {
+        FieldChangeKind::MetadataOnly
+    }
+}
+
+/// Classification for IVF-specific parameters. `n_probe` and `base_weight`
+/// are metadata-only (search-time only; the persisted `n_probe` value's
+/// read-back is discarded — see `laurus/src/vector/index/ivf/writer.rs`).
+/// `n_clusters` requires re-running k-means; `quantizer`/`rerank_storage`
+/// require rebuilding from the raw vectors already on disk.
+fn classify_ivf_specific(old: &IvfOption, new: &IvfOption) -> FieldChangeKind {
+    if old.n_clusters != new.n_clusters
+        || old.quantizer != new.quantizer
+        || old.rerank_storage != new.rerank_storage
+    {
+        FieldChangeKind::Reindex
+    } else {
+        FieldChangeKind::MetadataOnly
+    }
+}
+
 #[derive(Default)]
 pub struct SchemaBuilder {
     analyzers: HashMap<String, AnalyzerDefinition>,
@@ -422,6 +654,7 @@ impl SchemaBuilder {
             fields: self.fields,
             default_fields: self.default_fields,
             dynamic_field_policy: self.dynamic_field_policy,
+            pending_reindex: BTreeSet::new(),
         })
     }
 
@@ -534,6 +767,432 @@ mod tests {
             let json = serde_json::to_string(&policy).unwrap();
             let back: DynamicFieldPolicy = serde_json::from_str(&json).unwrap();
             assert_eq!(policy, back);
+        }
+    }
+
+    /// Issue #1079: an empty `pending_reindex` (the common case — no
+    /// destructive `update_field` has ever been applied) is omitted from
+    /// the TOML entirely, keeping `schema.toml` unchanged for schemas that
+    /// never touch the new field.
+    #[test]
+    fn pending_reindex_empty_is_omitted_from_toml() {
+        let schema = Schema::new();
+        let toml = schema.to_toml().unwrap();
+        assert!(
+            !toml.contains("pending_reindex"),
+            "empty pending_reindex should not appear in TOML: {toml}"
+        );
+    }
+
+    /// Issue #1079: a non-empty `pending_reindex` round-trips through TOML,
+    /// so `laurus get schema` (or reopening the index) still surfaces which
+    /// fields need a rebuild.
+    #[test]
+    fn pending_reindex_round_trips_through_toml() {
+        let mut schema = Schema::new();
+        schema.pending_reindex.insert("embedding".to_string());
+        schema.pending_reindex.insert("body".to_string());
+
+        let toml = schema.to_toml().unwrap();
+        let back = Schema::from_toml(&toml).unwrap();
+        assert_eq!(back.pending_reindex, schema.pending_reindex);
+    }
+
+    /// Issue #1079: table-driven coverage of `classify_change` for all 11
+    /// `FieldOption` variants, plus the cross-variant (lexical<->lexical,
+    /// vector<->vector, lexical<->vector) rules.
+    #[test]
+    fn classify_change_table() {
+        use crate::vector::core::distance::DistanceMetric;
+        use crate::vector::core::quantization::QuantizationMethod;
+        use crate::vector::core::rerank::RerankStorageKind;
+        use FieldChangeKind::{Destructive, MetadataOnly, Reindex};
+
+        let text = |f: fn(TextOption) -> TextOption| FieldOption::Text(f(TextOption::default()));
+        let integer = |f: fn(IntegerOption) -> IntegerOption| {
+            FieldOption::Integer(f(IntegerOption::default()))
+        };
+        let float =
+            |f: fn(FloatOption) -> FloatOption| FieldOption::Float(f(FloatOption::default()));
+        let boolean = |f: fn(BooleanOption) -> BooleanOption| {
+            FieldOption::Boolean(f(BooleanOption::default()))
+        };
+        let datetime = |f: fn(DateTimeOption) -> DateTimeOption| {
+            FieldOption::DateTime(f(DateTimeOption::default()))
+        };
+        let geo = |f: fn(GeoOption) -> GeoOption| FieldOption::Geo(f(GeoOption::default()));
+        let geo3d =
+            |f: fn(Geo3dOption) -> Geo3dOption| FieldOption::Geo3d(f(Geo3dOption::default()));
+        let bytes =
+            |f: fn(BytesOption) -> BytesOption| FieldOption::Bytes(f(BytesOption::default()));
+        let hnsw = |f: fn(HnswOption) -> HnswOption| FieldOption::Hnsw(f(HnswOption::default()));
+        let flat = |f: fn(FlatOption) -> FlatOption| FieldOption::Flat(f(FlatOption::default()));
+        let ivf = |f: fn(IvfOption) -> IvfOption| FieldOption::Ivf(f(IvfOption::default()));
+
+        let cases: Vec<(&str, FieldOption, FieldOption, FieldChangeKind)> = vec![
+            // ---- Text ----
+            (
+                "text: stored toggle is metadata-only",
+                text(|o| o),
+                text(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            (
+                "text: indexed false->true requires reindex",
+                text(|o| o.indexed(false)),
+                text(|o| o.indexed(true)),
+                Reindex,
+            ),
+            (
+                "text: indexed true->false is metadata-only",
+                text(|o| o.indexed(true)),
+                text(|o| o.indexed(false)),
+                MetadataOnly,
+            ),
+            (
+                "text: analyzer change requires reindex",
+                text(|o| o),
+                text(|o| o.analyzer("english")),
+                Reindex,
+            ),
+            // ---- Integer ----
+            (
+                "integer: stored toggle is metadata-only",
+                integer(|o| o),
+                integer(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            (
+                "integer: indexed false->true requires reindex",
+                integer(|o| o.indexed(false)),
+                integer(|o| o.indexed(true)),
+                Reindex,
+            ),
+            (
+                "integer: multi_valued false->true is metadata-only",
+                integer(|o| o),
+                integer(|mut o| {
+                    o.multi_valued = true;
+                    o
+                }),
+                MetadataOnly,
+            ),
+            (
+                "integer: multi_valued true->false requires reindex",
+                integer(|mut o| {
+                    o.multi_valued = true;
+                    o
+                }),
+                integer(|o| o),
+                Reindex,
+            ),
+            // ---- Float ----
+            (
+                "float: stored toggle is metadata-only",
+                float(|o| o),
+                float(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            (
+                "float: indexed false->true requires reindex",
+                float(|o| o.indexed(false)),
+                float(|o| o.indexed(true)),
+                Reindex,
+            ),
+            (
+                "float: multi_valued true->false requires reindex",
+                float(|mut o| {
+                    o.multi_valued = true;
+                    o
+                }),
+                float(|o| o),
+                Reindex,
+            ),
+            // ---- Boolean ----
+            (
+                "boolean: stored toggle is metadata-only",
+                boolean(|o| o),
+                boolean(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            (
+                "boolean: indexed false->true requires reindex",
+                boolean(|o| o.indexed(false)),
+                boolean(|o| o.indexed(true)),
+                Reindex,
+            ),
+            // ---- DateTime ----
+            (
+                "datetime: stored toggle is metadata-only",
+                datetime(|o| o),
+                datetime(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            (
+                "datetime: indexed false->true requires reindex",
+                datetime(|o| o.indexed(false)),
+                datetime(|o| o.indexed(true)),
+                Reindex,
+            ),
+            // ---- Geo ----
+            (
+                "geo: stored toggle is metadata-only",
+                geo(|o| o),
+                geo(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            (
+                "geo: indexed false->true requires reindex",
+                geo(|o| o.indexed(false)),
+                geo(|o| o.indexed(true)),
+                Reindex,
+            ),
+            // ---- Geo3d ----
+            (
+                "geo3d: stored toggle is metadata-only",
+                geo3d(|o| o),
+                geo3d(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            (
+                "geo3d: indexed false->true requires reindex",
+                geo3d(|o| o.indexed(false)),
+                geo3d(|o| o.indexed(true)),
+                Reindex,
+            ),
+            // ---- Bytes (no `indexed`; only `stored`) ----
+            (
+                "bytes: stored toggle is metadata-only",
+                bytes(|o| o),
+                bytes(|o| o.stored(false)),
+                MetadataOnly,
+            ),
+            // ---- Hnsw ----
+            (
+                "hnsw: default_ef_search change is metadata-only",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.default_ef_search = Some(64);
+                    o
+                }),
+                MetadataOnly,
+            ),
+            (
+                "hnsw: base_weight change is metadata-only",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.base_weight = 2.0;
+                    o
+                }),
+                MetadataOnly,
+            ),
+            (
+                "hnsw: m change requires reindex",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.m = 32;
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "hnsw: ef_construction change requires reindex",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.ef_construction = 400;
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "hnsw: quantizer change requires reindex",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.quantizer = QuantizationMethod::ProductQuantization { subvector_count: 8 };
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "hnsw: rerank_storage change requires reindex",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.rerank_storage = Some(RerankStorageKind::F32);
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "hnsw: pq_codebook_path change requires reindex",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.pq_codebook_path = Some("codebook.pqcb".to_string());
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "hnsw: dimension change is destructive",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.dimension = 256;
+                    o
+                }),
+                Destructive,
+            ),
+            (
+                "hnsw: distance change is destructive",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.distance = DistanceMetric::Euclidean;
+                    o
+                }),
+                Destructive,
+            ),
+            (
+                "hnsw: embedder change is destructive",
+                hnsw(|o| o),
+                hnsw(|mut o| {
+                    o.embedder = Some("new-embedder".to_string());
+                    o
+                }),
+                Destructive,
+            ),
+            // ---- Flat ----
+            (
+                "flat: base_weight change is metadata-only",
+                flat(|o| o),
+                flat(|mut o| {
+                    o.base_weight = 2.0;
+                    o
+                }),
+                MetadataOnly,
+            ),
+            (
+                "flat: quantizer change requires reindex",
+                flat(|o| o),
+                flat(|mut o| {
+                    o.quantizer = QuantizationMethod::ProductQuantization { subvector_count: 8 };
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "flat: rerank_storage change requires reindex",
+                flat(|o| o),
+                flat(|mut o| {
+                    o.rerank_storage = Some(RerankStorageKind::F32);
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "flat: dimension change is destructive",
+                flat(|o| o),
+                flat(|mut o| {
+                    o.dimension = 256;
+                    o
+                }),
+                Destructive,
+            ),
+            // ---- Ivf ----
+            (
+                "ivf: n_probe change is metadata-only",
+                ivf(|o| o),
+                ivf(|mut o| {
+                    o.n_probe = 8;
+                    o
+                }),
+                MetadataOnly,
+            ),
+            (
+                "ivf: base_weight change is metadata-only",
+                ivf(|o| o),
+                ivf(|mut o| {
+                    o.base_weight = 2.0;
+                    o
+                }),
+                MetadataOnly,
+            ),
+            (
+                "ivf: n_clusters change requires reindex",
+                ivf(|o| o),
+                ivf(|mut o| {
+                    o.n_clusters = 200;
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "ivf: quantizer change requires reindex",
+                ivf(|o| o),
+                ivf(|mut o| {
+                    o.quantizer = QuantizationMethod::ProductQuantization { subvector_count: 8 };
+                    o
+                }),
+                Reindex,
+            ),
+            (
+                "ivf: dimension change is destructive",
+                ivf(|o| o),
+                ivf(|mut o| {
+                    o.dimension = 256;
+                    o
+                }),
+                Destructive,
+            ),
+            // ---- Cross-variant: lexical <-> lexical ----
+            (
+                "text -> integer is a reindex (lexical type change)",
+                text(|o| o),
+                integer(|o| o),
+                Reindex,
+            ),
+            (
+                "bytes -> text is a reindex (lexical type change)",
+                bytes(|o| o),
+                text(|o| o),
+                Reindex,
+            ),
+            // ---- Cross-variant: vector <-> vector ----
+            (
+                "hnsw -> flat with identical dimension/distance/embedder is a reindex",
+                hnsw(|o| o),
+                flat(|o| o),
+                Reindex,
+            ),
+            (
+                "hnsw -> flat with a dimension change is destructive",
+                hnsw(|o| o),
+                flat(|mut o| {
+                    o.dimension = 256;
+                    o
+                }),
+                Destructive,
+            ),
+            (
+                "flat -> ivf with identical dimension/distance/embedder is a reindex",
+                flat(|o| o),
+                ivf(|o| o),
+                Reindex,
+            ),
+            // ---- Cross-variant: lexical <-> vector ----
+            (
+                "text -> hnsw is destructive (different storage subsystem)",
+                text(|o| o),
+                hnsw(|o| o),
+                Destructive,
+            ),
+            (
+                "hnsw -> text is destructive (different storage subsystem)",
+                hnsw(|o| o),
+                text(|o| o),
+                Destructive,
+            ),
+        ];
+
+        for (desc, old, new, expected) in cases {
+            assert_eq!(classify_change(&old, &new), expected, "case failed: {desc}");
         }
     }
 }

--- a/laurus/src/error.rs
+++ b/laurus/src/error.rs
@@ -266,6 +266,15 @@ impl LaurusError {
     pub fn cancelled<S: Into<String>>(msg: S) -> Self {
         LaurusError::OperationCancelled(msg.into())
     }
+
+    /// Creates a [`NotImplemented`](Self::NotImplemented) variant with the given message.
+    ///
+    /// # Parameters
+    ///
+    /// - `msg` - A descriptive message about what is not yet implemented.
+    pub fn not_implemented<S: Into<String>>(msg: S) -> Self {
+        LaurusError::NotImplemented(msg.into())
+    }
 }
 
 #[cfg(test)]

--- a/laurus/src/lib.rs
+++ b/laurus/src/lib.rs
@@ -96,12 +96,15 @@ pub use engine::schema::analyzer::{
     TokenizerConfig,
 };
 pub use engine::schema::embedder::EmbedderDefinition;
-pub use engine::schema::{DynamicFieldPolicy, FieldOption, Schema};
+pub use engine::schema::{
+    DynamicFieldPolicy, FieldChangeKind, FieldOption, Schema, classify_change,
+};
 pub use engine::search::{
     FusionAlgorithm, HybridMode, LexicalSearchOptions, SearchQuery, SearchRequest,
     SearchRequestBuilder, SearchResult, VectorSearchOptions, VectorSearchQuery,
 };
 pub use engine::type_inference::{InferredValue, infer_from_json, infer_option_from_data_value};
+pub use engine::{UpdateFieldOptions, UpdateFieldOutcome};
 pub use error::{LaurusError, Result};
 pub use lexical::core::field::{
     BooleanOption, BytesOption, DateTimeOption, FloatOption, Geo3dOption, GeoOption, IntegerOption,


### PR DESCRIPTION
## Summary

- Adds `laurus/src/engine/schema.rs::classify_change(old, new) -> FieldChangeKind`, classifying a field option change into `MetadataOnly` / `Reindex` / `Destructive` across all 11 `FieldOption` variants and their cross-variant combinations (lexical<->lexical, vector<->vector, lexical<->vector).
- Adds `Schema.pending_reindex: BTreeSet<String>`, persisted in `schema.toml` and surfaced via gRPC `GetSchema` / REST `GET /v1/schema`, so a destructive change is never silently undiscoverable (the Solr failure mode identified in #1077's investigation).
- Adds `Engine::update_field(name, option, opts) -> Result<UpdateFieldOutcome>`. Only `MetadataOnly` changes are applied and persisted in this phase; `Reindex`/`Destructive` are rejected with an error pointing at #1080/#1081. `dry_run: true` never mutates state.
- Adds a `tokio::sync::RwLock<()>` `schema_change_lock` to `Engine` so ingestion and `update_field` can't race each other.

Phase 1 of #1077. Depends on #1078 (merged).

Closes #1079

## Test plan

- [x] `cargo build`/`clippy --all-targets -- -D warnings`/`fmt --check` clean on `laurus`, `laurus-cli`, `laurus-server`, `laurus-mcp`
- [x] `cargo test -p laurus --lib`: 1382 passing, incl. 11 new (table-driven `classify_change` covering all 11 variants + cross-variant rules, 2 TOML round-trip tests for `pending_reindex`, 5 `update_field` tests covering every acceptance criterion)
- [x] `cargo test -p laurus --tests`: all 86 integration test binaries passing (no regressions)
- [x] `cargo test -p laurus-server`: all passing