### PR TITLE
fix(storage): wire FileLockManager/MemoryLockManager into Engine::build()

### DIFF
--- a/laurus-cli/src/commands/search.rs
+++ b/laurus-cli/src/commands/search.rs
@@ -123,6 +123,12 @@ tokenizer = { type = "ngram", min_gram = 2, max_gram = 2 }
             .await
             .unwrap();
         engine.commit().await.unwrap();
+        // Issue #1086: `Engine::build()` now takes an exclusive lock on
+        // the storage directory, so this handle must close before
+        // `execute` opens a second `Engine` over the same directory --
+        // exactly what a real CLI invocation would do anyway (each
+        // `laurus` command is a separate process that exits when done).
+        drop(engine);
 
         let results = execute(&search_command("吾輩は猫"), dir.path())
             .await
@@ -162,6 +168,12 @@ tokenizer = { type = "ngram", min_gram = 2, max_gram = 2 }
             .await
             .unwrap();
         engine.commit().await.unwrap();
+        // Issue #1086: `Engine::build()` now takes an exclusive lock on
+        // the storage directory, so this handle must close before
+        // `execute` opens a second `Engine` over the same directory --
+        // exactly what a real CLI invocation would do anyway (each
+        // `laurus` command is a separate process that exits when done).
+        drop(engine);
 
         let results = execute(&search_command("吾輩は猫"), dir.path())
             .await
@@ -191,6 +203,12 @@ tokenizer = { type = "ngram", min_gram = 2, max_gram = 2 }
             .await
             .unwrap();
         engine.commit().await.unwrap();
+        // Issue #1086: `Engine::build()` now takes an exclusive lock on
+        // the storage directory, so this handle must close before
+        // `execute` opens a second `Engine` over the same directory --
+        // exactly what a real CLI invocation would do anyway (each
+        // `laurus` command is a separate process that exits when done).
+        drop(engine);
 
         let results = execute(&search_command("_id:doc1"), dir.path())
             .await
@@ -237,6 +255,12 @@ tokenizer = { type = "ngram", min_gram = 2, max_gram = 2 }
                 .unwrap();
         }
         engine.commit().await.unwrap();
+        // Issue #1086: `Engine::build()` now takes an exclusive lock on
+        // the storage directory, so this handle must close before
+        // `execute` opens a second `Engine` over the same directory --
+        // exactly what a real CLI invocation would do anyway (each
+        // `laurus` command is a separate process that exits when done).
+        drop(engine);
 
         // The bigram analyzer needs a 2+ character query to produce any
         // token at all (min_gram = 2).
@@ -273,6 +297,12 @@ tokenizer = { type = "ngram", min_gram = 2, max_gram = 2 }
             .await
             .unwrap();
         engine.commit().await.unwrap();
+        // Issue #1086: `Engine::build()` now takes an exclusive lock on
+        // the storage directory, so this handle must close before
+        // `execute` opens a second `Engine` over the same directory --
+        // exactly what a real CLI invocation would do anyway (each
+        // `laurus` command is a separate process that exits when done).
+        drop(engine);
 
         // 2+ characters: the bigram analyzer needs at least min_gram (2).
         let results = execute(&search_command("猫で"), dir.path()).await.unwrap();

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -493,6 +493,15 @@ pub struct Engine {
     /// Optional callback that persists the schema outside the engine's own
     /// storage (Issue #1078). See [`SchemaPersistHook`].
     schema_persist_hook: Option<SchemaPersistHook>,
+    /// Exclusive lock on the root storage directory (Issue #1086), held for
+    /// the engine's lifetime so a second `Engine` built over the same
+    /// storage — another process, or another instance in this one — is
+    /// rejected instead of silently corrupting data through unsynchronized
+    /// concurrent writes. `None` when the storage backend doesn't support
+    /// locking (see [`Storage::lock_manager`]). Held only to keep the lock
+    /// alive; dropping the engine releases it (the concrete `StorageLock`
+    /// types release themselves in their own `Drop` impl).
+    _storage_lock: Option<Box<dyn crate::storage::StorageLock>>,
 }
 
 use crate::engine::search::{FusionAlgorithm, SearchResult};
@@ -3114,6 +3123,30 @@ impl EngineBuilder {
     /// Returns an error if storage initialization, index creation, WAL
     /// opening, or recovery replay fails.
     pub async fn build(self) -> Result<Engine> {
+        // Acquire an exclusive lock on the root storage before doing
+        // anything else (Issue #1086): a second `Engine` built over the
+        // same storage -- another process, or another instance in this
+        // one -- must fail fast here instead of silently racing this
+        // one's writes. Must happen while `self.storage` is still the
+        // bare root storage, before it's wrapped into the
+        // lexical/vector/document `PrefixedStorage` namespaces below and
+        // before it's moved into `DocumentLog::with_sync_policy` further
+        // down.
+        let storage_lock = match self.storage.lock_manager() {
+            Some(lock_manager) => match lock_manager.try_acquire_lock("engine")? {
+                Some(lock) => Some(lock),
+                None => {
+                    return Err(crate::error::LaurusError::storage(
+                        "Index directory is already locked by another Engine \
+                         instance (in this process or another process). If \
+                         the previous session did not shut down cleanly, \
+                         remove the stale lock file manually.",
+                    ));
+                }
+            },
+            None => None, // This storage backend doesn't support locking.
+        };
+
         let (lexical_config, vector_config) = Engine::split_schema(
             &self.schema,
             self.analyzer,
@@ -3191,6 +3224,7 @@ impl EngineBuilder {
             #[cfg(not(target_arch = "wasm32"))]
             _commit_timer: commit_timer,
             schema_persist_hook: self.schema_persist_hook,
+            _storage_lock: storage_lock,
         };
 
         engine.recover().await?;
@@ -3205,6 +3239,48 @@ mod tests {
     use crate::embedding::per_field::PerFieldEmbedder;
     use crate::embedding::precomputed::PrecomputedEmbedder;
     use crate::storage::memory::MemoryStorage;
+
+    /// Issue #1086: a second `Engine` built over the same storage (the
+    /// realistic in-process analogue of two processes opening the same
+    /// index directory) must be rejected, not silently allowed to race
+    /// the first one's writes.
+    #[tokio::test]
+    async fn build_rejects_a_second_engine_over_the_same_storage() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+
+        let _first = Engine::builder(storage.clone(), Schema::new())
+            .build()
+            .await
+            .unwrap();
+
+        let second = Engine::builder(storage, Schema::new()).build().await;
+        assert!(
+            second.is_err(),
+            "a second Engine over the same storage must be rejected while the first is alive"
+        );
+    }
+
+    /// Companion to the above: once the first `Engine` is dropped, its
+    /// lock releases automatically (Issue #1086's `Drop for
+    /// FileLockWrapper`/`MemoryLockWrapper`), so a fresh `Engine` build
+    /// over the same storage -- e.g. a CLI's `open_index` called again in
+    /// a later, separate call -- succeeds.
+    #[tokio::test]
+    async fn build_succeeds_again_after_the_first_engine_is_dropped() {
+        let storage: Arc<dyn Storage> = Arc::new(MemoryStorage::new(Default::default()));
+
+        let first = Engine::builder(storage.clone(), Schema::new())
+            .build()
+            .await
+            .unwrap();
+        drop(first);
+
+        let second = Engine::builder(storage, Schema::new()).build().await;
+        assert!(
+            second.is_ok(),
+            "a fresh Engine build must succeed once the previous one's lock is released"
+        );
+    }
 
     #[tokio::test]
     async fn test_accepts_per_field_analyzer() {

--- a/laurus/src/storage.rs
+++ b/laurus/src/storage.rs
@@ -555,6 +555,25 @@ pub trait Storage: Send + Sync + std::fmt::Debug {
     /// # }
     /// ```
     fn close(&mut self) -> Result<()>;
+
+    /// Get this storage's [`LockManager`], if it supports cross-instance
+    /// exclusion (Issue #1086).
+    ///
+    /// Returns `None` by default, so a decorator (e.g.
+    /// [`PrefixedStorage`](prefixed::PrefixedStorage)) or a test-only mock
+    /// doesn't need to implement locking at all. Only backends that
+    /// actually coordinate access across multiple `Engine`
+    /// instances/processes over the same directory (currently
+    /// `FileStorage` and [`MemoryStorage`](memory::MemoryStorage))
+    /// override this.
+    ///
+    /// `Engine::build()` calls this once, on the caller-supplied root
+    /// storage, before wrapping it into the lexical/vector/document
+    /// [`PrefixedStorage`](prefixed::PrefixedStorage) namespaces -- so a
+    /// decorator never needs to forward this itself.
+    fn lock_manager(&self) -> Option<Arc<dyn LockManager>> {
+        None
+    }
 }
 
 /// A trait for reading data from storage.
@@ -670,7 +689,7 @@ pub trait LockManager: Send + Sync + std::fmt::Debug {
 }
 
 /// A lock on a resource in storage.
-pub trait StorageLock: Send + std::fmt::Debug {
+pub trait StorageLock: Send + Sync + std::fmt::Debug {
     /// Get the name of the lock.
     fn name(&self) -> &str;
 

--- a/laurus/src/storage/file.rs
+++ b/laurus/src/storage/file.rs
@@ -715,6 +715,10 @@ impl Storage for FileStorage {
         self.lock_manager.release_all()?;
         Ok(())
     }
+
+    fn lock_manager(&self) -> Option<Arc<dyn LockManager>> {
+        Some(self.lock_manager.clone())
+    }
 }
 
 /// A file input implementation.
@@ -1038,7 +1042,11 @@ impl LockManager for FileLockManager {
             locks.insert(name.to_string(), lock.clone());
         }
 
-        Ok(Box::new(FileLockWrapper { lock }))
+        Ok(Box::new(FileLockWrapper {
+            lock,
+            name: name.to_string(),
+            manager_locks: self.locks.clone(),
+        }))
     }
 
     fn try_acquire_lock(&self, name: &str) -> Result<Option<Box<dyn StorageLock>>> {
@@ -1106,6 +1114,12 @@ impl FileLock {
 #[derive(Debug)]
 struct FileLockWrapper {
     lock: Arc<Mutex<FileLock>>,
+    /// This lock's name, and a handle to the owning [`FileLockManager`]'s
+    /// `locks` map, so `release()` can remove its own entry (Issue #1086)
+    /// instead of leaving [`LockManager::lock_exists`] reporting `true`
+    /// for a lock nothing holds any more.
+    name: String,
+    manager_locks: Arc<Mutex<HashMap<String, Arc<Mutex<FileLock>>>>>,
 }
 
 impl StorageLock for FileLockWrapper {
@@ -1118,13 +1132,32 @@ impl StorageLock for FileLockWrapper {
     }
 
     fn release(&mut self) -> Result<()> {
-        let mut lock = self.lock.lock().unwrap();
-        lock.release()
+        let result = {
+            let mut lock = self.lock.lock().unwrap();
+            lock.release()
+        };
+        // Drop the manager's bookkeeping entry regardless of whether the
+        // filesystem removal succeeded -- once the caller has asked to
+        // release, `lock_exists` must stop claiming this name is held.
+        self.manager_locks.lock().unwrap().remove(&self.name);
+        result
     }
 
     fn is_valid(&self) -> bool {
         let lock = self.lock.lock().unwrap();
         !lock.released
+    }
+}
+
+impl Drop for FileLockWrapper {
+    /// Releases the lock automatically once every handle holding it is
+    /// dropped (Issue #1086), e.g. when the `Engine` field storing it goes
+    /// out of scope. Mirrors `MemoryOutput`'s "best-effort cleanup on
+    /// drop" pattern elsewhere in this module -- a failure here (e.g. the
+    /// lock file was already removed out of band) has nowhere to
+    /// propagate to.
+    fn drop(&mut self) {
+        let _ = self.release();
     }
 }
 
@@ -1145,6 +1178,78 @@ mod tests {
     fn test_file_storage_creation() {
         let (_temp_dir, storage) = create_test_storage();
         assert!(!storage.closed);
+    }
+
+    /// Issue #1086: `Storage::lock_manager()` must actually be wired to
+    /// `FileStorage`'s lock manager, not just return `None` (the trait
+    /// default every other implementor keeps).
+    #[test]
+    fn lock_manager_returns_the_file_lock_manager() {
+        let (_temp_dir, storage) = create_test_storage();
+        assert!(
+            storage.lock_manager().is_some(),
+            "FileStorage must override the Storage::lock_manager() default"
+        );
+    }
+
+    /// Two independent lock managers over the SAME directory (simulating
+    /// two `FileStorage` instances -- i.e. two processes, or two `Engine`s
+    /// in this one -- opening the same index) must not both succeed in
+    /// acquiring the same lock name.
+    #[test]
+    fn try_acquire_lock_rejects_a_second_holder_over_the_same_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let first = FileLockManager::new(temp_dir.path().to_path_buf());
+        let second = FileLockManager::new(temp_dir.path().to_path_buf());
+
+        let first_lock = first.try_acquire_lock("engine").unwrap();
+        assert!(first_lock.is_some(), "the first holder must succeed");
+
+        let second_lock = second.try_acquire_lock("engine").unwrap();
+        assert!(
+            second_lock.is_none(),
+            "a second holder over the same directory must be rejected, not silently succeed"
+        );
+    }
+
+    /// Once the first holder's lock is dropped, a fresh acquisition attempt
+    /// (as a fresh `FileStorage`/process reopening the same directory
+    /// would make) must succeed -- the lock releases itself automatically
+    /// (Issue #1086's `Drop for FileLockWrapper`), it isn't stuck until an
+    /// explicit `release()` call nobody makes.
+    #[test]
+    fn dropping_the_lock_lets_a_fresh_acquisition_succeed() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = FileLockManager::new(temp_dir.path().to_path_buf());
+
+        let first_lock = manager.try_acquire_lock("engine").unwrap();
+        assert!(first_lock.is_some());
+        drop(first_lock);
+
+        let second_lock = manager.try_acquire_lock("engine").unwrap();
+        assert!(
+            second_lock.is_some(),
+            "dropping the first lock must release it so a fresh acquisition succeeds"
+        );
+    }
+
+    /// Releasing a lock (whether via an explicit `release()` call or via
+    /// `Drop`) must clear the manager's own bookkeeping, not just remove
+    /// the on-disk file -- otherwise `lock_exists()` would keep reporting
+    /// `true` for a name nothing holds any more.
+    #[test]
+    fn release_clears_lock_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let manager = FileLockManager::new(temp_dir.path().to_path_buf());
+
+        let mut lock = manager.acquire_lock("engine").unwrap();
+        assert!(manager.lock_exists("engine"));
+
+        lock.release().unwrap();
+        assert!(
+            !manager.lock_exists("engine"),
+            "release() must clear the manager's bookkeeping for this name"
+        );
     }
 
     /// Construct a `FileOutput` directly (bypassing the `Storage` trait) so

--- a/laurus/src/storage/memory.rs
+++ b/laurus/src/storage/memory.rs
@@ -359,6 +359,10 @@ impl Storage for MemoryStorage {
         self.lock_manager.release_all()?;
         Ok(())
     }
+
+    fn lock_manager(&self) -> Option<Arc<dyn LockManager>> {
+        Some(self.lock_manager.clone())
+    }
 }
 
 /// A read handle backed by an in-memory byte buffer.
@@ -669,7 +673,11 @@ impl LockManager for MemoryLockManager {
         let lock = Arc::new(Mutex::new(MemoryLock::new(name.to_string())));
         locks.insert(name.to_string(), lock.clone());
 
-        Ok(Box::new(MemoryLockWrapper { lock }))
+        Ok(Box::new(MemoryLockWrapper {
+            lock,
+            name: name.to_string(),
+            manager_locks: self.locks.clone(),
+        }))
     }
 
     fn try_acquire_lock(&self, name: &str) -> Result<Option<Box<dyn StorageLock>>> {
@@ -719,6 +727,13 @@ impl MemoryLock {
 #[derive(Debug)]
 struct MemoryLockWrapper {
     lock: Arc<Mutex<MemoryLock>>,
+    /// This lock's name, and a handle to the owning [`MemoryLockManager`]'s
+    /// `locks` map, so `release()` can remove its own entry (Issue #1086).
+    /// Without this, a name could never be re-acquired after a proper
+    /// `release()` -- `acquire_lock` only checks map membership, and
+    /// nothing but `release_all()`'s full clear used to remove an entry.
+    name: String,
+    manager_locks: Arc<Mutex<HashMap<String, Arc<Mutex<MemoryLock>>>>>,
 }
 
 impl StorageLock for MemoryLockWrapper {
@@ -731,14 +746,27 @@ impl StorageLock for MemoryLockWrapper {
     }
 
     fn release(&mut self) -> Result<()> {
-        let mut lock = self.lock.lock().unwrap();
-        lock.released = true;
+        {
+            let mut lock = self.lock.lock().unwrap();
+            lock.released = true;
+        }
+        self.manager_locks.lock().unwrap().remove(&self.name);
         Ok(())
     }
 
     fn is_valid(&self) -> bool {
         let lock = self.lock.lock().unwrap();
         !lock.released
+    }
+}
+
+impl Drop for MemoryLockWrapper {
+    /// Releases the lock automatically once every handle holding it is
+    /// dropped (Issue #1086), mirroring `FileLockWrapper`'s Drop impl and
+    /// the existing `_wal_flush_timer`/`_commit_timer` "held only for its
+    /// Drop side effect" pattern in `Engine`.
+    fn drop(&mut self) {
+        let _ = self.release();
     }
 }
 
@@ -752,6 +780,75 @@ mod tests {
         let storage = MemoryStorage::default();
         assert_eq!(storage.file_count(), 0);
         assert_eq!(storage.total_size(), 0);
+    }
+
+    /// Issue #1086: `Storage::lock_manager()` must actually be wired to
+    /// `MemoryStorage`'s lock manager, not just return `None` (the trait
+    /// default every other implementor keeps).
+    #[test]
+    fn lock_manager_returns_the_memory_lock_manager() {
+        let storage = MemoryStorage::default();
+        assert!(
+            storage.lock_manager().is_some(),
+            "MemoryStorage must override the Storage::lock_manager() default"
+        );
+    }
+
+    /// Two `Engine`s sharing the SAME `Arc<dyn Storage>` (the realistic
+    /// in-process analogue of two processes opening the same directory)
+    /// must not both succeed in acquiring the same lock name.
+    #[test]
+    fn try_acquire_lock_rejects_a_second_holder_over_the_same_manager() {
+        let manager = MemoryLockManager::new();
+
+        let first_lock = manager.try_acquire_lock("engine").unwrap();
+        assert!(first_lock.is_some(), "the first holder must succeed");
+
+        let second_lock = manager.try_acquire_lock("engine").unwrap();
+        assert!(
+            second_lock.is_none(),
+            "a second holder over the same manager must be rejected, not silently succeed"
+        );
+    }
+
+    /// Issue #1086 bug fix: before this fix, `acquire_lock` only checked
+    /// map membership and `release()` never removed the manager's entry
+    /// (only `release_all()`'s full clear did), so a name could never be
+    /// re-acquired after a proper release -- even though nothing was
+    /// actually holding it any more. This is the direct regression test:
+    /// dropping the lock (the normal path when an `Engine` goes out of
+    /// scope) must let a fresh acquisition of the SAME name succeed.
+    #[test]
+    fn dropping_the_lock_lets_a_fresh_acquisition_succeed() {
+        let manager = MemoryLockManager::new();
+
+        let first_lock = manager.try_acquire_lock("engine").unwrap();
+        assert!(first_lock.is_some());
+        drop(first_lock);
+
+        let second_lock = manager.try_acquire_lock("engine").unwrap();
+        assert!(
+            second_lock.is_some(),
+            "dropping the first lock must release it so a fresh acquisition succeeds"
+        );
+    }
+
+    /// Releasing a lock (whether via an explicit `release()` call or via
+    /// `Drop`) must clear the manager's own bookkeeping -- otherwise
+    /// `lock_exists()` would keep reporting `true` for a name nothing
+    /// holds any more.
+    #[test]
+    fn release_clears_lock_exists() {
+        let manager = MemoryLockManager::new();
+
+        let mut lock = manager.acquire_lock("engine").unwrap();
+        assert!(manager.lock_exists("engine"));
+
+        lock.release().unwrap();
+        assert!(
+            !manager.lock_exists("engine"),
+            "release() must clear the manager's bookkeeping for this name"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `Storage::lock_manager() -> Option<Arc<dyn LockManager>>` with a default (`None`) implementation -- decorators (`PrefixedStorage`, `CompoundSegmentStorage`) and every test-only `Storage` mock need zero changes; only `FileStorage`/`MemoryStorage` override it.
- `EngineBuilder::build()` acquires the lock (`try_acquire_lock("engine")`) before wrapping `self.storage` into the lexical/vector/document `PrefixedStorage` namespaces and before it's moved into `DocumentLog`. A conflict fails fast with a clear error instead of silently letting two `Engine`s race each other's writes.
- `Engine` gained a `_storage_lock` field held only for its `Drop` side effect -- same shape as the existing `_wal_flush_timer`/`_commit_timer` fields. `FileLockWrapper`/`MemoryLockWrapper` gained `Drop` impls so the lock releases automatically.
- `StorageLock` gained a `Sync` bound (needed for `dyn StorageLock` to satisfy `Engine`'s existing cross-thread bounds).
- Bug fix found along the way: `MemoryLockManager`/`FileLockManager` couldn't re-acquire a lock name after it was properly released (`release()` never removed the manager's own map entry) -- would have immediately broken the common "rebuild an `Engine` against the same storage" pattern (a CLI's `open_index` called again, a test simulating a reopen) the moment locking was wired in.
- Also fixed: 5 tests in `laurus-cli/src/commands/search.rs` kept a write-side `Engine` alive while opening a second one over the same directory -- a pattern real CLI usage (one process per command) can't produce, only surfaced now that it's actually rejected.

Closes #1086

## Test plan

- [x] `cargo build -p laurus -p laurus-cli -p laurus-server -p laurus-mcp -p laurus-wasm -p laurus-nodejs --all-targets` clean (laurus-python/php/ruby have pre-existing environment FFI link errors, reproducible on `main`, out of scope)
- [x] `cargo fmt` / `cargo clippy --all-targets -- -D warnings` (all 4 crates) clean
- [x] `cargo test -p laurus --lib`: 1387 passing, incl. 8 new lock tests (`FileLockManager`/`MemoryLockManager` reject-a-second-holder, release-then-reacquire, release-clears-lock_exists)
- [x] `cargo test -p laurus --tests`: every integration binary passing, no regressions
- [x] `cargo test -p laurus-cli -p laurus-server -p laurus-mcp`: all passing, incl. 2 new `Engine::build()` tests (second build over the same storage rejected; succeeds again once the first is dropped)
