### PR TITLE
feat(lexical): in-place segment rebuild for update_field

### DIFF
--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -1585,7 +1585,7 @@ impl Engine {
     }
 
     /// Dynamically change an existing field's type or options at runtime
-    /// (Issue #1077/#1079/#1080).
+    /// (Issue #1077/#1079/#1080/#1081).
     ///
     /// Unlike [`Self::add_field`]/[`Self::delete_field`], a field option
     /// change may or may not require existing on-disk data to be rebuilt.
@@ -1593,24 +1593,31 @@ impl Engine {
     ///
     /// - [`FieldChangeKind::MetadataOnly`](schema::FieldChangeKind::MetadataOnly):
     ///   applied immediately; no existing data is touched.
-    /// - [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex) for a
+    /// - [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex):
+    ///   rebuilt in place from the field's existing on-disk data. For a
     ///   **vector** field (e.g. HNSW `m`/`ef_construction`, any index
-    ///   kind's `quantizer`/`rerank_storage`, IVF `n_clusters`): rebuilt in
-    ///   place from the field's existing segments (no document-store
-    ///   read). Requires `opts.reindex == true`.
-    /// - [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive)
-    ///   for a **vector** field (`dimension`/`distance`/`embedder`):
-    ///   existing data is physically discarded and the field recreated
-    ///   empty under the new config (data loss — "warn and proceed", see
-    ///   #1077's investigation). The field is recorded in
+    ///   kind's `quantizer`/`rerank_storage`, IVF `n_clusters`) this reads
+    ///   only the field's own segments, no document-store read. For a
+    ///   **lexical** field (e.g. a text field's `analyzer`, or
+    ///   `indexed: false -> true`) every segment is rebuilt, re-deriving
+    ///   this field from its stored value while every other field is
+    ///   carried over unchanged — see
+    ///   [`crate::lexical::index::inverted::InvertedIndex::rebuild_field`].
+    ///   Requires `opts.reindex == true`.
+    /// - [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive):
+    ///   the field's existing data is discarded rather than rebuilt (data
+    ///   loss — "warn and proceed", see #1077's investigation). For a
+    ///   **vector** field (`dimension`/`distance`/`embedder`) this
+    ///   physically deletes the field's data and recreates it empty. For a
+    ///   **lexical** field (any change on a `stored: false` field) there
+    ///   is no separate purge step: the rebuild above naturally leaves the
+    ///   field empty for every document that has no stored value to
+    ///   re-derive it from. Either way the field is recorded in
     ///   [`Schema::pending_reindex`](schema::Schema::pending_reindex) so
-    ///   the loss stays discoverable via `GetSchema`. Also requires
-    ///   `opts.reindex == true` — this crate does not gate destructive
-    ///   changes behind a separate flag; see #1077's design discussion.
-    /// - `Reindex`/`Destructive` for a **lexical** field: rejected —
-    ///   rebuilding lexical fields (Issue #1081) is not yet implemented,
-    ///   since the inverted index shares one postings dictionary across
-    ///   every field in a segment.
+    ///   the loss stays discoverable via `GetSchema`, and this also
+    ///   requires `opts.reindex == true` — this crate does not gate
+    ///   destructive changes behind a separate flag; see #1077's design
+    ///   discussion.
     ///
     /// Blocks concurrently with ingestion via an internal write lock (see
     /// [`Engine`]'s `schema_change_lock`), so a document is never coerced
@@ -1635,9 +1642,7 @@ impl Engine {
     /// - The change is classified as [`FieldChangeKind::Reindex`](schema::FieldChangeKind::Reindex)
     ///   or [`FieldChangeKind::Destructive`](schema::FieldChangeKind::Destructive)
     ///   and `opts.reindex` is `false`.
-    /// - The change targets a lexical field and is classified as `Reindex`
-    ///   or `Destructive` (not yet implemented — Issue #1081).
-    /// - The underlying vector rebuild/recreate fails.
+    /// - The underlying vector or lexical rebuild/recreate fails.
     /// - A configured schema-persist hook fails (the in-memory schema has
     ///   already been updated at that point; this is not rolled back).
     pub async fn update_field(
@@ -1683,17 +1688,6 @@ impl Engine {
                 })
             }
             schema::FieldChangeKind::Reindex | schema::FieldChangeKind::Destructive => {
-                if !option.is_vector() {
-                    // Lexical rebuild is Issue #1081 (Phase 3): the
-                    // inverted index shares one postings dictionary across
-                    // every field, so this requires full segment
-                    // reconstruction, not yet implemented.
-                    return Err(crate::error::LaurusError::not_implemented(format!(
-                        "updating lexical field '{name}' requires rebuilding existing data, \
-                         which is not yet implemented (see \
-                         https://github.com/mosuka/laurus/issues/1081)"
-                    )));
-                }
                 if !opts.reindex {
                     return Err(crate::error::LaurusError::invalid_argument(format!(
                         "updating field '{name}' requires rebuilding or discarding existing \
@@ -1705,40 +1699,123 @@ impl Engine {
                 let purge = classification == schema::FieldChangeKind::Destructive;
                 if purge {
                     log::warn!(
-                        "update_field: field '{name}' has a destructive change \
-                         (dimension/distance/embedder); its existing data will be discarded"
+                        "update_field: field '{name}' has a destructive change; its existing \
+                         data will be discarded"
                     );
                 }
 
-                // Same embedder-resolution pattern as `add_field` above:
-                // clone the definition out of the `parking_lot` schema
-                // guard before the `await` (that guard is not `Send`).
-                let field_embedder = if let Some(embedder_name) = option.embedder_name() {
-                    let embedder_def = {
-                        let schema = self.schema.read();
-                        schema.embedders.get(embedder_name).cloned()
-                    };
-                    if let Some(def) = embedder_def {
-                        Some(
-                            crate::embedding::registry::create_embedder_from_definition(
-                                embedder_name,
-                                &def,
+                if option.is_vector() {
+                    // Same embedder-resolution pattern as `add_field`
+                    // above: clone the definition out of the
+                    // `parking_lot` schema guard before the `await`
+                    // (that guard is not `Send`).
+                    let field_embedder = if let Some(embedder_name) = option.embedder_name() {
+                        let embedder_def = {
+                            let schema = self.schema.read();
+                            schema.embedders.get(embedder_name).cloned()
+                        };
+                        if let Some(def) = embedder_def {
+                            Some(
+                                crate::embedding::registry::create_embedder_from_definition(
+                                    embedder_name,
+                                    &def,
+                                )
+                                .await?,
                             )
-                            .await?,
-                        )
+                        } else {
+                            None
+                        }
                     } else {
                         None
-                    }
-                } else {
-                    None
-                };
+                    };
 
-                let vector_opt = option
-                    .to_vector()
-                    .expect("is_vector() was true but to_vector() returned None");
-                self.vector
-                    .rebuild_field(name, &vector_opt, field_embedder, purge)
-                    .await?;
+                    let vector_opt = option
+                        .to_vector()
+                        .expect("is_vector() was true but to_vector() returned None");
+                    self.vector
+                        .rebuild_field(name, &vector_opt, field_embedder, purge)
+                        .await?;
+                } else {
+                    let lexical_opt = option
+                        .to_lexical()
+                        .expect("is_lexical() was true but to_lexical() returned None");
+
+                    // `reconstruct_segment_with_field_override` reads
+                    // `analyzer: None` as "this field is switching to
+                    // `indexed: false`" and skips generating any
+                    // terms/points for it (mirroring a fresh document's
+                    // `should_index` gate). So `field_analyzer` must be
+                    // `Some` whenever the NEW option is indexed --
+                    // including a Text field with no explicit `analyzer`
+                    // spec (which just means "use the index's default
+                    // analyzer", not "no analyzer") and every non-text
+                    // lexical field type (`analyze_field_value` never
+                    // reads the analyzer for those, but still requires a
+                    // reference to be passed through).
+                    let field_is_indexed = match &lexical_opt {
+                        crate::lexical::core::field::FieldOption::Text(opt) => opt.indexed,
+                        crate::lexical::core::field::FieldOption::Integer(opt) => opt.indexed,
+                        crate::lexical::core::field::FieldOption::Float(opt) => opt.indexed,
+                        crate::lexical::core::field::FieldOption::Boolean(opt) => opt.indexed,
+                        crate::lexical::core::field::FieldOption::DateTime(opt) => opt.indexed,
+                        crate::lexical::core::field::FieldOption::Geo(opt) => opt.indexed,
+                        crate::lexical::core::field::FieldOption::Geo3d(opt) => opt.indexed,
+                        crate::lexical::core::field::FieldOption::Bytes(_) => false,
+                    };
+
+                    // Same analyzer-resolution pattern as `add_field`
+                    // above. Note there is no `purge`-driven branch here,
+                    // unlike the vector side: `LexicalStore::rebuild_field`
+                    // re-derives `name`'s terms/points from its stored
+                    // value when one exists, and simply leaves them empty
+                    // when it doesn't (a `stored: false` field never has
+                    // one — this is exactly what makes a `Destructive`
+                    // lexical change "discard existing data" without a
+                    // separate purge step). The resolved analyzer is
+                    // passed through either way so future documents use
+                    // it regardless of classification.
+                    let field_analyzer = if !field_is_indexed {
+                        None
+                    } else if let schema::FieldOption::Text(ref text_opt) = option
+                        && let Some(ref analyzer_spec) = text_opt.analyzer
+                    {
+                        let schema = self.schema.read();
+                        Some(
+                            crate::analysis::analyzer::registry::create_analyzer_from_spec(
+                                analyzer_spec,
+                                &schema.analyzers,
+                                &self.runtime_analyzers,
+                            )
+                            .map_err(|e| {
+                                crate::error::LaurusError::invalid_argument(format!(
+                                    "Failed to resolve analyzer for field '{name}': {e}"
+                                ))
+                            })?,
+                        )
+                    } else {
+                        // A Text field with no explicit override (uses
+                        // the index's default analyzer), or a non-text
+                        // lexical field type. Resolve the store's plain
+                        // default analyzer directly -- NOT whatever is
+                        // presently registered for `name` in the
+                        // `PerFieldAnalyzer` map, which may still hold a
+                        // stale override from a previous change this call
+                        // is in the middle of clearing (that removal only
+                        // takes effect after `rebuild_field` below
+                        // succeeds).
+                        let index_analyzer = self.lexical.analyzer()?;
+                        Some(
+                            index_analyzer
+                                .as_any()
+                                .downcast_ref::<crate::analysis::analyzer::per_field::PerFieldAnalyzer>()
+                                .map(|pfa| pfa.default_analyzer().clone())
+                                .unwrap_or(index_analyzer),
+                        )
+                    };
+
+                    self.lexical
+                        .rebuild_field(name, lexical_opt, field_analyzer)?;
+                }
 
                 {
                     let mut schema = self.schema.write();
@@ -3817,12 +3894,13 @@ mod tests {
         assert_eq!(persisted.lock().len(), 1);
     }
 
-    /// Issue #1079/#1081: a `Reindex`-classified change on a LEXICAL field
-    /// (here, an analyzer swap) is always rejected -- lexical rebuild is
-    /// not yet implemented, regardless of `opts.reindex` -- and does not
-    /// mutate the schema.
+    /// Issue #1081 (Phase 3): a `Reindex`-classified change on a LEXICAL
+    /// field (here, an analyzer swap from the default tokenizing analyzer
+    /// to `keyword`) is rejected while `opts.reindex` is left at its
+    /// default (`false`) -- the opt-in gate applies to lexical fields the
+    /// same way it does to vector fields.
     #[tokio::test]
-    async fn test_update_field_rejects_reindex_change() {
+    async fn test_update_field_rejects_reindex_change_without_opt_in() {
         let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
         let schema = Schema::builder()
             .add_field(
@@ -3835,9 +3913,66 @@ mod tests {
         let new_option = schema::FieldOption::Text(
             crate::lexical::core::field::TextOption::default().analyzer("english"),
         );
-        // Even with the opt-in flag set, a lexical rebuild is rejected --
-        // this is a hard "not yet implemented", not a missing opt-in.
         let result = engine
+            .update_field("title", new_option, UpdateFieldOptions::default())
+            .await;
+
+        assert!(
+            result.is_err(),
+            "a Reindex change without opts.reindex must be rejected"
+        );
+        // The schema is untouched: still the original (analyzer: None) option.
+        match engine.schema().fields.get("title") {
+            Some(schema::FieldOption::Text(opt)) => assert!(opt.analyzer.is_none()),
+            other => panic!("expected FieldOption::Text, got {other:?}"),
+        }
+    }
+
+    /// Issue #1081 (Phase 3): a `Reindex`-classified change on a LEXICAL
+    /// field (an analyzer swap from the default analyzer to `keyword`) with
+    /// `opts.reindex: true` rebuilds the field's postings from the stored
+    /// original text -- not just the schema -- so search results reflect
+    /// the new analyzer's tokenization immediately.
+    #[tokio::test]
+    async fn test_update_field_rebuilds_lexical_field_reindex_change() {
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                schema::FieldOption::Text(crate::lexical::core::field::TextOption::default()),
+            )
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        engine
+            .add_document(
+                "doc1",
+                Document::builder()
+                    .add_text("title", "Rust Programming")
+                    .build(),
+            )
+            .await
+            .unwrap();
+        engine.commit().await.unwrap();
+
+        // Before the change: the default analyzer tokenizes the field, so a
+        // single-word query matches.
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:programming"))
+            .limit(10)
+            .build();
+        assert_eq!(
+            engine.search(request).await.unwrap().len(),
+            1,
+            "default analyzer should tokenize and match a single word"
+        );
+
+        let new_option = schema::FieldOption::Text(
+            crate::lexical::core::field::TextOption::default().analyzer("keyword"),
+        );
+        let outcome = engine
             .update_field(
                 "title",
                 new_option,
@@ -3846,14 +3981,122 @@ mod tests {
                     ..Default::default()
                 },
             )
-            .await;
+            .await
+            .unwrap();
 
-        assert!(result.is_err(), "a Reindex change must be rejected");
-        // The schema is untouched: still the original (analyzer: None) option.
-        match engine.schema().fields.get("title") {
-            Some(schema::FieldOption::Text(opt)) => assert!(opt.analyzer.is_none()),
+        assert_eq!(outcome.classification, schema::FieldChangeKind::Reindex);
+        match outcome.schema.fields.get("title") {
+            Some(schema::FieldOption::Text(opt)) => assert_eq!(
+                opt.analyzer,
+                Some(schema::analyzer::AnalyzerSpec::Named("keyword".into()))
+            ),
             other => panic!("expected FieldOption::Text, got {other:?}"),
         }
+        assert!(
+            outcome.schema.pending_reindex.is_empty(),
+            "a Reindex (non-destructive) change must not appear in pending_reindex"
+        );
+
+        // After the change: postings were rebuilt from the stored original
+        // text under `keyword`, so a single-word query no longer matches...
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:programming"))
+            .limit(10)
+            .build();
+        assert!(
+            engine.search(request).await.unwrap().is_empty(),
+            "keyword analyzer must not match a partial token"
+        );
+
+        // ...but the exact original phrase, as a single keyword term, does.
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:\"Rust Programming\""))
+            .limit(10)
+            .build();
+        assert_eq!(
+            engine.search(request).await.unwrap().len(),
+            1,
+            "keyword analyzer should match the exact stored phrase as one term"
+        );
+    }
+
+    /// Issue #1081 (Phase 3): a lexical field's `indexed: false -> true`
+    /// change, with NO explicit analyzer override in the new option (i.e.
+    /// it uses the index's default analyzer), still rebuilds the field's
+    /// postings from its stored value and makes it searchable. Regression
+    /// test for a bug where `field_analyzer` incorrectly resolved to
+    /// `None` in this case -- indistinguishable, to
+    /// `reconstruct_segment_with_field_override`, from switching the field
+    /// to `indexed: false` -- silently producing empty postings instead of
+    /// tokenizing under the default analyzer.
+    #[tokio::test]
+    async fn test_update_field_rebuilds_lexical_field_indexed_false_to_true() {
+        use crate::lexical::search::searcher::LexicalSearchQuery;
+
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                schema::FieldOption::Text(
+                    crate::lexical::core::field::TextOption::default().indexed(false),
+                ),
+            )
+            .build();
+        let engine = Engine::new(storage, schema).await.unwrap();
+
+        engine
+            .add_document(
+                "doc1",
+                Document::builder()
+                    .add_text("title", "Rust Programming")
+                    .build(),
+            )
+            .await
+            .unwrap();
+        engine.commit().await.unwrap();
+
+        // Before the change: the field is not indexed, so it is not
+        // searchable at all.
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:programming"))
+            .limit(10)
+            .build();
+        assert!(
+            engine.search(request).await.unwrap().is_empty(),
+            "an indexed: false field must not be searchable"
+        );
+
+        let new_option = schema::FieldOption::Text(
+            crate::lexical::core::field::TextOption::default().indexed(true),
+        );
+        let outcome = engine
+            .update_field(
+                "title",
+                new_option,
+                UpdateFieldOptions {
+                    reindex: true,
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(outcome.classification, schema::FieldChangeKind::Reindex);
+
+        // After the change: postings were rebuilt from the stored
+        // original text under the index's default analyzer -- even
+        // though the new option names no explicit analyzer -- so the
+        // same query now matches.
+        let request = crate::engine::search::SearchRequestBuilder::new()
+            .lexical_query(LexicalSearchQuery::from("title:programming"))
+            .limit(10)
+            .build();
+        assert_eq!(
+            engine.search(request).await.unwrap().len(),
+            1,
+            "indexed: false -> true must rebuild postings from the stored value, \
+             even with no explicit analyzer override"
+        );
     }
 
     /// Issue #1080: a `Reindex`/`Destructive`-classified change on a

--- a/laurus/src/engine/schema.rs
+++ b/laurus/src/engine/schema.rs
@@ -356,21 +356,31 @@ pub enum FieldChangeKind {
 pub fn classify_change(old: &FieldOption, new: &FieldOption) -> FieldChangeKind {
     match (old, new) {
         (FieldOption::Text(o), FieldOption::Text(n)) => classify_text(o, n),
-        (FieldOption::Integer(o), FieldOption::Integer(n)) => {
-            classify_numeric_lexical(o.indexed, n.indexed, o.multi_valued, n.multi_valued)
-        }
-        (FieldOption::Float(o), FieldOption::Float(n)) => {
-            classify_numeric_lexical(o.indexed, n.indexed, o.multi_valued, n.multi_valued)
-        }
+        (FieldOption::Integer(o), FieldOption::Integer(n)) => classify_numeric_lexical(
+            o.indexed,
+            n.indexed,
+            o.stored,
+            o.multi_valued,
+            n.multi_valued,
+        ),
+        (FieldOption::Float(o), FieldOption::Float(n)) => classify_numeric_lexical(
+            o.indexed,
+            n.indexed,
+            o.stored,
+            o.multi_valued,
+            n.multi_valued,
+        ),
         (FieldOption::Boolean(o), FieldOption::Boolean(n)) => {
-            classify_indexed_only(o.indexed, n.indexed)
+            classify_indexed_only(o.indexed, n.indexed, o.stored)
         }
         (FieldOption::DateTime(o), FieldOption::DateTime(n)) => {
-            classify_indexed_only(o.indexed, n.indexed)
+            classify_indexed_only(o.indexed, n.indexed, o.stored)
         }
-        (FieldOption::Geo(o), FieldOption::Geo(n)) => classify_indexed_only(o.indexed, n.indexed),
+        (FieldOption::Geo(o), FieldOption::Geo(n)) => {
+            classify_indexed_only(o.indexed, n.indexed, o.stored)
+        }
         (FieldOption::Geo3d(o), FieldOption::Geo3d(n)) => {
-            classify_indexed_only(o.indexed, n.indexed)
+            classify_indexed_only(o.indexed, n.indexed, o.stored)
         }
         // `stored` changes (for every lexical variant, including Bytes) are
         // always metadata-only: they only affect documents ingested after
@@ -398,7 +408,7 @@ pub fn classify_change(old: &FieldOption, new: &FieldOption) -> FieldChangeKind 
 /// Shared classification for `indexed`-only lexical options (Boolean,
 /// DateTime, Geo, Geo3d).
 ///
-/// Only the `false -> true` transition requires a reindex: documents
+/// Only the `false -> true` transition requires rebuilding: documents
 /// ingested while the field was `indexed: false` have no postings to
 /// search, so turning indexing on only takes effect for documents ingested
 /// afterward unless the field is rebuilt. The reverse direction
@@ -407,38 +417,68 @@ pub fn classify_change(old: &FieldOption, new: &FieldOption) -> FieldChangeKind 
 /// which is the only place `indexed` is read, at document-ingestion time),
 /// so it is metadata-only, matching the same limitation `delete_field`
 /// already has (Issue #1077's investigation).
-fn classify_indexed_only(old_indexed: bool, new_indexed: bool) -> FieldChangeKind {
+///
+/// A rebuild needs the field's original values, which only exist when
+/// `old_stored` is `true` (Issue #1081: laurus's lexical rebuild sources
+/// original values from the segment's own stored fields, not a document
+/// store, but the constraint is the same either way — nothing is stored
+/// for `stored: false` fields once a segment is sealed). Without them the
+/// change can only be applied by discarding the field's existing data, so
+/// it is classified `Destructive` instead of `Reindex`.
+fn classify_indexed_only(
+    old_indexed: bool,
+    new_indexed: bool,
+    old_stored: bool,
+) -> FieldChangeKind {
     if !old_indexed && new_indexed {
-        FieldChangeKind::Reindex
+        if old_stored {
+            FieldChangeKind::Reindex
+        } else {
+            FieldChangeKind::Destructive
+        }
     } else {
         FieldChangeKind::MetadataOnly
     }
 }
 
 /// Classification for `TextOption`: `indexed` follows
-/// [`classify_indexed_only`]; an `analyzer` change always requires a
-/// reindex, since existing postings were built with the old analyzer.
+/// [`classify_indexed_only`]; an `analyzer` change always requires
+/// rebuilding from the field's original values, since existing postings
+/// were built with the old analyzer — classified `Reindex` when
+/// `old.stored` (the rebuild can source original text from the segment's
+/// stored fields) or `Destructive` otherwise (see
+/// [`classify_indexed_only`]'s doc comment).
 fn classify_text(old: &TextOption, new: &TextOption) -> FieldChangeKind {
-    let mut kind = classify_indexed_only(old.indexed, new.indexed);
+    let mut kind = classify_indexed_only(old.indexed, new.indexed, old.stored);
     if old.analyzer != new.analyzer {
-        kind = kind.max(FieldChangeKind::Reindex);
+        kind = kind.max(if old.stored {
+            FieldChangeKind::Reindex
+        } else {
+            FieldChangeKind::Destructive
+        });
     }
     kind
 }
 
 /// Classification shared by `IntegerOption`/`FloatOption`: `indexed`
-/// follows [`classify_indexed_only`]. `multi_valued: false -> true` is
+/// follows [`classify_indexed_only`] (`stored`-dependent, since turning
+/// indexing on has no BKD points to source from for a `stored: false`
+/// field that was never indexed). `multi_valued: false -> true` is
 /// metadata-only (existing single values are still valid single-element
 /// matches under "any match" semantics); the reverse could leave stale
 /// multi-value postings misread as single-valued, so it conservatively
-/// requires a reindex.
+/// requires a reindex — always `Reindex`, never `Destructive`, regardless
+/// of `stored`: numeric points are read back from the segment's BKD tree
+/// (the authoritative source, Issue #758), not from stored fields, so a
+/// field that was already `indexed: true` always has a rebuild source.
 fn classify_numeric_lexical(
     old_indexed: bool,
     new_indexed: bool,
+    old_stored: bool,
     old_multi_valued: bool,
     new_multi_valued: bool,
 ) -> FieldChangeKind {
-    let mut kind = classify_indexed_only(old_indexed, new_indexed);
+    let mut kind = classify_indexed_only(old_indexed, new_indexed, old_stored);
     if old_multi_valued && !new_multi_valued {
         kind = kind.max(FieldChangeKind::Reindex);
     }
@@ -855,6 +895,18 @@ mod tests {
                 text(|o| o.analyzer("english")),
                 Reindex,
             ),
+            (
+                "text: analyzer change on a stored:false field is destructive (no original text to re-analyze)",
+                text(|o| o.stored(false)),
+                text(|o| o.stored(false).analyzer("english")),
+                Destructive,
+            ),
+            (
+                "text: indexed false->true on a stored:false field is destructive (no original text to index)",
+                text(|o| o.stored(false).indexed(false)),
+                text(|o| o.stored(false).indexed(true)),
+                Destructive,
+            ),
             // ---- Integer ----
             (
                 "integer: stored toggle is metadata-only",
@@ -884,6 +936,22 @@ mod tests {
                     o
                 }),
                 integer(|o| o),
+                Reindex,
+            ),
+            (
+                "integer: indexed false->true on a stored:false field is destructive (no BKD points, never indexed)",
+                integer(|o| o.stored(false).indexed(false)),
+                integer(|o| o.stored(false).indexed(true)),
+                Destructive,
+            ),
+            (
+                "integer: multi_valued true->false on a stored:false field stays a reindex (BKD is the source, not stored fields)",
+                integer(|mut o| {
+                    o.stored = false;
+                    o.multi_valued = true;
+                    o
+                }),
+                integer(|o| o.stored(false)),
                 Reindex,
             ),
             // ---- Float ----

--- a/laurus/src/lexical/index.rs
+++ b/laurus/src/lexical/index.rs
@@ -13,6 +13,7 @@
 
 use std::sync::Arc;
 
+use crate::analysis::analyzer::analyzer::Analyzer;
 use crate::error::Result;
 use crate::lexical::index::inverted::InvertedIndexStats;
 use crate::lexical::reader::LexicalIndexReader;
@@ -152,6 +153,51 @@ pub trait LexicalIndex: Send + Sync + std::fmt::Debug {
     fn delete_field(&self, _name: &str) -> Result<()> {
         Err(crate::error::LaurusError::invalid_argument(
             "This index implementation does not support dynamic field deletion",
+        ))
+    }
+
+    /// Rebuild an existing field's on-disk data under a new
+    /// option/analyzer, in place (Issue #1081: `Engine::update_field`'s
+    /// `Reindex`-classified lexical changes — e.g. a text field's
+    /// `analyzer`, or `indexed: false -> true` for any lexical field type).
+    ///
+    /// Every segment is rebuilt so `name`'s postings/BKD points match the
+    /// new setting; every other field is carried over unchanged.
+    /// Implementations must leave the field's existing data completely
+    /// untouched if the rebuild fails partway through (e.g. by writing new
+    /// segments before atomically publishing them, mirroring how a normal
+    /// segment merge already works).
+    ///
+    /// Only valid for a change that does not need original values the
+    /// index cannot supply — a field whose value was never stored on disk
+    /// has no original text/points to rebuild from, so callers gate this
+    /// via `laurus::engine::schema::classify_change` (which classifies
+    /// such a change `Destructive` instead, handled by the caller as
+    /// remove-then-add).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The field name. Must already be configured.
+    /// * `option` - The field's new option.
+    /// * `analyzer` - The resolved analyzer to re-tokenize `name`'s stored
+    ///   values with. `None` when the field is being switched to
+    ///   `indexed: false`, or has no analyzer (non-text field types).
+    ///
+    /// # Errors
+    ///
+    /// The default implementation always errors, the same as
+    /// [`Self::add_field`]/[`Self::delete_field`] (mirrors
+    /// [`crate::vector::index::VectorIndex::rebuild_field`]'s contract on
+    /// the vector side). Implementations also error if no field named
+    /// `name` is registered, or if the rebuild itself fails.
+    fn rebuild_field(
+        &self,
+        _name: &str,
+        _option: crate::lexical::core::field::FieldOption,
+        _analyzer: Option<Arc<dyn Analyzer>>,
+    ) -> Result<()> {
+        Err(crate::error::LaurusError::invalid_argument(
+            "This index implementation does not support rebuilding fields dynamically",
         ))
     }
 }

--- a/laurus/src/lexical/index/inverted.rs
+++ b/laurus/src/lexical/index/inverted.rs
@@ -21,6 +21,7 @@ use parking_lot::RwLock;
 
 use serde::{Deserialize, Serialize};
 
+use crate::analysis::analyzer::analyzer::Analyzer;
 use crate::error::{LaurusError, Result};
 use crate::lexical::core::field::FieldOption;
 use crate::lexical::index::LexicalIndex;
@@ -842,6 +843,97 @@ impl LexicalIndex for InvertedIndex {
         // the index level. Fields from the initial config remain in the
         // underlying index data but will be hidden from the engine-level schema.
         self.extra_fields.write().remove(name);
+        Ok(())
+    }
+
+    fn rebuild_field(
+        &self,
+        name: &str,
+        option: FieldOption,
+        analyzer: Option<Arc<dyn Analyzer>>,
+    ) -> Result<()> {
+        self.check_closed()?;
+
+        let segments = self.load_segments()?;
+        if !segments.is_empty() {
+            use self::segment::ManagedSegmentInfo;
+            use self::segment::merge_engine::{MergeConfig, MergeEngine};
+
+            let managed: Vec<ManagedSegmentInfo> = segments
+                .iter()
+                .map(|info| {
+                    let mut mi = ManagedSegmentInfo::new(info.clone());
+                    mi.size_bytes = self.segment_size_bytes(&info.segment_id);
+                    mi
+                })
+                .collect();
+
+            // Reserve one fresh generation per source segment up front, so
+            // every rebuilt segment has a final ID before any I/O runs —
+            // the merge engine writes to `new_segment_ids` directly, no
+            // renumbering needed after the fact.
+            let mut new_segment_ids = Vec::with_capacity(segments.len());
+            for _ in &segments {
+                let generation = self.next_generation()?;
+                new_segment_ids.push(format!("merged_{generation}"));
+            }
+
+            let engine = MergeEngine::new(
+                MergeConfig {
+                    use_compound: self.config.use_compound,
+                    ..MergeConfig::default()
+                },
+                self.storage.clone(),
+            );
+            // Nothing is published yet: a failure here leaves every source
+            // segment and the manifest completely untouched (Issue #1081's
+            // acceptance criterion). Only a partially-written new segment
+            // file might exist on disk, which is not referenced by any
+            // manifest and is swept up as an orphan on next open, the same
+            // as an aborted `perform_merge`.
+            let results = engine.rebuild_field_across_segments(
+                &managed,
+                name,
+                analyzer.as_ref(),
+                &new_segment_ids,
+            )?;
+
+            // Publish the whole batch as ONE manifest write (mirrors
+            // `merge_segment_set`): drop every source and insert every
+            // rebuilt segment, each keeping the generation its own ID
+            // already encodes.
+            let mut new_infos: Vec<SegmentInfo> = Vec::with_capacity(results.len());
+            for (result, new_segment_id) in results.into_iter().zip(&new_segment_ids) {
+                let mut info = result.new_segment.segment_info;
+                if let Some(generation) = segment_manifest::stem_ordinal(new_segment_id) {
+                    info.generation = generation;
+                }
+                new_infos.push(info);
+            }
+            let source_ids: Vec<String> = segments.iter().map(|s| s.segment_id.clone()).collect();
+            segment_manifest::publish_with(
+                self.storage.as_ref(),
+                &self.segment_manifest,
+                |list| {
+                    list.retain(|entry| !source_ids.contains(&entry.segment_id));
+                    for info in new_infos {
+                        segment_manifest::upsert_entry(list, info);
+                    }
+                },
+            )?;
+
+            // Physical cleanup only: the manifest write above already
+            // removed the sources from discovery atomically.
+            for info in &segments {
+                self.delete_segment_files(&info.segment_id)?;
+            }
+        }
+
+        // Update the field's option — same "extra_fields overrides base
+        // config" mechanism `add_field`/`writer()` already rely on (#1081:
+        // this also covers a field originally declared in the base config,
+        // which `add_field` cannot touch since it rejects duplicates).
+        self.extra_fields.write().insert(name.to_string(), option);
         Ok(())
     }
 }

--- a/laurus/src/lexical/index/inverted/segment/merge_engine.rs
+++ b/laurus/src/lexical/index/inverted/segment/merge_engine.rs
@@ -8,12 +8,15 @@ use std::sync::Arc;
 use ahash::AHashMap;
 use roaring::RoaringTreemap;
 
+use crate::analysis::analyzer::analyzer::Analyzer;
 use crate::error::{LaurusError, Result};
 use crate::lexical::core::analyzed::{AnalyzedDocument, AnalyzedTerm};
 use crate::lexical::index::inverted::reader::{InvertedIndexReader, SegmentReader};
 use crate::lexical::index::inverted::segment::SegmentInfo;
 use crate::lexical::index::inverted::segment::{ManagedSegmentInfo, MergeCandidate, MergeStrategy};
-use crate::lexical::index::inverted::writer::{InvertedIndexWriter, InvertedIndexWriterConfig};
+use crate::lexical::index::inverted::writer::{
+    InvertedIndexWriter, InvertedIndexWriterConfig, analyze_field_value,
+};
 use crate::lexical::index::structures::aabb::AABB;
 use crate::lexical::index::structures::visitor::{CellRelation, IntersectVisitor};
 use crate::lexical::reader::LexicalIndexReader;
@@ -392,6 +395,131 @@ impl MergeEngine {
         })
     }
 
+    /// Rebuild every one of `segments` into a same-count set of NEW
+    /// segments, with `target_field` re-derived per
+    /// [`Self::reconstruct_segment_with_field_override`] and every other
+    /// field carried over unchanged (Issue #1081: `Engine::update_field`
+    /// rebuilding a lexical field's analyzer/indexed setting).
+    ///
+    /// Unlike [`Self::merge_segments`] (N sources -> 1 output), this is a
+    /// 1:1 transform — one new segment per source, each keeping that
+    /// source's document set — so the caller
+    /// ([`InvertedIndex::rebuild_field`](crate::lexical::index::inverted::InvertedIndex::rebuild_field))
+    /// can publish the whole batch as a single atomic manifest swap
+    /// without disturbing segment count or merge policy.
+    ///
+    /// `new_segment_ids` must have the same length as `segments`, in the
+    /// same order (the caller reserves one fresh ID per source via
+    /// `InvertedIndex`'s segment ID generator).
+    ///
+    /// # Errors
+    ///
+    /// Returns the first error encountered and aborts the writer that hit
+    /// it (no partial segment is left committed). The caller is expected
+    /// to treat any error here as "nothing published yet" and leave the
+    /// existing segments completely untouched — this function never
+    /// touches a manifest itself.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `new_segment_ids.len() != segments.len()`.
+    pub fn rebuild_field_across_segments(
+        &self,
+        segments: &[ManagedSegmentInfo],
+        target_field: &str,
+        analyzer: Option<&Arc<dyn Analyzer>>,
+        new_segment_ids: &[String],
+    ) -> Result<Vec<MergeResult>> {
+        assert_eq!(
+            segments.len(),
+            new_segment_ids.len(),
+            "one new segment ID is required per source segment"
+        );
+
+        // Detected from the first posting seen across ALL segments (shared
+        // with `reconstruct_segment_with_field_override`'s signature), so
+        // every rebuilt segment agrees on whether to store term positions.
+        let mut store_positions: Option<bool> = None;
+        let mut results = Vec::with_capacity(segments.len());
+
+        for (segment, new_segment_id) in segments.iter().zip(new_segment_ids) {
+            let reader = SegmentReader::open(segment.segment_info.clone(), self.storage.clone())?;
+            let deleted = self.load_deleted_docs(&segment.segment_info)?;
+            let reconstructed = self.reconstruct_segment_with_field_override(
+                &reader,
+                &deleted,
+                &mut store_positions,
+                target_field,
+                analyzer,
+            )?;
+
+            let doc_count = reconstructed.len() as u64;
+            let min_doc_id = reconstructed.iter().map(|(id, _)| *id).min().unwrap_or(0);
+            let max_doc_id = reconstructed.iter().map(|(id, _)| *id).max().unwrap_or(0);
+
+            let writer_config = InvertedIndexWriterConfig {
+                store_term_positions: store_positions.unwrap_or(true),
+                shard_id: segment.segment_info.shard_id,
+                max_buffered_docs: usize::MAX,
+                max_buffer_memory: usize::MAX,
+                use_compound: self.config.use_compound,
+                ..Default::default()
+            };
+            // Deliberately `new`, not `with_shared_metadata` (#1023): see
+            // `perform_merge`'s identical comment above.
+            let mut writer = InvertedIndexWriter::new(self.storage.clone(), writer_config)?;
+            let replayed = (|| -> Result<Vec<String>> {
+                for (doc_id, analyzed) in reconstructed {
+                    writer.upsert_analyzed_document(doc_id, analyzed)?;
+                }
+                writer.flush_buffered_to_segment(new_segment_id)
+            })();
+            let file_paths = match replayed {
+                Ok(paths) => paths,
+                Err(e) => {
+                    writer.abort();
+                    return Err(e);
+                }
+            };
+
+            let segment_info = SegmentInfo {
+                segment_id: new_segment_id.clone(),
+                doc_count,
+                min_doc_id,
+                max_doc_id,
+                generation: 0, // The caller assigns the final generation.
+                has_deletions: false,
+                shard_id: segment.segment_info.shard_id,
+            };
+            let size_bytes = file_paths
+                .iter()
+                .map(|path| {
+                    self.storage
+                        .metadata(path)
+                        .map(|meta| meta.size)
+                        .unwrap_or(0)
+                })
+                .sum();
+            let mut managed_info = ManagedSegmentInfo::new(segment_info);
+            managed_info.size_bytes = size_bytes;
+            managed_info.file_paths = file_paths.clone();
+
+            results.push(MergeResult {
+                new_segment: managed_info,
+                stats: MergeStats {
+                    segments_merged: 1,
+                    docs_processed: doc_count,
+                    postings_merged: doc_count,
+                    shard_id: segment.segment_info.shard_id,
+                    ..Default::default()
+                },
+                file_paths,
+            });
+        }
+
+        Ok(results)
+    }
+
     /// Load the set of deleted doc_ids for a segment from its `.delmap`.
     fn load_deleted_docs(&self, segment_info: &SegmentInfo) -> Result<RoaringTreemap> {
         if !segment_info.has_deletions {
@@ -570,6 +698,165 @@ impl MergeEngine {
             let indexed_fields: Vec<String> = analyzed.field_terms.keys().cloned().collect();
             for field_name in indexed_fields {
                 if let Some(len) = reader.field_length(doc_id, &field_name)? {
+                    analyzed.field_lengths.insert(field_name, len);
+                }
+            }
+
+            out.push((doc_id, analyzed));
+        }
+
+        Ok(out)
+    }
+
+    /// Reconstruct a segment's analyzed documents like
+    /// [`Self::reconstruct_segment`], but with `target_field`'s existing
+    /// postings/BKD points discarded and re-derived from its stored value
+    /// using `analyzer` (Issue #1081).
+    ///
+    /// Every other field is carried over unchanged, exactly as
+    /// [`Self::reconstruct_segment`] does — this is the "field-conversion
+    /// hook" that lets a rebuild change one field's analyzer/indexed
+    /// setting without perturbing the rest of the segment. `analyzer` is
+    /// `None` when the field is being switched to `indexed: false`: its
+    /// terms/points are simply omitted (skipped in Pass 1/1.5 below), the
+    /// same as [`InvertedIndexWriter::analyze_document`]'s `should_index`
+    /// gate for a fresh document.
+    ///
+    /// A live document whose stored fields lack `target_field` entirely is
+    /// left with no terms/points for it, exactly as if the field were
+    /// absent from the original document — this function does not
+    /// validate that `target_field` is actually `stored: true` in the
+    /// schema; callers (`InvertedIndex::rebuild_field`, gated by
+    /// `Engine::update_field`'s `classify_change` call) are responsible
+    /// for that.
+    fn reconstruct_segment_with_field_override(
+        &self,
+        reader: &SegmentReader,
+        deleted: &RoaringTreemap,
+        store_positions: &mut Option<bool>,
+        target_field: &str,
+        analyzer: Option<&Arc<dyn Analyzer>>,
+    ) -> Result<Vec<(u64, AnalyzedDocument)>> {
+        // Pass 1: bucket postings into per-doc analyzed terms, EXCEPT
+        // `target_field` — its old postings were built under the previous
+        // analyzer/indexed setting and are stale under the new one.
+        let mut field_terms: AHashMap<u64, AHashMap<String, Vec<AnalyzedTerm>>> = AHashMap::new();
+        if let Some(dict) = reader.term_dictionary()? {
+            for (term_key, _info) in dict.iter() {
+                let Some((field, term)) = term_key.split_once(':') else {
+                    continue;
+                };
+                if field == target_field {
+                    continue;
+                }
+                if let Some(mut iter) = reader.postings(field, term)? {
+                    while iter.next()? {
+                        // See `reconstruct_segment`'s identical comment:
+                        // `postings` already excludes deleted documents.
+                        let doc_id = iter.doc_id();
+                        let positions = iter.positions()?;
+                        let freq = iter.term_freq();
+                        if store_positions.is_none() {
+                            *store_positions = Some(!positions.is_empty());
+                        }
+                        let terms = field_terms
+                            .entry(doc_id)
+                            .or_default()
+                            .entry(field.to_string())
+                            .or_default();
+                        if positions.is_empty() {
+                            terms.push(AnalyzedTerm {
+                                term: term.to_string(),
+                                position: 0,
+                                frequency: freq as u32,
+                                offset: (0, 0),
+                            });
+                        } else {
+                            for pos in positions {
+                                terms.push(AnalyzedTerm {
+                                    term: term.to_string(),
+                                    position: pos as u32,
+                                    frequency: freq as u32,
+                                    offset: (0, 0),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // BKD points, EXCEPT `target_field` for the same reason (a numeric
+        // field switching `indexed: false -> true`, or being re-derived
+        // for consistency, needs fresh points from its stored value).
+        let mut points: AHashMap<u64, AHashMap<String, Vec<Vec<f64>>>> = AHashMap::new();
+        for field in reader.bkd_field_names()? {
+            let field = field.as_str();
+            if field == target_field {
+                continue;
+            }
+            if let Some(tree) = reader.get_bkd_tree(field)? {
+                let mut visitor = CollectPointsVisitor::default();
+                tree.intersect(&mut visitor)?;
+                for (doc_id, point) in visitor.entries {
+                    if deleted.contains(doc_id) {
+                        continue;
+                    }
+                    points
+                        .entry(doc_id)
+                        .or_default()
+                        .entry(field.to_string())
+                        .or_default()
+                        .push(point);
+                }
+            }
+        }
+
+        // Pass 2: assemble each live document, re-deriving `target_field`
+        // from its stored value via the SAME per-value analysis
+        // `InvertedIndexWriter::analyze_document` uses for fresh ingestion
+        // (`analyze_field_value`), so a rebuilt field is indistinguishable
+        // from one indexed fresh under the new option.
+        let mut out = Vec::new();
+        for doc_id in reader.doc_ids()? {
+            if deleted.contains(doc_id) {
+                continue;
+            }
+            let Some(stored) = reader.document(doc_id)? else {
+                continue;
+            };
+
+            let mut analyzed = AnalyzedDocument::new();
+            analyzed.field_terms = field_terms.remove(&doc_id).unwrap_or_default();
+            analyzed.point_values = points.remove(&doc_id).unwrap_or_default();
+
+            for (field_name, value) in &stored.fields {
+                analyzed
+                    .stored_fields
+                    .insert(field_name.clone(), value.clone());
+            }
+
+            if let (Some(analyzer), Some(target_value)) =
+                (analyzer, stored.fields.get(target_field))
+            {
+                let (terms, pts) = analyze_field_value(target_field, target_value, analyzer)?;
+                if !terms.is_empty() {
+                    analyzed.field_terms.insert(target_field.to_string(), terms);
+                }
+                if !pts.is_empty() {
+                    analyzed.point_values.insert(target_field.to_string(), pts);
+                }
+            }
+            // `analyzer.is_none()` (switching to `indexed: false`):
+            // `target_field`'s terms/points are already absent (Pass 1/1.5
+            // skipped it above), so there is nothing further to do here.
+
+            let indexed_fields: Vec<String> = analyzed.field_terms.keys().cloned().collect();
+            for field_name in indexed_fields {
+                if field_name == target_field {
+                    let len = analyzed.field_terms[&field_name].len() as u32;
+                    analyzed.field_lengths.insert(field_name, len);
+                } else if let Some(len) = reader.field_length(doc_id, &field_name)? {
                     analyzed.field_lengths.insert(field_name, len);
                 }
             }

--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -11,6 +11,7 @@ use crate::analysis::analyzer::analyzer::Analyzer;
 use crate::analysis::analyzer::per_field::PerFieldAnalyzer;
 use crate::analysis::analyzer::standard::StandardAnalyzer;
 use crate::analysis::token::Token;
+use crate::data::DataValue;
 use crate::error::{LaurusError, Result};
 use crate::lexical::core::analyzed::{AnalyzedDocument, AnalyzedTerm};
 use crate::lexical::core::document::Document;
@@ -314,6 +315,170 @@ impl std::fmt::Debug for InvertedIndexWriter {
             .field("stats", &self.stats)
             .finish()
     }
+}
+
+/// Analyze one field's raw value into its indexed terms and/or BKD point
+/// values, using `analyzer` for text (a [`PerFieldAnalyzer`] resolves a
+/// field-specific analyzer by name; any other [`Analyzer`] is applied
+/// uniformly).
+///
+/// Shared by [`InvertedIndexWriter::analyze_document`] (fresh ingestion)
+/// and
+/// [`MergeEngine`](crate::lexical::index::inverted::segment::merge_engine::MergeEngine)'s
+/// field-override rebuild (Issue #1081), so a field rebuilt under a new
+/// analyzer/option is indistinguishable from one indexed fresh under it —
+/// both paths derive a field's analyzed form through this one function.
+///
+/// Returns `(terms, points)`; either may be empty (e.g. a `Bool` value
+/// produces terms but no points; an unindexable value like `Bytes`
+/// produces neither).
+pub(crate) fn analyze_field_value(
+    field_name: &str,
+    val: &DataValue,
+    analyzer: &Arc<dyn Analyzer>,
+) -> Result<(Vec<AnalyzedTerm>, Vec<Vec<f64>>)> {
+    let mut terms = Vec::new();
+    let mut points = Vec::new();
+    match val {
+        DataValue::Text(text) => {
+            // Use analyzer from config (can be PerFieldAnalyzer for field-specific analysis)
+            let tokens =
+                if let Some(per_field) = analyzer.as_any().downcast_ref::<PerFieldAnalyzer>() {
+                    per_field.analyze_field(field_name, text)?
+                } else {
+                    analyzer.analyze(text)?
+                };
+            let token_vec: Vec<Token> = tokens.collect();
+            terms = tokens_to_analyzed_terms(token_vec);
+        }
+
+        DataValue::Int64(num) => {
+            // Convert integer to text for indexing
+            let text = num.to_string();
+            terms.push(AnalyzedTerm {
+                term: text.clone(),
+                position: 0,
+                frequency: 1,
+                offset: (0, text.len()),
+            });
+            points.push(vec![*num as f64]);
+        }
+        DataValue::Float64(num) => {
+            terms.push(AnalyzedTerm {
+                term: num.to_string(),
+                position: 0,
+                frequency: 1,
+                offset: (0, num.to_string().len()),
+            });
+            points.push(vec![*num]);
+        }
+        DataValue::DateTime(dt) => {
+            let ts = dt.timestamp() as f64;
+            terms.push(AnalyzedTerm {
+                term: ts.to_string(),
+                position: 0,
+                frequency: 1,
+                offset: (0, ts.to_string().len()),
+            });
+            points.push(vec![ts]);
+        }
+        DataValue::Bool(b) => {
+            // bool is indexed as "true"/"false" text for lexical queries,
+            // and also stored as a point value (1.0/0.0) for numeric range queries
+            let text = if *b { "true" } else { "false" };
+            terms.push(AnalyzedTerm {
+                term: text.to_string(),
+                position: 0,
+                frequency: 1,
+                offset: (0, text.len()),
+            });
+        }
+        DataValue::Geo(p) => {
+            // Geo points are indexed as 2D points in BKD
+            let text = format!("{},{}", p.lat, p.lon);
+            terms.push(AnalyzedTerm {
+                term: text.clone(),
+                position: 0,
+                frequency: 1,
+                offset: (0, text.len()),
+            });
+            points.push(vec![p.lat, p.lon]);
+        }
+        DataValue::GeoEcef(p) => {
+            // 3D ECEF point: emitting a 3-element point here is what tells
+            // `BKDWriter::new` to build a 3D BKD when the per-field tree is
+            // materialized. Schema-side, `FieldOption::Geo3d` (#298)
+            // classifies the field as lexical and respects the (indexed,
+            // stored) flags exactly like 2D Geo.
+            let text = format!("{},{},{}", p.x, p.y, p.z);
+            terms.push(AnalyzedTerm {
+                term: text.clone(),
+                position: 0,
+                frequency: 1,
+                offset: (0, text.len()),
+            });
+            points.push(vec![p.x, p.y, p.z]);
+        }
+        DataValue::Int64Array(arr) => {
+            // Multi-valued integer field. Each element is a distinct
+            // analyzed term and a distinct 1D BKD point so range queries
+            // match if any value falls in range (Lucene "any match"
+            // semantics).
+            let mut offset = 0usize;
+            for (idx, num) in arr.iter().enumerate() {
+                let text = num.to_string();
+                let len = text.len();
+                terms.push(AnalyzedTerm {
+                    term: text,
+                    position: idx as u32,
+                    frequency: 1,
+                    offset: (offset, offset + len),
+                });
+                offset += len + 1;
+                points.push(vec![*num as f64]);
+            }
+        }
+        DataValue::Float64Array(arr) => {
+            // Multi-valued float field. Same shape as Int64Array.
+            let mut offset = 0usize;
+            for (idx, num) in arr.iter().enumerate() {
+                let text = num.to_string();
+                let len = text.len();
+                terms.push(AnalyzedTerm {
+                    term: text,
+                    position: idx as u32,
+                    frequency: 1,
+                    offset: (offset, offset + len),
+                });
+                offset += len + 1;
+                points.push(vec![*num]);
+            }
+        }
+        // Handle other variants (Bytes, Vector, Null) — not lexically indexed.
+        _ => {}
+    }
+    Ok((terms, points))
+}
+
+/// Convert tokens to analyzed terms.
+pub(crate) fn tokens_to_analyzed_terms(tokens: Vec<Token>) -> Vec<AnalyzedTerm> {
+    let mut term_frequencies = AHashMap::new();
+    let mut analyzed_terms = Vec::new();
+
+    for (position, token) in tokens.into_iter().enumerate() {
+        let term = token.text;
+        let frequency = term_frequencies.entry(term.clone()).or_insert(0);
+        *frequency += 1;
+
+        analyzed_terms.push(AnalyzedTerm {
+            term: term.clone(),
+            position: position as u32,
+            frequency: *frequency,
+            offset: (token.start_offset, token.end_offset),
+        });
+    }
+
+    analyzed_terms
 }
 
 impl InvertedIndexWriter {
@@ -677,8 +842,6 @@ impl InvertedIndexWriter {
 
         // Process each field in the document
         for (field_name, val) in &doc.fields {
-            use crate::data::DataValue;
-
             // 1. Get field option (Schema-aware)
             // If the field is not in schema, we check if it starts with "_" (internal)
             // Internal fields are indexed/stored by default unless explicitly disabled?
@@ -709,155 +872,12 @@ impl InvertedIndexWriter {
 
             // Index the field if enabled
             if should_index {
-                match val {
-                    DataValue::Text(text) => {
-                        // Use analyzer from config (can be PerFieldAnalyzer for field-specific analysis)
-                        let tokens = if let Some(per_field) = self
-                            .config
-                            .analyzer
-                            .as_any()
-                            .downcast_ref::<PerFieldAnalyzer>()
-                        {
-                            per_field.analyze_field(field_name, text)?
-                        } else {
-                            self.config.analyzer.analyze(text)?
-                        };
-                        let token_vec: Vec<Token> = tokens.collect();
-                        let analyzed_terms = self.tokens_to_analyzed_terms(token_vec);
-
-                        field_terms.insert(field_name.clone(), analyzed_terms);
-                    }
-
-                    DataValue::Int64(num) => {
-                        // Convert integer to text for indexing
-                        let text = num.to_string();
-
-                        let analyzed_term = AnalyzedTerm {
-                            term: text.clone(),
-                            position: 0,
-                            frequency: 1,
-                            offset: (0, text.len()),
-                        };
-
-                        field_terms.insert(field_name.clone(), vec![analyzed_term]);
-                        point_values.insert(field_name.clone(), vec![vec![*num as f64]]);
-                    }
-                    DataValue::Float64(num) => {
-                        // ...
-                        field_terms.insert(
-                            field_name.clone(),
-                            vec![AnalyzedTerm {
-                                term: num.to_string(),
-                                position: 0,
-                                frequency: 1,
-                                offset: (0, num.to_string().len()),
-                            }],
-                        );
-                        point_values.insert(field_name.clone(), vec![vec![*num]]);
-                    }
-                    DataValue::DateTime(dt) => {
-                        let ts = dt.timestamp() as f64;
-                        field_terms.insert(
-                            field_name.clone(),
-                            vec![AnalyzedTerm {
-                                term: ts.to_string(),
-                                position: 0,
-                                frequency: 1,
-                                offset: (0, ts.to_string().len()),
-                            }],
-                        );
-                        point_values.insert(field_name.clone(), vec![vec![ts]]);
-                    }
-                    DataValue::Bool(b) => {
-                        // bool is indexed as "true"/"false" text for lexical queries,
-                        // and also stored as a point value (1.0/0.0) for numeric range queries
-                        let text = if *b { "true" } else { "false" };
-                        field_terms.insert(
-                            field_name.clone(),
-                            vec![AnalyzedTerm {
-                                term: text.to_string(),
-                                position: 0,
-                                frequency: 1,
-                                offset: (0, text.len()),
-                            }],
-                        );
-                    }
-                    DataValue::Geo(p) => {
-                        // Geo points are indexed as 2D points in BKD
-                        field_terms.insert(
-                            field_name.clone(),
-                            vec![AnalyzedTerm {
-                                term: format!("{},{}", p.lat, p.lon),
-                                position: 0,
-                                frequency: 1,
-                                offset: (0, format!("{},{}", p.lat, p.lon).len()),
-                            }],
-                        );
-                        point_values.insert(field_name.clone(), vec![vec![p.lat, p.lon]]);
-                    }
-                    DataValue::GeoEcef(p) => {
-                        // 3D ECEF point: emitting a 3-element point here is
-                        // what tells `BKDWriter::new` to build a 3D BKD when
-                        // the per-field tree is materialized. Schema-side,
-                        // `FieldOption::Geo3d` (#298) classifies the field
-                        // as lexical and respects the (indexed, stored)
-                        // flags exactly like 2D Geo.
-                        field_terms.insert(
-                            field_name.clone(),
-                            vec![AnalyzedTerm {
-                                term: format!("{},{},{}", p.x, p.y, p.z),
-                                position: 0,
-                                frequency: 1,
-                                offset: (0, format!("{},{},{}", p.x, p.y, p.z).len()),
-                            }],
-                        );
-                        point_values.insert(field_name.clone(), vec![vec![p.x, p.y, p.z]]);
-                    }
-                    DataValue::Int64Array(arr) => {
-                        // Multi-valued integer field. Each element is a
-                        // distinct analyzed term and a distinct 1D BKD
-                        // point so range queries match if any value falls
-                        // in range (Lucene "any match" semantics).
-                        let mut terms: Vec<AnalyzedTerm> = Vec::with_capacity(arr.len());
-                        let mut points: Vec<Vec<f64>> = Vec::with_capacity(arr.len());
-                        let mut offset = 0usize;
-                        for (idx, num) in arr.iter().enumerate() {
-                            let text = num.to_string();
-                            let len = text.len();
-                            terms.push(AnalyzedTerm {
-                                term: text,
-                                position: idx as u32,
-                                frequency: 1,
-                                offset: (offset, offset + len),
-                            });
-                            offset += len + 1;
-                            points.push(vec![*num as f64]);
-                        }
-                        field_terms.insert(field_name.clone(), terms);
-                        point_values.insert(field_name.clone(), points);
-                    }
-                    DataValue::Float64Array(arr) => {
-                        // Multi-valued float field. Same shape as Int64Array.
-                        let mut terms: Vec<AnalyzedTerm> = Vec::with_capacity(arr.len());
-                        let mut points: Vec<Vec<f64>> = Vec::with_capacity(arr.len());
-                        let mut offset = 0usize;
-                        for (idx, num) in arr.iter().enumerate() {
-                            let text = num.to_string();
-                            let len = text.len();
-                            terms.push(AnalyzedTerm {
-                                term: text,
-                                position: idx as u32,
-                                frequency: 1,
-                                offset: (offset, offset + len),
-                            });
-                            offset += len + 1;
-                            points.push(vec![*num]);
-                        }
-                        field_terms.insert(field_name.clone(), terms);
-                        point_values.insert(field_name.clone(), points);
-                    }
-                    // Handle other variants (Bytes, Vector, Null) — not lexically indexed.
-                    _ => {}
+                let (terms, points) = analyze_field_value(field_name, val, &self.config.analyzer)?;
+                if !terms.is_empty() {
+                    field_terms.insert(field_name.clone(), terms);
+                }
+                if !points.is_empty() {
+                    point_values.insert(field_name.clone(), points);
                 }
             }
 
@@ -879,27 +899,6 @@ impl InvertedIndexWriter {
             field_lengths,
             point_values,
         })
-    }
-
-    /// Convert tokens to analyzed terms.
-    fn tokens_to_analyzed_terms(&self, tokens: Vec<Token>) -> Vec<AnalyzedTerm> {
-        let mut term_frequencies = AHashMap::new();
-        let mut analyzed_terms = Vec::new();
-
-        for (position, token) in tokens.into_iter().enumerate() {
-            let term = token.text;
-            let frequency = term_frequencies.entry(term.clone()).or_insert(0);
-            *frequency += 1;
-
-            analyzed_terms.push(AnalyzedTerm {
-                term: term.clone(),
-                position: position as u32,
-                frequency: *frequency,
-                offset: (token.start_offset, token.end_offset),
-            });
-        }
-
-        analyzed_terms
     }
 
     /// Add an analyzed document to the inverted index.

--- a/laurus/src/lexical/store.rs
+++ b/laurus/src/lexical/store.rs
@@ -779,6 +779,92 @@ impl LexicalStore {
         Ok(())
     }
 
+    /// Rebuild an existing lexical field's on-disk data under a new
+    /// option/analyzer (Issue #1081: `Engine::update_field`'s `Reindex`
+    /// classification for lexical fields — e.g. a text field's
+    /// `analyzer`, or `indexed: false -> true`).
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - The field name. Must already exist.
+    /// * `option` - The field's new configuration.
+    /// * `analyzer` - The field-specific analyzer to register for `name`.
+    ///   `None` removes any existing per-field registration (e.g. the
+    ///   field is being switched to `indexed: false`, or has no
+    ///   analyzer).
+    ///
+    /// # Ordering (this is the fix for Issue #1081's race)
+    ///
+    /// The segment rebuild ([`LexicalIndex::rebuild_field`]) runs FIRST;
+    /// the per-field analyzer swap
+    /// ([`PerFieldAnalyzer::add_analyzer`](crate::analysis::analyzer::per_field::PerFieldAnalyzer::add_analyzer)/
+    /// `remove_analyzer`) only happens after it succeeds. [`Self::add_field`]
+    /// does the opposite (analyzer first) because a brand-new field has no
+    /// existing postings to race against; a rebuild does, so swapping the
+    /// analyzer first would let a query issued mid-rebuild parse against
+    /// the NEW analyzer while on-disk postings are still built with the
+    /// OLD one.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if flushing a cached writer's pending changes
+    /// fails, or if the underlying rebuild fails. Unlike
+    /// [`Self::add_field`]/[`Self::delete_field`], a flush failure is
+    /// **propagated**, not cached for a later retry — the writer's
+    /// buffered state is not a safe starting point for a rebuild that is
+    /// about to replace every segment (same reasoning [`Self::optimize`]
+    /// already applies).
+    pub fn rebuild_field(
+        &self,
+        name: &str,
+        option: crate::lexical::core::field::FieldOption,
+        analyzer: Option<Arc<dyn Analyzer>>,
+    ) -> Result<()> {
+        // Flush pending writes BEFORE the rebuild (mirrors `optimize()`):
+        // the rebuild reads segments straight from storage, so anything
+        // still buffered in the cached writer must be durable first, or
+        // the rebuild would silently miss it. A failure here is
+        // propagated, not swallowed — see the doc comment above.
+        let mut writer_guard = self.writer_cache.lock();
+        if let Some(writer) = writer_guard.as_mut() {
+            writer.commit()?;
+        }
+
+        self.index.rebuild_field(name, option, analyzer.clone())?;
+
+        // Only NOW does the analyzer swap become visible to the query
+        // parser — after the rebuild has fully replaced the field's
+        // postings under the new analyzer (see the ordering note above).
+        if let Ok(index_analyzer) = self.analyzer()
+            && let Some(pfa) = index_analyzer
+                .as_any()
+                .downcast_ref::<crate::analysis::analyzer::per_field::PerFieldAnalyzer>(
+            )
+        {
+            match analyzer {
+                Some(field_analyzer) => pfa.add_analyzer(name, field_analyzer),
+                None => pfa.remove_analyzer(name),
+            }
+        }
+
+        // The rebuild replaced every segment, so the writer's cached
+        // segment view (if it survived the flush above) is now stale —
+        // mirrors `optimize()`'s `invalidate_segment_cache` handling.
+        if let Some(writer) = writer_guard.as_mut()
+            && let Err(e) = writer.invalidate_segment_cache()
+        {
+            *writer_guard = None;
+            drop(writer_guard);
+            *self.searcher_cache.write() = None;
+            return Err(e);
+        }
+        *writer_guard = None;
+        drop(writer_guard);
+        *self.searcher_cache.write() = None;
+
+        Ok(())
+    }
+
     /// Remove a field from the lexical store.
     ///
     /// Removes the field from the underlying index (if it was dynamically added)

--- a/laurus/tests/lexical_field_rebuild_test.rs
+++ b/laurus/tests/lexical_field_rebuild_test.rs
@@ -1,0 +1,304 @@
+//! Issue #1081 (Phase 3) acceptance tests: `Engine::update_field`'s lexical
+//! `Reindex` path must actually rebuild a field's on-disk postings from its
+//! stored original value -- not just accept the call -- and a rebuild that
+//! fails partway through must leave the existing segments and manifest
+//! completely untouched.
+//!
+//! Mirrors `vector_field_rebuild_recall_test.rs` (a real behavior-change
+//! proof, not just a "the call returns Ok" check) and
+//! `merge_failure_publication_test.rs` (a `Storage` decorator that injects a
+//! failure into the merge's segment write, then inspects the manifest).
+
+use std::io::Read;
+use std::sync::Arc;
+
+use laurus::lexical::core::field::TextOption;
+use laurus::lexical::{
+    FieldOption as LexicalFieldOption, LexicalIndexConfig, LexicalSearchRequest, LexicalStore,
+};
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::storage::{Storage, StorageConfig, StorageFactory, StorageInput, StorageOutput};
+use laurus::{
+    BuiltinAnalyzerSpec, Document, Engine, FieldChangeKind, FieldOption as SchemaFieldOption,
+    LaurusError, Result, Schema, UpdateFieldOptions,
+};
+
+/// Same `AnalyzerSpec` shape `japanese_lexical_search_test.rs` uses, but
+/// `body` starts with NO analyzer override (the index's default --
+/// `StandardAnalyzer`) so the test can `update_field` it to Japanese and
+/// compare before/after.
+const SCHEMA_JSON: &str = r#"
+{
+    "default_fields": ["body"],
+    "fields": {
+        "body": { "Text": { "indexed": true, "stored": true, "term_vectors": false } }
+    }
+}
+"#;
+
+async fn engine_with_default_analyzer() -> Result<Engine> {
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let schema: Schema = serde_json::from_str(SCHEMA_JSON).expect("valid schema JSON");
+    Engine::new(storage, schema).await
+}
+
+/// Before the switch, `StandardAnalyzer`'s `\w+` tokenizer treats a whole
+/// unspaced Japanese clause as a single token (Japanese script is
+/// `\p{Alphabetic}`, so nothing splits it except punctuation) -- so a
+/// sub-string query for part of that clause does not match. After
+/// `update_field` swaps `body`'s analyzer to Japanese (Lindera) with
+/// `reindex: true`, the field's postings are rebuilt from the stored
+/// original text into morphemes, and the same query -- now parsed under the
+/// SAME new analyzer via `unified_query_parser` -- matches both documents,
+/// exactly like a field defined with the Japanese analyzer from the start
+/// (`japanese_lexical_search_test.rs`).
+#[tokio::test(flavor = "multi_thread")]
+async fn update_field_switches_to_japanese_analyzer_and_changes_search_behavior() -> Result<()> {
+    let engine = engine_with_default_analyzer().await?;
+
+    engine
+        .put_document(
+            "doc1",
+            Document::builder()
+                .add_text("body", "吾輩は猫である。名前はまだ無い。")
+                .build(),
+        )
+        .await?;
+    engine
+        .put_document(
+            "doc2",
+            Document::builder()
+                .add_text("body", "猫が吾輩を見た日のことである。")
+                .build(),
+        )
+        .await?;
+    engine.commit().await?;
+
+    // Before: the default analyzer does not split the clause into
+    // morphemes, so a partial-clause query matches nothing.
+    let parser = engine.unified_query_parser()?;
+    let request = parser.parse("吾輩は猫").await?;
+    let before = engine.search(request).await?;
+    assert!(
+        before.is_empty(),
+        "the default analyzer should not tokenize unspaced Japanese into \
+         matchable morphemes, got {before:?}"
+    );
+
+    let new_option = SchemaFieldOption::Text(TextOption::default().analyzer(
+        BuiltinAnalyzerSpec::Japanese {
+            mode: "normal".into(),
+            dict: "embedded://ipadic".into(),
+            user_dict: None,
+        },
+    ));
+    let outcome = engine
+        .update_field(
+            "body",
+            new_option,
+            UpdateFieldOptions {
+                reindex: true,
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert_eq!(outcome.classification, FieldChangeKind::Reindex);
+
+    // After: postings were rebuilt from the stored original text under
+    // Lindera, so the bare query's morphemes OR-match both documents.
+    let parser = engine.unified_query_parser()?;
+    let request = parser.parse("吾輩は猫").await?;
+    let results = engine.search(request).await?;
+    let ids: Vec<&str> = results.iter().map(|h| h.id.as_str()).collect();
+    assert_eq!(
+        ids.len(),
+        2,
+        "both docs share morphemes with the query after the rebuild, got {ids:?}"
+    );
+
+    Ok(())
+}
+
+/// Storage decorator failing the next `create_output` whose name has the
+/// armed prefix -- aimed at `InvertedIndex::rebuild_field`'s rebuilt
+/// segment (named `merged_<generation>`, see `inverted.rs`), so the rebuild
+/// dies before it ever calls `segment_manifest::publish_with`.
+#[derive(Debug)]
+struct FailingStorage {
+    inner: Arc<dyn Storage>,
+    fail_create_with_prefix: parking_lot::Mutex<Option<String>>,
+}
+
+impl FailingStorage {
+    fn new(inner: Arc<dyn Storage>) -> Self {
+        Self {
+            inner,
+            fail_create_with_prefix: parking_lot::Mutex::new(None),
+        }
+    }
+
+    fn fail_next_create_with_prefix(&self, prefix: &str) {
+        *self.fail_create_with_prefix.lock() = Some(prefix.to_string());
+    }
+}
+
+impl Storage for FailingStorage {
+    fn create_output(&self, name: &str) -> Result<Box<dyn StorageOutput>> {
+        let armed = {
+            let mut guard = self.fail_create_with_prefix.lock();
+            if guard.as_ref().is_some_and(|p| name.starts_with(p)) {
+                *guard = None;
+                true
+            } else {
+                false
+            }
+        };
+        if armed {
+            return Err(LaurusError::storage(format!(
+                "injected failure creating {name}"
+            )));
+        }
+        self.inner.create_output(name)
+    }
+
+    fn create_output_append(&self, name: &str) -> Result<Box<dyn StorageOutput>> {
+        self.inner.create_output_append(name)
+    }
+
+    fn open_input(&self, name: &str) -> Result<Box<dyn StorageInput>> {
+        self.inner.open_input(name)
+    }
+
+    fn file_exists(&self, name: &str) -> bool {
+        self.inner.file_exists(name)
+    }
+
+    fn delete_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_file(name)
+    }
+
+    fn rename_file(&self, old_name: &str, new_name: &str) -> Result<()> {
+        self.inner.rename_file(old_name, new_name)
+    }
+
+    fn list_files(&self) -> Result<Vec<String>> {
+        self.inner.list_files()
+    }
+
+    fn file_size(&self, name: &str) -> Result<u64> {
+        self.inner.file_size(name)
+    }
+
+    fn sync(&self) -> Result<()> {
+        self.inner.sync()
+    }
+
+    fn metadata(&self, name: &str) -> Result<laurus::storage::FileMetadata> {
+        self.inner.metadata(name)
+    }
+
+    fn create_temp_output(&self, prefix: &str) -> Result<(String, Box<dyn StorageOutput>)> {
+        self.inner.create_temp_output(prefix)
+    }
+
+    fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+fn doc(body: &str) -> Document {
+    Document::builder().add_text("title", body).build()
+}
+
+/// The segment ids the manifest -- the sole publication record -- lists.
+/// Mirrors `merge_failure_publication_test.rs`'s helper: the manifest file
+/// is a varint-length-prefixed payload, not bare JSON.
+fn list_manifest_ids(storage: &Arc<dyn Storage>) -> Vec<String> {
+    let mut input = storage.open_input("segments.json").unwrap();
+    let mut bytes = Vec::new();
+    input.read_to_end(&mut bytes).unwrap();
+    let payload: serde_json::Value = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            let mut len: u64 = 0;
+            let mut shift = 0;
+            let mut cursor = 0usize;
+            loop {
+                let byte = bytes[cursor];
+                cursor += 1;
+                len |= u64::from(byte & 0x7F) << shift;
+                if byte & 0x80 == 0 {
+                    break;
+                }
+                shift += 7;
+            }
+            serde_json::from_slice(&bytes[cursor..cursor + len as usize]).unwrap()
+        }
+    };
+    let mut ids: Vec<String> = payload["segments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["segment_id"].as_str().unwrap().to_string())
+        .collect();
+    ids.sort();
+    ids
+}
+
+/// A rebuild that dies partway through (here, writing the rebuilt
+/// segment's first file) must not publish anything: the manifest must
+/// still list exactly the original segment, and the field's data under
+/// the OLD analyzer must still be intact and searchable.
+#[test]
+fn rebuild_field_failure_leaves_original_segment_and_manifest_untouched() {
+    let inner: Arc<dyn Storage> = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let failing = Arc::new(FailingStorage::new(inner.clone()));
+    let storage: Arc<dyn Storage> = failing.clone();
+
+    let config = LexicalIndexConfig::builder()
+        .add_field("title", LexicalFieldOption::Text(TextOption::default()))
+        .build();
+    let store = LexicalStore::new(storage.clone(), config).unwrap();
+    store.upsert_document(1, doc("Rust Programming")).unwrap();
+    store.commit().unwrap();
+
+    let before_ids = list_manifest_ids(&inner);
+
+    // `rebuild_field` reserves a fresh `merged_<generation>` id for every
+    // source segment up front (see `InvertedIndex::rebuild_field`) and
+    // writes each rebuilt segment before publishing any of them.
+    failing.fail_next_create_with_prefix("merged_");
+    let new_analyzer: Arc<dyn laurus::Analyzer> =
+        Arc::new(laurus::analysis::analyzer::keyword::KeywordAnalyzer::new());
+    let result = store.rebuild_field(
+        "title",
+        LexicalFieldOption::Text(TextOption::default().analyzer("keyword")),
+        Some(new_analyzer),
+    );
+    assert!(
+        result.is_err(),
+        "the injected failure creating the rebuilt segment must surface"
+    );
+
+    // The manifest is byte-for-byte the same set of segment ids as before
+    // the failed rebuild -- nothing was published.
+    let after_ids = list_manifest_ids(&inner);
+    assert_eq!(
+        before_ids, after_ids,
+        "a failed rebuild must not change the published segment set"
+    );
+
+    // The original document is still searchable under the ORIGINAL
+    // (default) analyzer -- e.g. a single tokenized word still matches,
+    // which it would NOT under `keyword` (whole-field exact match only).
+    let hits = store
+        .search(LexicalSearchRequest::new(Box::new(
+            laurus::lexical::TermQuery::new("title", "programming"),
+        )))
+        .unwrap();
+    assert_eq!(
+        hits.hits.len(),
+        1,
+        "a failed rebuild must leave the field's existing data intact and searchable"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `MergeEngine::reconstruct_segment_with_field_override`/`rebuild_field_across_segments`, which rebuild a single field's postings/BKD from a segment's own stored fields under a new analyzer/option while carrying every other field over unchanged. Nothing is published until every source segment converts successfully, so a mid-way failure leaves the existing segments and manifest completely untouched. No document-store full-scan API was added -- investigated the existing `reconstruct_segment` directly and confirmed segment-local data (postings + stored fields + BKD) is already sufficient, and the document store hits the exact same `stored: false` limitation anyway.
- `InvertedIndex::rebuild_field`/`LexicalIndex::rebuild_field` (default errors) publish the whole rebuilt segment set as ONE manifest write.
- `LexicalStore::rebuild_field` runs the segment rebuild FIRST and only swaps the field's `PerFieldAnalyzer` registration AFTER it succeeds -- closing the `per_field.rs:86` race this issue calls out (a query parsed against the new analyzer while postings are still built under the old one).
- `classify_change` now upgrades a `stored: false` field's analyzer/indexed change to `Destructive` (no original value to re-analyze from).
- `Engine::update_field`'s lexical branch is implemented, resolving the analyzer the same way `add_field` does.
- Bug fix found along the way: the lexical branch left `field_analyzer` as `None` whenever the new option was `indexed: true` but named no explicit analyzer (default analyzer, or any non-text lexical field type) -- indistinguishable, to the rebuild, from switching to `indexed: false`, so it silently produced empty postings instead of rebuilding under the default analyzer. Fixed by resolving the index's own default analyzer in that case; added a direct regression test.

Phase 3 of #1077. Depends on #1080 (merged).

Closes #1081

## Test plan

- [x] `cargo build -p laurus`/`clippy -p laurus --all-targets -- -D warnings`/`fmt -p laurus -- --check` clean
- [x] `cargo test -p laurus --lib`: 1387 passing
- [x] `cargo test --workspace` (laurus, laurus-cli, laurus-server, laurus-mcp, laurus-wasm, incl. doctests): all passing, no regressions, incl.:
  - `classify_change_table` extended for `stored: false` analyzer/indexed changes classifying `Destructive`
  - an analyzer swap (default -> `keyword`) via `update_field` that measurably changes search behavior (word match -> exact-phrase-only)
  - `indexed: false -> true` with NO explicit analyzer -- the direct regression test for the bug above
  - a Japanese Lindera analyzer switch via `update_field`: before the switch an unspaced clause is one token and a partial query matches nothing; after, the morphemes OR-match both documents -- also proves the `per_field.rs:86` race is closed, since the query parser picks up the post-rebuild analyzer too
  - a `FailingStorage`-injected mid-rebuild failure leaving the manifest's segment-id set unchanged and the field still searchable under the OLD analyzer
