### PR TITLE
feat(vector): in-place field rebuild for update_field

### DIFF
--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1585,7 +1585,7 @@ impl Engine {
     }
 
     /// Dynamically change an existing field's type or options at runtime
-    /// (Issue #1077/#1079).
+    /// (Issue #1077/#1079/#1080).
     ///
     /// Unlike [`Self::add_field`]/[`Self::delete_field`], a field option
     /// change may or may not require existing on-disk data to be rebuilt.
@@ -1593,11 +1593,24 @@ impl Engine {
     ///
     /// - [`FieldChangeKind::MetadataOnly`](schema::FieldChangeKind::MetadataOnly):
     ///   applied immediately; no existing data is touched.
-    /// - [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex) /
-    ///   [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive):
-    ///   rejected in this phase — rebuilding vector fields (Issue #1080)
-    ///   and lexical fields (Issue #1081) is not yet implemented. `opts.reindex`
-    ///   is reserved for when those land and has no effect yet.
+    /// - [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex) for a
+    ///   **vector** field (e.g. HNSW `m`/`ef_construction`, any index
+    ///   kind's `quantizer`/`rerank_storage`, IVF `n_clusters`): rebuilt in
+    ///   place from the field's existing segments (no document-store
+    ///   read). Requires `opts.reindex == true`.
+    /// - [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive)
+    ///   for a **vector** field (`dimension`/`distance`/`embedder`):
+    ///   existing data is physically discarded and the field recreated
+    ///   empty under the new config (data loss — "warn and proceed", see
+    ///   #1077's investigation). The field is recorded in
+    ///   [`Schema::pending_reindex`](schema::Schema::pending_reindex) so
+    ///   the loss stays discoverable via `GetSchema`. Also requires
+    ///   `opts.reindex == true` — this crate does not gate destructive
+    ///   changes behind a separate flag; see #1077's design discussion.
+    /// - `Reindex`/`Destructive` for a **lexical** field: rejected —
+    ///   rebuilding lexical fields (Issue #1081) is not yet implemented,
+    ///   since the inverted index shares one postings dictionary across
+    ///   every field in a segment.
     ///
     /// Blocks concurrently with ingestion via an internal write lock (see
     /// [`Engine`]'s `schema_change_lock`), so a document is never coerced
@@ -1621,7 +1634,10 @@ impl Engine {
     /// - No field with the given name exists in the schema.
     /// - The change is classified as [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex)
     ///   or [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive)
-    ///   (not yet implemented in this phase).
+    ///   and `opts.reindex` is `false`.
+    /// - The change targets a lexical field and is classified as `Reindex`
+    ///   or `Destructive` (not yet implemented — Issue #1081).
+    /// - The underlying vector rebuild/recreate fails.
     /// - A configured schema-persist hook fails (the in-memory schema has
     ///   already been updated at that point; this is not rolled back).
     pub async fn update_field(
@@ -1666,20 +1682,79 @@ impl Engine {
                     schema: updated,
                 })
             }
-            schema::FieldChangeKind::Reindex => {
-                Err(crate::error::LaurusError::not_implemented(format!(
-                    "updating field '{name}' requires rebuilding existing data, which is not \
-                     yet implemented (see https://github.com/mosuka/laurus/issues/1080 for \
-                     vector fields or https://github.com/mosuka/laurus/issues/1081 for lexical \
-                     fields)"
-                )))
-            }
-            schema::FieldChangeKind::Destructive => {
-                Err(crate::error::LaurusError::not_implemented(format!(
-                    "updating field '{name}' would discard its existing data, which is not yet \
-                     implemented (see https://github.com/mosuka/laurus/issues/1080 for vector \
-                     fields or https://github.com/mosuka/laurus/issues/1081 for lexical fields)"
-                )))
+            schema::FieldChangeKind::Reindex | schema::FieldChangeKind::Destructive => {
+                if !option.is_vector() {
+                    // Lexical rebuild is Issue #1081 (Phase 3): the
+                    // inverted index shares one postings dictionary across
+                    // every field, so this requires full segment
+                    // reconstruction, not yet implemented.
+                    return Err(crate::error::LaurusError::not_implemented(format!(
+                        "updating lexical field '{name}' requires rebuilding existing data, \
+                         which is not yet implemented (see \
+                         https://github.com/mosuka/laurus/issues/1081)"
+                    )));
+                }
+                if !opts.reindex {
+                    return Err(crate::error::LaurusError::invalid_argument(format!(
+                        "updating field '{name}' requires rebuilding or discarding existing \
+                         data (classified as {classification:?}); pass `UpdateFieldOptions {{ \
+                         reindex: true, .. }}` to proceed"
+                    )));
+                }
+
+                let purge = classification == schema::FieldChangeKind::Destructive;
+                if purge {
+                    log::warn!(
+                        "update_field: field '{name}' has a destructive change \
+                         (dimension/distance/embedder); its existing data will be discarded"
+                    );
+                }
+
+                // Same embedder-resolution pattern as `add_field` above:
+                // clone the definition out of the `parking_lot` schema
+                // guard before the `await` (that guard is not `Send`).
+                let field_embedder = if let Some(embedder_name) = option.embedder_name() {
+                    let embedder_def = {
+                        let schema = self.schema.read();
+                        schema.embedders.get(embedder_name).cloned()
+                    };
+                    if let Some(def) = embedder_def {
+                        Some(
+                            crate::embedding::registry::create_embedder_from_definition(
+                                embedder_name,
+                                &def,
+                            )
+                            .await?,
+                        )
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
+                let vector_opt = option
+                    .to_vector()
+                    .expect("is_vector() was true but to_vector() returned None");
+                self.vector
+                    .rebuild_field(name, &vector_opt, field_embedder, purge)
+                    .await?;
+
+                {
+                    let mut schema = self.schema.write();
+                    schema.fields.insert(name.to_string(), option);
+                    if purge {
+                        schema.pending_reindex.insert(name.to_string());
+                    } else {
+                        schema.pending_reindex.remove(name);
+                    }
+                }
+                let updated = self.schema.read().clone();
+                self.persist_schema(&updated)?;
+                Ok(UpdateFieldOutcome {
+                    classification,
+                    schema: updated,
+                })
             }
         }
     }
@@ -3742,8 +3817,10 @@ mod tests {
         assert_eq!(persisted.lock().len(), 1);
     }
 
-    /// Issue #1079: a `Reindex`-classified change (here, an analyzer swap)
-    /// is rejected in this phase, and does not mutate the schema.
+    /// Issue #1079/#1081: a `Reindex`-classified change on a LEXICAL field
+    /// (here, an analyzer swap) is always rejected -- lexical rebuild is
+    /// not yet implemented, regardless of `opts.reindex` -- and does not
+    /// mutate the schema.
     #[tokio::test]
     async fn test_update_field_rejects_reindex_change() {
         let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
@@ -3758,8 +3835,17 @@ mod tests {
         let new_option = schema::FieldOption::Text(
             crate::lexical::core::field::TextOption::default().analyzer("english"),
         );
+        // Even with the opt-in flag set, a lexical rebuild is rejected --
+        // this is a hard "not yet implemented", not a missing opt-in.
         let result = engine
-            .update_field("title", new_option, UpdateFieldOptions::default())
+            .update_field(
+                "title",
+                new_option,
+                UpdateFieldOptions {
+                    reindex: true,
+                    ..Default::default()
+                },
+            )
             .await;
 
         assert!(result.is_err(), "a Reindex change must be rejected");
@@ -3770,8 +3856,10 @@ mod tests {
         }
     }
 
-    /// Issue #1079: a `Destructive`-classified change (here, a dimension
-    /// change) is rejected in this phase, and does not mutate the schema.
+    /// Issue #1080: a `Reindex`/`Destructive`-classified change on a
+    /// VECTOR field is rejected when `opts.reindex` is left at its default
+    /// (`false`) -- the opt-in gate applies to destructive changes too, not
+    /// just expensive-but-safe rebuilds (Issue #1077's design decision).
     #[tokio::test]
     async fn test_update_field_rejects_destructive_change() {
         let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
@@ -3792,11 +3880,125 @@ mod tests {
             .update_field("embedding", new_option, UpdateFieldOptions::default())
             .await;
 
-        assert!(result.is_err(), "a Destructive change must be rejected");
+        assert!(
+            result.is_err(),
+            "a Destructive change without opts.reindex must be rejected"
+        );
         match engine.schema().fields.get("embedding") {
             Some(schema::FieldOption::Hnsw(opt)) => assert_eq!(opt.dimension, 4),
             other => panic!("expected FieldOption::Hnsw, got {other:?}"),
         }
+    }
+
+    /// Issue #1080: a `Reindex`-classified vector change (HNSW `m`) with
+    /// `opts.reindex: true` actually rebuilds the field in place, keeping
+    /// existing vectors and applying the new schema.
+    #[tokio::test]
+    async fn test_update_field_rebuilds_vector_field_reindex_change() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "embedding",
+                schema::FieldOption::Hnsw(
+                    crate::vector::core::field::HnswOption::default().dimension(4),
+                ),
+            )
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        engine
+            .add_document(
+                "doc1",
+                Document::builder()
+                    .add_vector("embedding", vec![1.0, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .await
+            .unwrap();
+        engine.commit().await.unwrap();
+
+        let mut new_hnsw = crate::vector::core::field::HnswOption::default().dimension(4);
+        new_hnsw.m = 32;
+        new_hnsw.ef_construction = 400;
+        let outcome = engine
+            .update_field(
+                "embedding",
+                schema::FieldOption::Hnsw(new_hnsw),
+                UpdateFieldOptions {
+                    reindex: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.classification, schema::FieldChangeKind::Reindex);
+        match outcome.schema.fields.get("embedding") {
+            Some(schema::FieldOption::Hnsw(opt)) => assert_eq!(opt.m, 32),
+            other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+        }
+        assert!(
+            outcome.schema.pending_reindex.is_empty(),
+            "a Reindex (non-destructive) change must not appear in pending_reindex"
+        );
+
+        // The existing document's vector survived the rebuild.
+        let docs = engine.get_documents("doc1").await.unwrap();
+        assert_eq!(docs.len(), 1);
+    }
+
+    /// Issue #1080: a `Destructive`-classified vector change (dimension)
+    /// with `opts.reindex: true` discards existing data, applies the new
+    /// schema, and records the field in `pending_reindex` so the loss
+    /// stays discoverable.
+    #[tokio::test]
+    async fn test_update_field_destructive_change_discards_data_and_records_pending_reindex() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "embedding",
+                schema::FieldOption::Hnsw(
+                    crate::vector::core::field::HnswOption::default().dimension(4),
+                ),
+            )
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        engine
+            .add_document(
+                "doc1",
+                Document::builder()
+                    .add_vector("embedding", vec![1.0, 0.0, 0.0, 0.0])
+                    .build(),
+            )
+            .await
+            .unwrap();
+        engine.commit().await.unwrap();
+
+        let new_option = schema::FieldOption::Hnsw(
+            crate::vector::core::field::HnswOption::default().dimension(8),
+        );
+        let outcome = engine
+            .update_field(
+                "embedding",
+                new_option,
+                UpdateFieldOptions {
+                    reindex: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.classification, schema::FieldChangeKind::Destructive);
+        match outcome.schema.fields.get("embedding") {
+            Some(schema::FieldOption::Hnsw(opt)) => assert_eq!(opt.dimension, 8),
+            other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+        }
+        assert!(
+            outcome.schema.pending_reindex.contains("embedding"),
+            "a Destructive change must be recorded in pending_reindex"
+        );
     }
 
     /// Issue #1079: `dry_run: true` reports the classification without

--- a/laurus/src/vector/index.rs
+++ b/laurus/src/vector/index.rs
@@ -235,15 +235,55 @@ pub trait VectorIndex: Send + Sync + std::fmt::Debug {
     }
 
     /// Remove a vector field from this index's routing (Issue #948: dynamic
-    /// schema evolution). Does NOT delete the field's on-disk data --
-    /// mirrors [`crate::vector::store::VectorStore`]'s existing
-    /// "unregister only" contract for `delete_field`, so the data can be
-    /// recovered by re-adding the field with the same name.
+    /// schema evolution).
+    ///
+    /// With `purge: false`, this only unregisters the field -- mirrors
+    /// [`crate::vector::store::VectorStore`]'s existing "unregister only"
+    /// contract for `delete_field`, so the data can be recovered by
+    /// re-adding the field with the same name.
+    ///
+    /// With `purge: true` (Issue #1080: `Engine::update_field` rebuilding a
+    /// field under a new type), the field's on-disk data is also
+    /// physically deleted, so a same-name re-add under a different type
+    /// cannot misread the old bytes.
     ///
     /// Defaults to `Ok(())` (a no-op): index types without field boundaries
-    /// have nothing to unregister.
-    fn remove_field(&self, _name: &str) -> Result<()> {
+    /// have nothing to unregister or purge.
+    fn remove_field(&self, _name: &str, _purge: bool) -> Result<()> {
         Ok(())
+    }
+
+    /// Rebuild an existing vector field's on-disk data under a new
+    /// configuration, in place (Issue #1080: `Engine::update_field`'s
+    /// `Reindex`-classified vector changes -- e.g. HNSW `m`/
+    /// `ef_construction`, any index kind's `quantizer`/`rerank_storage`,
+    /// IVF `n_clusters`).
+    ///
+    /// The field keeps its identity and physical storage location; only
+    /// the segments are rewritten under `new_config`. Implementations must
+    /// leave the field's existing data completely untouched if the rebuild
+    /// fails partway through (e.g. by writing new segments before
+    /// atomically publishing them, the way [`Self::optimize`] already
+    /// does).
+    ///
+    /// Only valid for parameters that do not change the meaning of
+    /// already-written vectors (dimension, distance metric, and embedder
+    /// must be unchanged -- callers gate this via
+    /// `laurus::engine::schema::classify_change`). Rebuilding under a
+    /// different `dimension`/`distance`/`embedder` is a
+    /// [`crate::engine::schema::FieldChangeKind::Destructive`] change
+    /// instead, handled by the caller as remove-then-add.
+    ///
+    /// # Errors
+    ///
+    /// The default implementation always errors; callers must gate on
+    /// [`Self::supports_dynamic_fields`] first. Implementations also error
+    /// if no field named `name` is registered, or if the rebuild itself
+    /// fails.
+    fn rebuild_field(&self, _name: &str, _new_config: VectorIndexTypeConfig) -> Result<()> {
+        Err(LaurusError::InvalidOperation(
+            "this index type does not support rebuilding fields dynamically".to_string(),
+        ))
     }
 
     /// The configured vector dimension of every field, keyed by field name

--- a/laurus/src/vector/index/multi_field.rs
+++ b/laurus/src/vector/index/multi_field.rs
@@ -425,11 +425,56 @@ impl VectorIndex for MultiFieldVectorIndex {
         Ok(())
     }
 
-    fn remove_field(&self, name: &str) -> Result<()> {
-        // Unregister only -- mirrors `VectorStore::delete_field`'s existing
-        // contract (does not delete on-disk data), so re-adding the same
-        // field name later recovers it.
+    fn remove_field(&self, name: &str, purge: bool) -> Result<()> {
+        // Unregister first (mirrors `VectorStore::delete_field`'s existing
+        // contract when `purge` is false: does not delete on-disk data, so
+        // re-adding the same field name later recovers it).
         self.fields.write().remove(name);
+
+        if purge {
+            // Issue #1080: physically remove the field's files so a
+            // same-name re-add under a DIFFERENT type cannot misread old
+            // bytes. `list_files` on the field's own `PrefixedStorage`
+            // already returns only this field's (prefix-stripped) names.
+            let field_storage = PrefixedStorage::new(name.to_string(), self.storage.clone());
+            let files = field_storage.list_files()?;
+            try_all(files.iter(), |file| field_storage.delete_file(file))?;
+        }
+        Ok(())
+    }
+
+    fn rebuild_field(&self, name: &str, new_config: VectorIndexTypeConfig) -> Result<()> {
+        if !self.fields.read().contains_key(name) {
+            return Err(LaurusError::invalid_argument(format!(
+                "vector field '{name}' does not exist"
+            )));
+        }
+
+        // Reopen the SAME physical namespace under the new config -- this
+        // does not move or lose any data, it only changes which config the
+        // existing segments are read/merged under. `open_or_create` always
+        // takes the `open` path here (the field's `metadata.json` already
+        // exists), so the existing segment manifest is picked up as-is.
+        let field_storage: Arc<dyn Storage> =
+            Arc::new(PrefixedStorage::new(name.to_string(), self.storage.clone()));
+        let index =
+            VectorIndexFactory::open_or_create(field_storage, SUB_INDEX_NAME, new_config.clone())?;
+
+        // Force-merge every existing segment into one new segment under
+        // the new config. `optimize()` writes the new segment fully before
+        // atomically publishing it (see `SegmentedHnswIndex::optimize`), so
+        // a failure here never touches `self.fields` below -- the field's
+        // existing data is left completely untouched.
+        index.optimize()?;
+
+        self.fields.write().insert(
+            name.to_string(),
+            FieldEntry {
+                dimension: new_config.dimension(),
+                distance_metric: new_config.distance_metric(),
+                index: Arc::from(index),
+            },
+        );
         Ok(())
     }
 

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -1085,7 +1085,10 @@ impl VectorStore {
     /// Returns an error if unregistering the field from the underlying
     /// index fails.
     pub async fn delete_field(&self, name: &str) -> Result<()> {
-        self.index.remove_field(name)?;
+        // `purge: false` -- this method's existing "unregister only"
+        // contract (documented above) is unchanged; physical deletion is
+        // opt-in via `Self::rebuild_field` (Issue #1080).
+        self.index.remove_field(name, false)?;
 
         // Remove the field-specific embedder from the PerFieldEmbedder if present.
         let index_embedder = self.index.embedder();
@@ -1111,6 +1114,82 @@ impl VectorStore {
             }
             *writer_guard = None;
         }
+        *self.searcher_cache.write() = None;
+        Ok(())
+    }
+
+    /// Rebuild a field's on-disk data under a new type/option configuration
+    /// (Issue #1080: `Engine::update_field`'s `Reindex`/`Destructive`
+    /// classified vector changes).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The vector field to rebuild. Must already exist.
+    /// * `new_option` - The field's new schema-level vector option.
+    /// * `embedder` - Optional field-specific embedder to register under
+    ///   the new option (same as [`Self::add_field`]).
+    /// * `purge` - `false` for a [`FieldChangeKind::Reindex`]-classified
+    ///   change: rebuilds in place from the field's existing segments via
+    ///   [`VectorIndex::rebuild_field`]. `true` for a
+    ///   [`FieldChangeKind::Destructive`]-classified change: physically
+    ///   discards the field's existing data ([`VectorIndex::remove_field`]
+    ///   with `purge: true`) and recreates it empty under the new config
+    ///   ([`VectorIndex::add_field`]) -- `dimension`/`distance`/`embedder`
+    ///   changes cannot be rebuilt from already-encoded data.
+    ///
+    /// [`FieldChangeKind::Reindex`]: crate::engine::schema::FieldChangeKind::Reindex
+    /// [`FieldChangeKind::Destructive`]: crate::engine::schema::FieldChangeKind::Destructive
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing a cached writer's pending changes
+    /// fails, or if the underlying rebuild (`purge: false`) or purge +
+    /// recreate (`purge: true`) fails. Unlike [`Self::add_field`]/
+    /// [`Self::delete_field`], a flush failure is **propagated**, not
+    /// cached for a later retry — the writer's buffered state is not a
+    /// safe starting point for a rebuild, the same reasoning
+    /// [`Self::optimize`] already applies.
+    pub async fn rebuild_field(
+        &self,
+        name: &str,
+        new_option: &crate::vector::core::field::FieldOption,
+        embedder: Option<Arc<dyn Embedder>>,
+        purge: bool,
+    ) -> Result<()> {
+        let deletion_config = self
+            .config
+            .as_ref()
+            .map(|c| c.deletion_config.clone())
+            .unwrap_or_default();
+        let new_config = self::config::build_field_index_config(
+            new_option,
+            self.index.embedder(),
+            &deletion_config,
+        );
+
+        let mut writer_guard = self.writer_cache.lock().await;
+        let flush_result = match writer_guard.as_mut() {
+            Some(writer) if writer.has_pending_changes() => writer.commit(),
+            _ => Ok(()),
+        };
+        flush_result?;
+        *writer_guard = None;
+
+        if purge {
+            self.index.remove_field(name, true)?;
+            self.index.add_field(name, new_config)?;
+        } else {
+            self.index.rebuild_field(name, new_config)?;
+        }
+
+        if let Some(field_embedder) = embedder {
+            let index_embedder = self.index.embedder();
+            if let Some(pfe) = index_embedder.as_any().downcast_ref::<PerFieldEmbedder>() {
+                pfe.add_embedder(name, field_embedder);
+            }
+        }
+
+        drop(writer_guard);
         *self.searcher_cache.write() = None;
         Ok(())
     }

--- a/laurus/src/vector/store/config.rs
+++ b/laurus/src/vector/store/config.rs
@@ -195,6 +195,7 @@ pub fn build_field_index_config(
             dimension: opt.dimension,
             distance_metric: opt.distance,
             rerank_storage: opt.rerank_storage,
+            quantization_method: opt.quantizer,
             normalize_vectors: opt.distance == DistanceMetric::Cosine,
             auto_compaction: deletion_config.auto_compaction,
             compaction_threshold: deletion_config.compaction_threshold,
@@ -213,6 +214,7 @@ pub fn build_field_index_config(
             n_clusters: opt.n_clusters,
             n_probe: opt.n_probe,
             rerank_storage: opt.rerank_storage,
+            quantization_method: opt.quantizer,
             normalize_vectors: opt.distance == DistanceMetric::Cosine,
             auto_compaction: deletion_config.auto_compaction,
             compaction_threshold: deletion_config.compaction_threshold,
@@ -588,6 +590,66 @@ mod tests {
                 assert_eq!(c.default_ef_search, Some(77));
             }
             other => panic!("expected HNSW config, got {other:?}"),
+        }
+    }
+
+    /// Issue #1080: `build_field_index_config`'s Flat and IVF branches used
+    /// to drop `opt.quantizer` on the floor (falling back to
+    /// `..Default::default()`'s `Scalar8Bit`), while the HNSW branch
+    /// propagated it correctly. A `Flat`/`Ivf` field configured with a
+    /// non-default quantizer must convert with that same quantizer, or
+    /// `Engine::update_field` rebuilding a quantizer change would silently
+    /// no-op for these two index kinds.
+    #[test]
+    fn field_index_configs_propagates_quantizer_for_flat_and_ivf() {
+        let flat_config = VectorIndexConfig::builder()
+            .field(
+                "vec",
+                VectorFieldConfig {
+                    vector: Some(FieldOption::Flat(FlatOption {
+                        quantizer: QuantizationMethod::ProductQuantization { subvector_count: 4 },
+                        rerank_storage: Some(RerankStorageKind::F32),
+                        ..Default::default()
+                    })),
+                    lexical: None,
+                },
+            )
+            .build()
+            .unwrap();
+        match &flat_config.field_index_configs()["vec"] {
+            VectorIndexTypeConfig::Flat(c) => {
+                assert_eq!(
+                    c.quantization_method,
+                    QuantizationMethod::ProductQuantization { subvector_count: 4 }
+                );
+                assert_eq!(c.rerank_storage, Some(RerankStorageKind::F32));
+            }
+            other => panic!("expected Flat config, got {other:?}"),
+        }
+
+        let ivf_config = VectorIndexConfig::builder()
+            .field(
+                "vec",
+                VectorFieldConfig {
+                    vector: Some(FieldOption::Ivf(IvfOption {
+                        quantizer: QuantizationMethod::ProductQuantization { subvector_count: 4 },
+                        rerank_storage: Some(RerankStorageKind::F32),
+                        ..Default::default()
+                    })),
+                    lexical: None,
+                },
+            )
+            .build()
+            .unwrap();
+        match &ivf_config.field_index_configs()["vec"] {
+            VectorIndexTypeConfig::IVF(c) => {
+                assert_eq!(
+                    c.quantization_method,
+                    QuantizationMethod::ProductQuantization { subvector_count: 4 }
+                );
+                assert_eq!(c.rerank_storage, Some(RerankStorageKind::F32));
+            }
+            other => panic!("expected IVF config, got {other:?}"),
         }
     }
 

--- a/laurus/tests/vector_field_rebuild_recall_test.rs
+++ b/laurus/tests/vector_field_rebuild_recall_test.rs
@@ -1,0 +1,172 @@
+//! Issue #1080 acceptance test: rebuilding a live HNSW field's `m` /
+//! `ef_construction` via [`MultiFieldVectorIndex::rebuild_field`] must
+//! actually change search behavior, not just accept the call.
+//!
+//! Mirrors `vector_recall_test.rs`'s ground-truth-via-brute-force approach
+//! (independent of any laurus index code path) but drives the index
+//! through [`MultiFieldVectorIndex`] end to end: build with deliberately
+//! poor HNSW parameters, measure recall, `rebuild_field` to much better
+//! parameters, and confirm recall improves.
+
+use std::any::Any;
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::Vector;
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::index::VectorIndex;
+use laurus::vector::index::config::{HnswIndexConfig, VectorIndexTypeConfig};
+use laurus::vector::index::multi_field::MultiFieldVectorIndex;
+use laurus::vector::search::searcher::{VectorIndexQuery, VectorIndexQueryParams};
+use laurus::{EmbedInput, EmbedInputType, Embedder, Result};
+
+/// Never actually invoked: every vector in this test is inserted directly
+/// via the writer, not embedded from raw input.
+#[derive(Debug)]
+struct UnusedEmbedder;
+
+#[async_trait]
+impl Embedder for UnusedEmbedder {
+    async fn embed(&self, _input: &EmbedInput<'_>) -> Result<Vector> {
+        Err(laurus::LaurusError::invalid_argument(
+            "embedding not used by this test",
+        ))
+    }
+    fn supported_input_types(&self) -> Vec<EmbedInputType> {
+        vec![EmbedInputType::Text]
+    }
+    fn name(&self) -> &str {
+        "unused"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+const DIM: usize = 32;
+const N_VECTORS: usize = 400;
+const N_QUERIES: usize = 30;
+const TOP_K: usize = 10;
+const FIELD: &str = "embedding";
+
+fn pseudo_random_f32(seed: u32, len: usize) -> Vec<f32> {
+    let mut state = seed.wrapping_mul(0x9E37_79B9).wrapping_add(0xDEAD_BEEF);
+    (0..len)
+        .map(|_| {
+            state = state.wrapping_mul(1103515245).wrapping_add(12345);
+            let bits = (state >> 16) as u16;
+            (bits as f32 / u16::MAX as f32) * 2.0 - 1.0
+        })
+        .collect()
+}
+
+fn exact_cosine_distance(a: &[f32], b: &[f32]) -> f32 {
+    let mut dot = 0.0_f32;
+    let mut na = 0.0_f32;
+    let mut nb = 0.0_f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    let denom = na.sqrt() * nb.sqrt();
+    if denom == 0.0 { 1.0 } else { 1.0 - dot / denom }
+}
+
+fn exact_top_k(corpus: &[Vec<f32>], query: &[f32], k: usize) -> HashSet<u64> {
+    let mut scored: Vec<(u64, f32)> = corpus
+        .iter()
+        .enumerate()
+        .map(|(idx, v)| (idx as u64, exact_cosine_distance(query, v)))
+        .collect();
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.into_iter().take(k).map(|(id, _)| id).collect()
+}
+
+fn recall_at_k(exact: &HashSet<u64>, approx: &HashSet<u64>, k: usize) -> f32 {
+    exact.intersection(approx).count() as f32 / k as f32
+}
+
+fn hnsw_config(m: usize, ef_construction: usize) -> VectorIndexTypeConfig {
+    VectorIndexTypeConfig::HNSW(HnswIndexConfig {
+        dimension: DIM,
+        m,
+        ef_construction,
+        distance_metric: DistanceMetric::Cosine,
+        normalize_vectors: true,
+        ..Default::default()
+    })
+}
+
+fn measure_recall(index: &MultiFieldVectorIndex, corpus: &[Vec<f32>], queries: &[Vec<f32>]) -> f32 {
+    let searcher = index.searcher().expect("searcher");
+    let mut total = 0.0_f32;
+    for query in queries {
+        let exact = exact_top_k(corpus, query, TOP_K);
+        let request = VectorIndexQuery {
+            query: Vector::new(query.clone()),
+            params: VectorIndexQueryParams {
+                top_k: TOP_K,
+                ..Default::default()
+            },
+            field_name: Some(FIELD.to_string()),
+            filter: None,
+        };
+        let results = searcher.search(&request).expect("search");
+        let approx: HashSet<u64> = results.results.iter().map(|r| r.doc_id).collect();
+        total += recall_at_k(&exact, &approx, TOP_K);
+    }
+    total / queries.len() as f32
+}
+
+/// Issue #1080 acceptance criterion: "Search results reflect the new
+/// parameters after the rebuild (e.g. recall changes as expected)."
+///
+/// Builds an HNSW field with a deliberately weak graph (`m: 2`,
+/// `ef_construction: 4` -- poor recall by construction, matching the
+/// documented recall-vs-`ef_search`/`m` relationship also exercised in
+/// `vector_recall_test.rs`), measures recall, `rebuild_field`s to a much
+/// stronger graph (`m: 32`, `ef_construction: 200`) with the SAME vectors
+/// already committed, and confirms recall improves substantially -- proof
+/// the rebuild actually re-ran graph construction under the new config,
+/// not just accepted the call as a no-op.
+#[test]
+fn rebuild_field_improves_recall_with_stronger_hnsw_params() {
+    let corpus: Vec<Vec<f32>> = (0..N_VECTORS)
+        .map(|i| pseudo_random_f32(i as u32, DIM))
+        .collect();
+    let queries: Vec<Vec<f32>> = (0..N_QUERIES)
+        .map(|i| pseudo_random_f32(10_000 + i as u32, DIM))
+        .collect();
+
+    let mut fields = BTreeMap::new();
+    fields.insert(FIELD.to_string(), hnsw_config(2, 4));
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let index =
+        MultiFieldVectorIndex::open_or_create(storage, &fields, Arc::new(UnusedEmbedder)).unwrap();
+
+    let mut writer = index.writer().unwrap();
+    let docs: Vec<(u64, String, Vector)> = corpus
+        .iter()
+        .enumerate()
+        .map(|(i, v)| (i as u64, FIELD.to_string(), Vector::new(v.clone())))
+        .collect();
+    writer.build(docs).unwrap();
+    writer.finalize().unwrap();
+    writer.commit().unwrap();
+
+    let weak_recall = measure_recall(&index, &corpus, &queries);
+
+    index.rebuild_field(FIELD, hnsw_config(32, 200)).unwrap();
+
+    let strong_recall = measure_recall(&index, &corpus, &queries);
+
+    assert!(
+        strong_recall > weak_recall + 0.1,
+        "rebuild_field with much stronger HNSW params must measurably improve \
+         recall: weak={weak_recall}, strong={strong_recall}"
+    );
+}

--- a/laurus/tests/vector_multi_field_test.rs
+++ b/laurus/tests/vector_multi_field_test.rs
@@ -290,7 +290,7 @@ fn remove_field_does_not_affect_others() {
         .unwrap();
     writer.commit().unwrap();
 
-    index.remove_field("title_vec").unwrap();
+    index.remove_field("title_vec", false).unwrap();
 
     assert_eq!(
         index.field_dimensions().keys().collect::<Vec<_>>(),
@@ -299,6 +299,234 @@ fn remove_field_does_not_affect_others() {
     );
     let reader = index.reader().unwrap();
     assert_eq!(reader.get_vectors_by_field("body_vec").unwrap().len(), 1);
+}
+
+/// Issue #1080: `remove_field(purge: true)` must physically delete the
+/// field's on-disk data, unlike the `purge: false` case above -- a
+/// same-name re-add must NOT resurrect the old vectors.
+#[test]
+fn remove_field_with_purge_deletes_on_disk_data() {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "title_vec".to_string(),
+        hnsw_config(3, DistanceMetric::Cosine),
+    );
+    let index =
+        MultiFieldVectorIndex::open_or_create(storage(), &fields, Arc::new(MockEmbedder)).unwrap();
+
+    let mut writer = index.writer().unwrap();
+    writer
+        .add_vectors(vec![(1, "title_vec".to_string(), vec_of(&[1.0, 0.0, 0.0]))])
+        .unwrap();
+    writer.commit().unwrap();
+
+    index.remove_field("title_vec", true).unwrap();
+    assert!(
+        index.storage().list_files().unwrap().is_empty(),
+        "purge must physically delete every file under the field's prefix"
+    );
+
+    // Re-adding under the same name must start from a clean slate.
+    index
+        .add_field("title_vec", hnsw_config(3, DistanceMetric::Cosine))
+        .unwrap();
+    let reader = index.reader().unwrap();
+    assert_eq!(
+        reader.get_vectors_by_field("title_vec").unwrap().len(),
+        0,
+        "the old vector must not resurface after a purge + re-add"
+    );
+}
+
+/// Issue #1080: `rebuild_field` must preserve existing vectors while
+/// applying the new config, and must reject a field name that does not
+/// exist.
+#[test]
+fn rebuild_field_preserves_vectors_under_new_config() {
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "title_vec".to_string(),
+        hnsw_config(3, DistanceMetric::Cosine),
+    );
+    let index =
+        MultiFieldVectorIndex::open_or_create(storage(), &fields, Arc::new(MockEmbedder)).unwrap();
+
+    let mut writer = index.writer().unwrap();
+    writer
+        .add_vectors(vec![
+            (1, "title_vec".to_string(), vec_of(&[1.0, 0.0, 0.0])),
+            (2, "title_vec".to_string(), vec_of(&[0.0, 1.0, 0.0])),
+        ])
+        .unwrap();
+    writer.commit().unwrap();
+
+    let mut new_config = hnsw_config(3, DistanceMetric::Cosine);
+    if let VectorIndexTypeConfig::HNSW(c) = &mut new_config {
+        c.m = 32;
+        c.ef_construction = 400;
+    }
+    index.rebuild_field("title_vec", new_config).unwrap();
+
+    let reader = index.reader().unwrap();
+    assert_eq!(
+        reader.get_vectors_by_field("title_vec").unwrap().len(),
+        2,
+        "rebuild must preserve every existing vector, not just re-create an empty field"
+    );
+    assert_eq!(
+        index.field_dimensions()["title_vec"],
+        3,
+        "rebuild must keep reporting the (unchanged) dimension"
+    );
+}
+
+/// Storage decorator failing the next `create_output` whose name has the
+/// armed prefix -- same technique as
+/// `merge_failure_publication_test.rs::FailingStorage`, used here to kill
+/// `rebuild_field`'s internal `optimize()` partway through.
+#[derive(Debug)]
+struct FailingStorage {
+    inner: Arc<dyn Storage>,
+    fail_create_with_prefix: parking_lot::Mutex<Option<String>>,
+}
+
+impl FailingStorage {
+    fn new(inner: Arc<dyn Storage>) -> Self {
+        Self {
+            inner,
+            fail_create_with_prefix: parking_lot::Mutex::new(None),
+        }
+    }
+
+    fn fail_next_create_with_prefix(&self, prefix: &str) {
+        *self.fail_create_with_prefix.lock() = Some(prefix.to_string());
+    }
+}
+
+impl Storage for FailingStorage {
+    fn create_output(&self, name: &str) -> Result<Box<dyn laurus::storage::StorageOutput>> {
+        let armed = {
+            let mut guard = self.fail_create_with_prefix.lock();
+            if guard.as_ref().is_some_and(|p| name.starts_with(p)) {
+                *guard = None;
+                true
+            } else {
+                false
+            }
+        };
+        if armed {
+            return Err(LaurusError::storage(format!(
+                "injected failure creating {name}"
+            )));
+        }
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> Result<Box<dyn laurus::storage::StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+
+    fn open_input(&self, name: &str) -> Result<Box<dyn laurus::storage::StorageInput>> {
+        self.inner.open_input(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> Result<()> {
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn list_files(&self) -> Result<Vec<String>> {
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> Result<u64> {
+        self.inner.file_size(name)
+    }
+
+    fn sync(&self) -> Result<()> {
+        self.inner.sync()
+    }
+
+    fn metadata(&self, name: &str) -> Result<laurus::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+
+    fn create_temp_output(
+        &self,
+        prefix: &str,
+    ) -> Result<(String, Box<dyn laurus::storage::StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Issue #1080 acceptance criterion: "A failure mid-rebuild leaves the
+/// original field index untouched." Kills the write of the merged
+/// segment `optimize()` (inside `rebuild_field`) produces, and confirms
+/// the field's original vectors and dimension are exactly as they were.
+#[test]
+fn rebuild_field_failure_leaves_original_field_untouched() {
+    let inner: Arc<dyn Storage> = storage();
+    let failing = Arc::new(FailingStorage::new(inner));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let mut fields = BTreeMap::new();
+    fields.insert(
+        "title_vec".to_string(),
+        hnsw_config(3, DistanceMetric::Cosine),
+    );
+    let index =
+        MultiFieldVectorIndex::open_or_create(storage, &fields, Arc::new(MockEmbedder)).unwrap();
+
+    let mut writer = index.writer().unwrap();
+    writer
+        .add_vectors(vec![
+            (1, "title_vec".to_string(), vec_of(&[1.0, 0.0, 0.0])),
+            (2, "title_vec".to_string(), vec_of(&[0.0, 1.0, 0.0])),
+        ])
+        .unwrap();
+    writer.commit().unwrap();
+
+    // `rebuild_field` reopens under the field's own `PrefixedStorage`, so
+    // the merged segment's file name is prefixed with the field name.
+    failing.fail_next_create_with_prefix("title_vec/segment_");
+    let mut new_config = hnsw_config(3, DistanceMetric::Cosine);
+    if let VectorIndexTypeConfig::HNSW(c) = &mut new_config {
+        c.m = 32;
+        c.ef_construction = 400;
+    }
+    let result = index.rebuild_field("title_vec", new_config);
+    assert!(result.is_err(), "the injected failure must surface");
+
+    // The field's original data and routing are completely untouched: same
+    // dimension, same vectors, still searchable.
+    assert_eq!(index.field_dimensions()["title_vec"], 3);
+    let reader = index.reader().unwrap();
+    assert_eq!(
+        reader.get_vectors_by_field("title_vec").unwrap().len(),
+        2,
+        "a failed rebuild must not lose or partially apply the original vectors"
+    );
+}
+
+#[test]
+fn rebuild_field_rejects_nonexistent_field() {
+    let fields = BTreeMap::new();
+    let index =
+        MultiFieldVectorIndex::open_or_create(storage(), &fields, Arc::new(MockEmbedder)).unwrap();
+
+    let result = index.rebuild_field("nonexistent", hnsw_config(3, DistanceMetric::Cosine));
+    assert!(result.is_err());
 }
 
 /// `search_batch_with_threshold` must return results in the SAME order as

--- a/laurus/tests/vector_multi_field_wal_test.rs
+++ b/laurus/tests/vector_multi_field_wal_test.rs
@@ -120,7 +120,7 @@ fn removing_the_lagging_field_lifts_the_aggregate_to_the_remaining_fields_minimu
     index.add_field("c", hnsw_config(3)).unwrap();
     assert_eq!(index.last_wal_seq(), 0);
 
-    index.remove_field("c").unwrap();
+    index.remove_field("c", false).unwrap();
     assert_eq!(
         index.last_wal_seq(),
         100,


### PR DESCRIPTION
## Summary

- Adds `VectorIndex::rebuild_field(name, new_config)` (default errors) and adds `purge: bool` to `VectorIndex::remove_field` for physical deletion on a type change.
- `MultiFieldVectorIndex::rebuild_field` reopens a field's existing physical namespace under a new config (existing `segments.json` carries over) and force-merges via `optimize()` -- which already writes a new segment fully before atomically swapping the manifest, so a failure never touches the field's existing data. No shadow-build indirection needed: investigated `SegmentedHnswIndex::optimize()` directly and confirmed this safety property already exists; `Storage` has no prefix-level atomic rename API anyway, so building one would only have added complexity.
- `VectorStore::rebuild_field` expresses both `Reindex` (`purge: false`) and `Destructive` (`purge: true`, data loss) through one API.
- `Engine::update_field`'s `Reindex`/`Destructive` branches are implemented for vector fields. `opts.reindex` is now the real execution gate; `Destructive` changes are recorded in `pending_reindex` and logged. Lexical fields remain not-yet-implemented (Phase 3, #1081).
- Bug fix found along the way: `build_field_index_config`'s Flat/IVF branches never propagated `opt.quantizer` (always fell back to `Scalar8Bit`), which would have made this phase's own quantizer-change acceptance criterion silently no-op for those two index kinds.

Phase 2 of #1077. Depends on #1079 (merged).

Closes #1080

## Test plan

- [x] `cargo build`/`clippy --all-targets -- -D warnings`/`fmt --check` clean on `laurus`, `laurus-cli`, `laurus-server`, `laurus-mcp`
- [x] `cargo test -p laurus --lib`: 1385 passing (+3), incl. the quantizer-propagation regression test
- [x] `cargo test -p laurus --tests`: all 87 integration binaries passing (+1 new file, no regressions), incl.:
  - `rebuild_field` preserving existing vectors under a new config, rejecting unknown fields
  - `remove_field(purge: true)` physically deleting on-disk data (no resurrection on re-add)
  - a `FailingStorage`-injected mid-rebuild failure leaving the original field completely untouched
  - a recall test rebuilding from deliberately weak HNSW params to strong ones and confirming recall measurably improves -- direct proof search results reflect the new parameters
  - two `Engine::update_field` end-to-end tests (successful rebuild, destructive change recorded in `pending_reindex`)
- [x] `cargo test -p laurus-cli -p laurus-server -p laurus-mcp`: all passing, no regressions