### PR TITLE
feat(server,cli,mcp): expose update_field via gRPC/REST/CLI/MCP

### DIFF
--- a/docs/ja/src/concepts/schema_and_fields.md
+++ b/docs/ja/src/concepts/schema_and_fields.md
@@ -363,8 +363,7 @@ let schema = Schema::builder()
 
 ## 動的フィールド管理
 
-稼働中のエンジンに対して、フィールドの追加および削除を動的に行えます。
-フィールドの型変更はサポートされていません。
+稼働中のエンジンに対して、フィールドの追加・削除・変更を動的に行えます。
 
 ### フィールドの追加
 
@@ -405,10 +404,34 @@ let updated_schema = engine.delete_field("category").await?;
 - フィールドに紐づくアナライザーおよびエンベッダーの登録が解除されます。
 - 既にインデックスされたデータは物理的に残りますが、スキーマから削除されたフィールドにはアクセスできなくなります。
 
+### フィールドの変更
+
+`Engine::update_field()` を使用すると、既存フィールドの型・オプションを稼働中のエンジンに対して変更できます。
+
+```rust,ignore
+let outcome = engine.update_field(
+    "title",
+    FieldOption::Text(TextOption::default().analyzer("english")),
+    UpdateFieldOptions { reindex: true, ..Default::default() },
+).await?;
+```
+
+変更内容は次の3種類に分類され、`outcome.classification` で確認できます。
+
+- **`MetadataOnly`**（メタデータのみ）: 既存データへの影響がなく、常に適用されます（例: HNSW の `default_ef_search`）。
+- **`Reindex`**（再構築が必要）: 保存済みの元データから再構築が可能です（例: text フィールドの `analyzer` 変更、`indexed: false → true`、HNSW の `m`/`ef_construction` 変更）。
+- **`Destructive`**（破壊的変更）: 元データから再構築できず、既存データを破棄します（例: ベクトルフィールドの `dimension`/`embedder`/`distance` 変更、`stored: false` フィールドの型変更）。
+
+`Reindex` と `Destructive` は、明示的に `UpdateFieldOptions { reindex: true, .. }` を指定しない限り拒否されます（再構築に時間がかかる、あるいはデータを失うため、意図しない実行を防ぐオプトイン方式です）。
+
+`Destructive` な変更を適用すると、対象フィールド名がスキーマの `pending_reindex` に記録されます。これは Solr のように「スキーマとインデックスが静かに食い違う」状態を避けるための可視化機構で、`GetSchema` / `laurus get schema` から確認できます。既存データを失ったフィールドが分かるので、必要に応じてドキュメントの再投入で解消してください。
+
+`UpdateFieldOptions { dry_run: true, .. }` を指定すると、実際には何も適用せずに分類結果だけを確認できます。
+
 ### 共通の注意事項
 
 `Engine::builder().persist_schema_with(hook)` でスキーマ永続化フックを設定していれば、
-`add_field`/`delete_field` は返却前に自らそのフックを呼び出してスキーマを永続化します
+`add_field`/`delete_field`/`update_field` は返却前に自らそのフックを呼び出してスキーマを永続化します
 （`laurus-cli` と `laurus-server` はどちらもこのフックで `schema.toml` への書き出しを
 行っています）。フックを設定していない場合は、従来どおり返却された `Schema` を
 呼び出し側で永続化する必要があります（例: `schema.toml` への書き出し）。

--- a/docs/src/concepts/schema_and_fields.md
+++ b/docs/src/concepts/schema_and_fields.md
@@ -383,9 +383,8 @@ returning silently-empty results.
 
 ## Dynamic Field Management
 
-Fields can be added to or removed from a running engine at runtime.
-Type changes are not supported—remove the field and re-add it with the
-new type instead.
+Fields can be added to, removed from, or changed on a running engine at
+runtime.
 
 ### Adding a Field
 
@@ -413,11 +412,11 @@ Existing documents are unaffected—they simply have no value for the new
 field.
 
 If a schema-persist hook was configured via
-`Engine::builder().persist_schema_with(hook)`, `add_field`/`delete_field`
-call it themselves before returning, persisting the schema on the
-caller's behalf (both `laurus-cli` and `laurus-server` configure this
-hook to write `schema.toml`). Otherwise, as before, the returned `Schema`
-should be persisted (e.g., to `schema.toml`) by the caller.
+`Engine::builder().persist_schema_with(hook)`, `add_field`/`delete_field`/
+`update_field` call it themselves before returning, persisting the schema
+on the caller's behalf (both `laurus-cli` and `laurus-server` configure
+this hook to write `schema.toml`). Otherwise, as before, the returned
+`Schema` should be persisted (e.g., to `schema.toml`) by the caller.
 
 ### Removing a Field
 
@@ -435,6 +434,44 @@ When a field is deleted:
 - If the field was listed in `default_fields`, it is automatically removed.
 - Any per-field analyzer or embedder registered for the field is
   unregistered.
+
+### Changing a Field
+
+Use `Engine::update_field()` to change an existing field's type/options on
+a running engine.
+
+```rust,ignore
+let outcome = engine.update_field(
+    "title",
+    FieldOption::Text(TextOption::default().analyzer("english")),
+    UpdateFieldOptions { reindex: true, ..Default::default() },
+).await?;
+```
+
+The requested change is classified into one of three kinds, reported as
+`outcome.classification`:
+
+- **`MetadataOnly`** — no existing data is affected; always applied (e.g.
+  an HNSW field's `default_ef_search`).
+- **`Reindex`** — can be rebuilt from the field's already-stored values
+  (e.g. a text field's `analyzer`, `indexed: false → true`, or an HNSW
+  field's `m`/`ef_construction`).
+- **`Destructive`** — cannot be rebuilt from existing data; applying it
+  discards the field's data (e.g. a vector field's `dimension`/`embedder`/
+  `distance`, or a type change on a `stored: false` field).
+
+`Reindex` and `Destructive` changes are rejected unless you explicitly
+pass `UpdateFieldOptions { reindex: true, .. }` — an opt-in gate against
+accidentally triggering an expensive rebuild or a data-losing change.
+
+Applying a `Destructive` change records the field's name in the schema's
+`pending_reindex` set. This is a visibility mechanism against the known
+Solr failure mode where the schema and the index silently drift apart —
+check it via `GetSchema` / `laurus get schema` to find fields whose data
+no longer matches the schema, and re-ingest their documents as needed.
+
+Pass `UpdateFieldOptions { dry_run: true, .. }` to see how a change would
+be classified without applying anything.
 
 ## Schema Design Tips
 

--- a/laurus-cli/src/cli.rs
+++ b/laurus-cli/src/cli.rs
@@ -39,6 +39,8 @@ pub enum Command {
     Put(PutCommand),
     /// Delete a resource.
     Delete(DeleteCommand),
+    /// Update a resource.
+    Update(UpdateCommand),
     /// Commit pending changes.
     Commit,
     /// Train an auxiliary index structure (e.g. a shared PQ codebook).
@@ -243,6 +245,48 @@ pub enum DeleteResource {
         /// The name of the field to delete.
         #[arg(long)]
         name: String,
+    },
+}
+
+// --- Update ---
+
+/// CLI arguments for the `update` subcommand.
+///
+/// Holds the target resource to update (e.g. an existing field).
+#[derive(Parser)]
+pub struct UpdateCommand {
+    #[command(subcommand)]
+    pub resource: UpdateResource,
+}
+
+#[derive(Subcommand)]
+pub enum UpdateResource {
+    /// Change an existing field's type/options.
+    ///
+    /// Metadata-only changes (e.g. an HNSW field's `default_ef_search`)
+    /// apply immediately. A change that requires rebuilding or discarding
+    /// existing on-disk data (e.g. a text field's `analyzer`, or a vector
+    /// field's `dimension`) is rejected unless `--reindex` is given.
+    Field {
+        /// The name of the field to update. Must already exist.
+        #[arg(long)]
+        name: String,
+        /// The field's new configuration as a JSON string.
+        ///
+        /// Uses the same externally-tagged format as the schema TOML.
+        /// Examples:
+        ///   '{"Text": {"indexed": true, "stored": true, "analyzer": "english"}}'
+        ///   '{"Hnsw": {"dimension": 384, "m": 32, "ef_construction": 400}}'
+        #[arg(long)]
+        field_option: String,
+        /// Opt in to a change that requires rebuilding or discarding
+        /// existing on-disk data. Ignored for a metadata-only change.
+        #[arg(long, default_value_t = false)]
+        reindex: bool,
+        /// Classify the change and print the result without applying
+        /// anything.
+        #[arg(long, default_value_t = false)]
+        dry_run: bool,
     },
 }
 

--- a/laurus-cli/src/commands.rs
+++ b/laurus-cli/src/commands.rs
@@ -13,6 +13,7 @@
 //! - [`search`] - One-shot search query execution.
 //! - [`serve`] - gRPC (and optional HTTP gateway) server.
 //! - [`train`] - Train auxiliary index structures (shared PQ codebook).
+//! - [`update`] - Change a resource (an existing field's type/options).
 
 pub mod add;
 pub mod bulk;
@@ -26,3 +27,4 @@ pub mod repl;
 pub mod search;
 pub mod serve;
 pub mod train;
+pub mod update;

--- a/laurus-cli/src/commands/update.rs
+++ b/laurus-cli/src/commands/update.rs
@@ -1,0 +1,72 @@
+//! Implementations for the `update` subcommand.
+//!
+//! Handles changing resources in an existing index:
+//!
+//! - [`run_field`] - Change an existing field's type/options.
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use laurus::{FieldOption, UpdateFieldOptions};
+
+use crate::context;
+
+/// Execute the `update field` command.
+///
+/// Opens the index at `index_dir`, parses the field option JSON, and calls
+/// [`Engine::update_field`], which persists the updated schema itself (the
+/// engine returned by [`context::open_index`] is configured with a
+/// schema-persist hook — see Issue #1078). A `Reindex`- or
+/// `Destructive`-classified change (e.g. a text field's `analyzer`, or a
+/// vector field's `dimension`) is rejected unless `reindex` is `true` --
+/// see [`UpdateFieldOptions::reindex`].
+///
+/// # Arguments
+///
+/// * `name` - The name of the field to update. Must already exist.
+/// * `field_option_json` - A JSON string describing the field's new
+///   configuration (e.g. `{"Text": {"indexed": true, "stored": true,
+///   "analyzer": "english"}}`).
+/// * `reindex` - Opt-in gate for a `Reindex`/`Destructive` change.
+/// * `dry_run` - When `true`, classifies the change and reports it without
+///   applying anything.
+/// * `index_dir` - Path to the index directory holding the index.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The index cannot be opened.
+/// - The JSON string cannot be parsed into a [`FieldOption`].
+/// - The engine rejects the change (e.g. unknown field, a `Reindex`/
+///   `Destructive` change without `--reindex`).
+/// - The updated schema cannot be persisted to disk.
+pub async fn run_field(
+    name: &str,
+    field_option_json: &str,
+    reindex: bool,
+    dry_run: bool,
+    index_dir: &Path,
+) -> Result<()> {
+    let engine = context::open_index(index_dir).await?;
+
+    let field_option: FieldOption =
+        serde_json::from_str(field_option_json).context("Failed to parse field option JSON")?;
+
+    let outcome = engine
+        .update_field(name, field_option, UpdateFieldOptions { reindex, dry_run })
+        .await
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
+    if dry_run {
+        println!(
+            "Dry run: change to field '{name}' classified as {:?}. Nothing was applied.",
+            outcome.classification
+        );
+    } else {
+        println!(
+            "Field '{name}' updated successfully (classified as {:?}).",
+            outcome.classification
+        );
+    }
+    Ok(())
+}

--- a/laurus-cli/src/context.rs
+++ b/laurus-cli/src/context.rs
@@ -326,4 +326,58 @@ mod tests {
             "delete_field should have persisted schema.toml via the engine's hook"
         );
     }
+
+    /// Issue #1082: like `dynamic_field_add_survives_reopen`, but for
+    /// `update_field` -- it must persist `schema.toml` itself via the same
+    /// hook, so a field's changed option survives closing and reopening
+    /// the index.
+    #[tokio::test]
+    async fn dynamic_field_update_survives_reopen() {
+        let schema = Schema::builder()
+            .add_field(
+                "title",
+                laurus::FieldOption::Text(laurus::TextOption::default()),
+            )
+            .build();
+        let dir = tempfile::tempdir().unwrap();
+        create_index_from_schema(dir.path(), schema).await.unwrap();
+
+        {
+            let engine = open_index(dir.path()).await.unwrap();
+            engine
+                .update_field(
+                    "title",
+                    laurus::FieldOption::Text(laurus::TextOption::default().analyzer("keyword")),
+                    laurus::UpdateFieldOptions {
+                        reindex: true,
+                        ..Default::default()
+                    },
+                )
+                .await
+                .unwrap();
+            // No explicit `save_schema` call here — the point of this test.
+        }
+
+        // Reopen as a fresh process would, and confirm the change survived.
+        let reopened_schema = read_schema(dir.path()).unwrap();
+        match reopened_schema.fields.get("title") {
+            Some(laurus::FieldOption::Text(opt)) => assert_eq!(
+                opt.analyzer,
+                Some(laurus::AnalyzerSpec::Named("keyword".into())),
+                "update_field should have persisted schema.toml via the engine's hook"
+            ),
+            other => panic!("expected FieldOption::Text, got {other:?}"),
+        }
+
+        let engine = open_index(dir.path()).await.unwrap();
+        match engine.schema().fields.get("title") {
+            Some(laurus::FieldOption::Text(opt)) => {
+                assert_eq!(
+                    opt.analyzer,
+                    Some(laurus::AnalyzerSpec::Named("keyword".into()))
+                )
+            }
+            other => panic!("expected FieldOption::Text, got {other:?}"),
+        }
+    }
 }

--- a/laurus-cli/src/main.rs
+++ b/laurus-cli/src/main.rs
@@ -26,10 +26,10 @@ use clap::Parser;
 
 use crate::cli::{
     AddResource, Cli, Command, CreateResource, DeleteResource, GetResource, McpCommand,
-    PutResource, TrainResource,
+    PutResource, TrainResource, UpdateResource,
 };
 use crate::commands::{
-    add, bulk, commit, create, delete, get, mcp, put, repl, search, serve, train,
+    add, bulk, commit, create, delete, get, mcp, put, repl, search, serve, train, update,
 };
 
 #[tokio::main]
@@ -93,6 +93,14 @@ async fn main() -> Result<()> {
         Command::Delete(cmd) => match cmd.resource {
             DeleteResource::Docs { id } => delete::run_docs(&id, &index_dir).await,
             DeleteResource::Field { name } => delete::run_field(&name, &index_dir).await,
+        },
+        Command::Update(cmd) => match cmd.resource {
+            UpdateResource::Field {
+                name,
+                field_option,
+                reindex,
+                dry_run,
+            } => update::run_field(&name, &field_option, reindex, dry_run, &index_dir).await,
         },
         Command::Commit => commit::run(&index_dir).await,
         Command::Train(cmd) => match cmd.resource {

--- a/laurus-mcp/src/server.rs
+++ b/laurus-mcp/src/server.rs
@@ -20,10 +20,11 @@ use tracing::info;
 
 use laurus_server::proto::laurus::v1::{
     AddDocumentRequest, AddDocumentsRequest, AddFieldRequest, CommitRequest, CreateIndexRequest,
-    DeleteDocumentsRequest, DeleteFieldRequest, DocumentEntry, GetDocumentsRequest,
-    GetIndexRequest, GetSchemaRequest, PutDocumentRequest, PutDocumentsRequest, SearchBatchRequest,
-    SearchRequest, document_service_client::DocumentServiceClient,
-    index_service_client::IndexServiceClient, search_service_client::SearchServiceClient,
+    DeleteDocumentsRequest, DeleteFieldRequest, DocumentEntry, FieldChangeKind,
+    GetDocumentsRequest, GetIndexRequest, GetSchemaRequest, PutDocumentRequest,
+    PutDocumentsRequest, SearchBatchRequest, SearchRequest, UpdateFieldRequest,
+    document_service_client::DocumentServiceClient, index_service_client::IndexServiceClient,
+    search_service_client::SearchServiceClient,
 };
 
 use crate::convert;
@@ -205,6 +206,36 @@ struct AddFieldParams {
 struct DeleteFieldParams {
     /// The name of the field to remove from the index schema.
     name: String,
+}
+
+/// Parameters for the `update_field` tool.
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct UpdateFieldParams {
+    /// The name of the field to update. Must already exist.
+    name: String,
+
+    /// The field's new configuration as a JSON string.
+    ///
+    /// Uses the same externally-tagged serde representation as the schema.
+    /// Example:
+    ///
+    /// ```json
+    /// {"Text": {"indexed": true, "stored": true, "analyzer": "english"}}
+    /// {"Hnsw": {"dimension": 384, "m": 32, "ef_construction": 400}}
+    /// ```
+    field_option_json: String,
+
+    /// Opt in to a change that requires rebuilding or discarding existing
+    /// on-disk data (e.g. a text field's `analyzer`, or a vector field's
+    /// `dimension`). Ignored for a metadata-only change. Defaults to
+    /// `false`, which rejects such a change.
+    #[serde(default)]
+    reindex: bool,
+
+    /// When `true`, classifies the change and reports it without applying
+    /// anything. Defaults to `false`.
+    #[serde(default)]
+    dry_run: bool,
 }
 
 // ── Server struct ─────────────────────────────────────────────────────────────
@@ -480,6 +511,76 @@ impl LaurusMcpServer {
                 )]))
             }
             Err(e) => Ok(Self::tool_error(format!("Failed to delete field: {e}"))),
+        }
+    }
+
+    /// Change an existing field's type/options.
+    #[tool(
+        description = "Change an existing field's type/options (e.g. a text field's analyzer, or a vector field's dimension/m/ef_construction). field_option_json is a JSON string in the same format as add_field's. Metadata-only changes (e.g. default_ef_search) apply immediately; a change that requires rebuilding or discarding existing on-disk data is rejected unless reindex is true. Set dry_run to true to see how a change would be classified (metadata_only / reindex / destructive) without applying it. Returns the classification and the updated schema."
+    )]
+    async fn update_field(
+        &self,
+        Parameters(params): Parameters<UpdateFieldParams>,
+    ) -> Result<CallToolResult, McpError> {
+        let channel = match self.channel.read().await.clone() {
+            Some(ch) => ch,
+            None => {
+                return Ok(Self::tool_error(
+                    "Not connected. Call the connect tool first.",
+                ));
+            }
+        };
+
+        let field_option: laurus::FieldOption =
+            match serde_json::from_str(&params.field_option_json) {
+                Ok(fo) => fo,
+                Err(e) => {
+                    return Ok(Self::tool_error(format!(
+                        "Failed to parse field_option_json: {e}"
+                    )));
+                }
+            };
+
+        let proto_field_option =
+            laurus_server::convert::schema::field_option_to_proto(&field_option);
+        let request = UpdateFieldRequest {
+            name: params.name.clone(),
+            field_option: Some(proto_field_option),
+            reindex: params.reindex,
+            dry_run: params.dry_run,
+        };
+
+        match IndexServiceClient::new(channel).update_field(request).await {
+            Ok(resp) => {
+                let r = resp.into_inner();
+                let classification = match FieldChangeKind::try_from(r.classification) {
+                    Ok(FieldChangeKind::MetadataOnly) => Some("metadata_only"),
+                    Ok(FieldChangeKind::Reindex) => Some("reindex"),
+                    Ok(FieldChangeKind::Destructive) => Some("destructive"),
+                    Ok(FieldChangeKind::Unspecified) | Err(_) => None,
+                };
+                let output = if let Some(schema) = r.schema {
+                    let field_names: Vec<&String> = schema.fields.keys().collect();
+                    json!({
+                        "message": if params.dry_run {
+                            format!("Dry run: change to field '{}' classified.", params.name)
+                        } else {
+                            format!("Field '{}' updated successfully.", params.name)
+                        },
+                        "classification": classification,
+                        "fields": field_names,
+                    })
+                } else {
+                    json!({
+                        "message": format!("Field '{}' updated successfully.", params.name),
+                        "classification": classification,
+                    })
+                };
+                Ok(CallToolResult::success(vec![ContentBlock::text(
+                    output.to_string(),
+                )]))
+            }
+            Err(e) => Ok(Self::tool_error(format!("Failed to update field: {e}"))),
         }
     }
 
@@ -926,8 +1027,8 @@ impl ServerHandler for LaurusMcpServer {
             .with_instructions(
                 "Laurus search engine MCP server (gRPC client). \
              Tools: connect, create_index, get_stats, get_schema, add_field, delete_field, \
-             put_document, add_document, put_documents, add_documents, get_documents, \
-             delete_documents, commit, search. \
+             update_field, put_document, add_document, put_documents, add_documents, \
+             get_documents, delete_documents, commit, search. \
              Start by calling connect(endpoint) to connect to a running laurus-server, \
              then use the other tools to manage and search the index."
                     .to_string(),

--- a/laurus-server/proto/laurus/v1/index.proto
+++ b/laurus-server/proto/laurus/v1/index.proto
@@ -17,6 +17,10 @@ service IndexService {
 
   // Remove a field from the current index schema.
   rpc DeleteField(DeleteFieldRequest) returns (DeleteFieldResponse);
+
+  // Change an existing field's type/options, optionally rebuilding or
+  // discarding its on-disk data.
+  rpc UpdateField(UpdateFieldRequest) returns (UpdateFieldResponse);
 }
 
 // ---- Schema definitions ----
@@ -37,6 +41,20 @@ message Schema {
   // non-stored field) and therefore no longer have valid on-disk data
   // matching the current schema. See laurus::Schema::pending_reindex.
   repeated string pending_reindex = 6;
+}
+
+// How UpdateField classified a requested field option change. Mirrors
+// laurus::engine::schema::FieldChangeKind.
+enum FieldChangeKind {
+  FIELD_CHANGE_KIND_UNSPECIFIED = 0;
+  // Only a schema-level setting changes; no existing on-disk data needs
+  // to be touched.
+  FIELD_CHANGE_KIND_METADATA_ONLY = 1;
+  // Existing on-disk data is rebuilt from stored values.
+  FIELD_CHANGE_KIND_REINDEX = 2;
+  // The change cannot be applied from existing on-disk data; applying it
+  // discards the field's existing data.
+  FIELD_CHANGE_KIND_DESTRUCTIVE = 3;
 }
 
 // Policy for handling undeclared fields during document ingestion.
@@ -320,4 +338,27 @@ message DeleteFieldRequest {
 message DeleteFieldResponse {
   // The updated schema after the field has been removed.
   Schema schema = 1;
+}
+
+message UpdateFieldRequest {
+  // The name of the field to update. Must already exist.
+  string name = 1;
+  // The field's new configuration.
+  FieldOption field_option = 2;
+  // Required (must be true) to apply a Reindex- or Destructive-classified
+  // change; a MetadataOnly change ignores this flag. Rejected otherwise,
+  // since a reindex may take time and a destructive change discards
+  // existing data.
+  bool reindex = 3;
+  // When true, classifies the change and returns it without applying
+  // anything (the returned schema is the unchanged current schema).
+  bool dry_run = 4;
+}
+
+message UpdateFieldResponse {
+  // How the requested change was classified.
+  FieldChangeKind classification = 1;
+  // The schema after the update, or -- when dry_run was true, or the
+  // change was rejected -- the unchanged current schema.
+  Schema schema = 2;
 }

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -10,8 +10,9 @@ use laurus::vector::core::rerank::RerankStorageKind;
 use laurus::{
     AnalyzerDefinition, AnalyzerSpec, BooleanOption, BuiltinAnalyzerSpec, BytesOption,
     CharFilterConfig, DateTimeOption, DistanceMetric, DynamicFieldPolicy, EmbedderDefinition,
-    FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption, IntegerOption,
-    IvfOption, QuantizationMethod, Schema, TextOption, TokenFilterConfig, TokenizerConfig,
+    FieldChangeKind, FieldOption, FlatOption, FloatOption, Geo3dOption, GeoOption, HnswOption,
+    IntegerOption, IvfOption, QuantizationMethod, Schema, TextOption, TokenFilterConfig,
+    TokenizerConfig,
 };
 
 use crate::proto::laurus::v1;
@@ -96,6 +97,20 @@ fn dynamic_field_policy_from_proto(value: i32) -> DynamicFieldPolicy {
         Ok(v1::DynamicFieldPolicy::Dynamic) => DynamicFieldPolicy::Dynamic,
         Ok(v1::DynamicFieldPolicy::Ignore) => DynamicFieldPolicy::Ignore,
         Ok(v1::DynamicFieldPolicy::Unspecified) | Err(_) => DynamicFieldPolicy::default(),
+    }
+}
+
+/// Convert a laurus `FieldChangeKind` (an `Engine::update_field` outcome)
+/// into a proto enum value.
+///
+/// # Arguments
+///
+/// * `kind` - The laurus field change classification.
+pub fn field_change_kind_to_proto(kind: FieldChangeKind) -> v1::FieldChangeKind {
+    match kind {
+        FieldChangeKind::MetadataOnly => v1::FieldChangeKind::MetadataOnly,
+        FieldChangeKind::Reindex => v1::FieldChangeKind::Reindex,
+        FieldChangeKind::Destructive => v1::FieldChangeKind::Destructive,
     }
 }
 
@@ -756,6 +771,33 @@ fn embedder_definition_from_proto(
 mod tests {
     use super::*;
     use laurus::{BooleanOption, FlatOption, IntegerOption, TextOption};
+
+    /// Every `FieldChangeKind` variant maps to its own distinct,
+    /// non-`Unspecified` proto value -- `Unspecified` is reserved for the
+    /// proto3 zero-default (a client that never set the field), which a
+    /// server response never sends.
+    #[test]
+    fn field_change_kind_to_proto_covers_every_variant_distinctly() {
+        let mapped: Vec<v1::FieldChangeKind> = [
+            FieldChangeKind::MetadataOnly,
+            FieldChangeKind::Reindex,
+            FieldChangeKind::Destructive,
+        ]
+        .into_iter()
+        .map(field_change_kind_to_proto)
+        .collect();
+
+        assert!(
+            !mapped.contains(&v1::FieldChangeKind::Unspecified),
+            "no laurus FieldChangeKind should map to Unspecified: {mapped:?}"
+        );
+        let unique: std::collections::HashSet<_> = mapped.iter().collect();
+        assert_eq!(
+            unique.len(),
+            mapped.len(),
+            "every FieldChangeKind variant must map to a distinct proto value: {mapped:?}"
+        );
+    }
 
     /// Round-trip a `DynamicFieldPolicy` through proto and back for every
     /// concrete variant, verifying the enum mapping is complete.

--- a/laurus-server/src/gateway.rs
+++ b/laurus-server/src/gateway.rs
@@ -54,7 +54,10 @@ pub fn create_router(state: GatewayState) -> Router {
         .route("/v1/index", post(index::create).get(index::get_index))
         .route("/v1/schema", get(index::get_schema))
         .route("/v1/schema/fields", post(index::add_field))
-        .route("/v1/schema/fields/{name}", delete(index::delete_field))
+        .route(
+            "/v1/schema/fields/{name}",
+            delete(index::delete_field).patch(index::update_field),
+        )
         .route(
             "/v1/documents/{id}",
             put(document::put_document)

--- a/laurus-server/src/gateway/convert.rs
+++ b/laurus-server/src/gateway/convert.rs
@@ -253,6 +253,21 @@ fn proto_dynamic_field_policy_to_json(value: i32) -> Option<&'static str> {
     }
 }
 
+/// Converts a proto `FieldChangeKind` enum value (an `UpdateField` outcome)
+/// to its JSON string name. Returns `None` if the value is unrecognized.
+///
+/// # Arguments
+///
+/// * `value` - The proto enum value (i32).
+pub fn proto_field_change_kind_to_json(value: i32) -> Option<&'static str> {
+    match v1::FieldChangeKind::try_from(value).ok()? {
+        v1::FieldChangeKind::MetadataOnly => Some("metadata_only"),
+        v1::FieldChangeKind::Reindex => Some("reindex"),
+        v1::FieldChangeKind::Destructive => Some("destructive"),
+        v1::FieldChangeKind::Unspecified => None,
+    }
+}
+
 /// Converts a proto `Schema` to a JSON value.
 pub fn proto_schema_to_json(schema: &v1::Schema) -> Value {
     let fields: Map<String, Value> = schema
@@ -1369,5 +1384,29 @@ mod tests {
         assert_eq!(req.limit, 10);
         assert_eq!(req.offset, 0);
         assert_eq!(*req.field_boosts.get("title").unwrap(), 2.0);
+    }
+
+    /// Every concrete `FieldChangeKind` value maps to its own distinct
+    /// JSON name, and `Unspecified` (the proto3 zero-default, never sent
+    /// by the server) maps to `None`.
+    #[test]
+    fn test_proto_field_change_kind_to_json() {
+        assert_eq!(
+            proto_field_change_kind_to_json(v1::FieldChangeKind::MetadataOnly as i32),
+            Some("metadata_only")
+        );
+        assert_eq!(
+            proto_field_change_kind_to_json(v1::FieldChangeKind::Reindex as i32),
+            Some("reindex")
+        );
+        assert_eq!(
+            proto_field_change_kind_to_json(v1::FieldChangeKind::Destructive as i32),
+            Some("destructive")
+        );
+        assert_eq!(
+            proto_field_change_kind_to_json(v1::FieldChangeKind::Unspecified as i32),
+            None
+        );
+        assert_eq!(proto_field_change_kind_to_json(9999), None);
     }
 }

--- a/laurus-server/src/gateway/index.rs
+++ b/laurus-server/src/gateway/index.rs
@@ -137,3 +137,52 @@ pub async fn delete_field(
 
     Ok(Json(json!({ "schema": schema_json })))
 }
+
+/// `PATCH /v1/schema/fields/:name` — Changes an existing field's
+/// type/options, optionally rebuilding or discarding its on-disk data.
+pub async fn update_field(
+    State(mut state): State<GatewayState>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    Json(body): Json<Value>,
+) -> Result<Json<Value>, Response> {
+    let field_option_json = body
+        .get("field_option")
+        .ok_or_else(|| BadRequest("missing \"field_option\" key".to_string()).into_response())?;
+
+    let field_option = convert::json_to_proto_field_option(field_option_json)
+        .map_err(|e| BadRequest(e).into_response())?;
+
+    // Both default to `false`, matching `UpdateFieldOptions::default()`.
+    let reindex = body
+        .get("reindex")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let dry_run = body
+        .get("dry_run")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let response = state
+        .index_client
+        .update_field(v1::UpdateFieldRequest {
+            name,
+            field_option: Some(field_option),
+            reindex,
+            dry_run,
+        })
+        .await
+        .map_err(|s| GatewayError(s).into_response())?;
+
+    let inner = response.into_inner();
+    let schema_json = inner
+        .schema
+        .as_ref()
+        .map(convert::proto_schema_to_json)
+        .unwrap_or(Value::Null);
+    let classification = convert::proto_field_change_kind_to_json(inner.classification);
+
+    Ok(Json(json!({
+        "classification": classification,
+        "schema": schema_json,
+    })))
+}

--- a/laurus-server/src/service/index.rs
+++ b/laurus-server/src/service/index.rs
@@ -9,14 +9,15 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
-use laurus::{CommitPolicy, Engine, WalSyncPolicy};
+use laurus::{CommitPolicy, Engine, UpdateFieldOptions, WalSyncPolicy};
 
 use crate::context;
 use crate::convert::{error, schema as schema_convert};
 use crate::proto::laurus::v1::{
     AddFieldRequest, AddFieldResponse, CreateIndexRequest, CreateIndexResponse, DeleteFieldRequest,
     DeleteFieldResponse, GetIndexRequest, GetIndexResponse, GetSchemaRequest, GetSchemaResponse,
-    VectorFieldStats, index_service_server::IndexService as IndexServiceTrait,
+    UpdateFieldRequest, UpdateFieldResponse, VectorFieldStats,
+    index_service_server::IndexService as IndexServiceTrait,
 };
 
 /// gRPC IndexService implementation.
@@ -161,6 +162,54 @@ impl IndexServiceTrait for IndexService {
         tracing::info!("Field '{}' deleted from index", name);
         let proto_schema = schema_convert::to_proto(&updated_schema);
         Ok(Response::new(DeleteFieldResponse {
+            schema: Some(proto_schema),
+        }))
+    }
+
+    /// Changes an existing field's type/options, optionally rebuilding or
+    /// discarding its on-disk data, and persists the updated schema.
+    async fn update_field(
+        &self,
+        request: Request<UpdateFieldRequest>,
+    ) -> Result<Response<UpdateFieldResponse>, Status> {
+        let req = request.into_inner();
+        let name = req.name;
+        if name.is_empty() {
+            return Err(Status::invalid_argument("field name is required"));
+        }
+        let proto_field_option = req
+            .field_option
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("field_option is required"))?;
+        let field_option = schema_convert::field_option_from_proto(proto_field_option)
+            .ok_or_else(|| Status::invalid_argument("field_option has no option set"))?;
+
+        let guard = self.engine.read().await;
+        let engine = guard
+            .as_ref()
+            .ok_or_else(|| Status::failed_precondition("No index is open"))?;
+
+        let outcome = engine
+            .update_field(
+                &name,
+                field_option,
+                UpdateFieldOptions {
+                    reindex: req.reindex,
+                    dry_run: req.dry_run,
+                },
+            )
+            .await
+            .map_err(error::to_status)?;
+
+        tracing::info!(
+            "Field '{}' updated (classification: {:?})",
+            name,
+            outcome.classification
+        );
+        let proto_schema = schema_convert::to_proto(&outcome.schema);
+        Ok(Response::new(UpdateFieldResponse {
+            classification: schema_convert::field_change_kind_to_proto(outcome.classification)
+                as i32,
             schema: Some(proto_schema),
         }))
     }

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -46,13 +46,15 @@ pub type SchemaPersistHook = Arc<dyn Fn(&Schema) -> Result<()> + Send + Sync>;
 /// Options for [`Engine::update_field`] (Issue #1079).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct UpdateFieldOptions {
-    /// Reserved for Issues #1080/#1081: once vector- and lexical-field
-    /// rebuilding are implemented, this will need to be `true` to actually
-    /// rebuild a [`schema::FieldChangeKind::Reindex`]-classified field from
-    /// its existing data (mirroring Typesense's opt-in reindex step, rather
-    /// than silently doing potentially expensive work on every call).
-    /// Currently has no effect: this phase rejects every `Reindex`/
-    /// `Destructive` change regardless of this flag.
+    /// Must be `true` to actually apply a
+    /// [`schema::FieldChangeKind::Reindex`]- or
+    /// [`schema::FieldChangeKind::Destructive`]-classified change
+    /// (mirroring Typesense's opt-in reindex step, rather than silently
+    /// doing potentially expensive -- or destructive -- work on every
+    /// call). Ignored for a [`schema::FieldChangeKind::MetadataOnly`]
+    /// change, which always applies. `false` (the default) rejects both
+    /// `Reindex` and `Destructive` changes with an error naming the
+    /// classification.
     pub reindex: bool,
     /// When `true`, classify the change and report the outcome without
     /// applying anything — not even a


### PR DESCRIPTION
## Summary

Exposes the core `Engine::update_field` (implemented in Phases 1-3, #1079/#1080/#1081) through gRPC, REST, CLI, and MCP -- the same layers `add_field`/`delete_field` are already exposed through, and in the exact same patterns. The 5 language bindings (python/nodejs/wasm/ruby/php) don't expose `add_field`/`delete_field` either, so no cross-binding work is needed.

- proto: `UpdateField` RPC + `UpdateFieldRequest`/`UpdateFieldResponse` + a `FieldChangeKind` enum (mirrors `laurus::engine::schema::FieldChangeKind`)
- gRPC (`service/index.rs`): an `update_field` handler shaped like `add_field`/`delete_field`
- REST: `PATCH /v1/schema/fields/{name}` (chained onto the existing `DELETE` route); handler + JSON conversion in `gateway/index.rs` / `gateway/convert.rs`
- proto conversions: `field_change_kind_to_proto` (`convert/schema.rs`), `proto_field_change_kind_to_json` (`gateway/convert.rs`)
- CLI: `laurus update field --name <name> --field-option <json> [--reindex] [--dry-run]`
- MCP: an `update_field` tool, added to the tool list in `get_info`'s instructions
- Docs: a "Changing a Field" subsection in both `docs/ja/` and `docs/src/`'s `schema_and_fields.md`, replacing the old "type changes are not supported" line with the 3-way classification, the `reindex` opt-in gate, `pending_reindex`, and `dry_run`
- Bug fix found along the way: `UpdateFieldOptions::reindex`'s doc comment still said "currently has no effect" -- a Phase 1 leftover never updated after Phases 2/3 shipped real behavior

Phase 4 of #1077. Depends on #1081 (merged).

Closes #1082

## Test plan

- [x] `cargo build -p laurus -p laurus-cli -p laurus-server -p laurus-mcp --all-targets` clean
- [x] `cargo fmt` / `cargo clippy --all-targets -- -D warnings` (all 4 crates) clean
- [x] `cargo test -p laurus -p laurus-cli -p laurus-server -p laurus-mcp`: all passing, no regressions (laurus 1387 lib tests + all integration binaries, laurus-cli 35 tests incl. new `dynamic_field_update_survives_reopen`, laurus-mcp 14 tests, laurus-server 52 lib tests incl. new `FieldChangeKind` conversion tests + 2 integration tests, all doctests)
- [x] `markdownlint-cli2`: 0 issues on both docs
- [x] Manual smoke test: started a real `laurus serve` and drove `grpcurl`, `curl`, the `laurus update field` CLI subcommand, and `laurus mcp` (stdio JSON-RPC) independently through dry-run -> rejection without `reindex` -> apply with `reindex: true` -> search behavior actually changing -> `schema.toml` persisting -- neither `add_field`/`delete_field` nor this repo have an automated end-to-end test harness for a real running server, so this stands in for that
