### PR TITLE
perf(ci): parallelize regression.yml job DAG and cut redundant build cost

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -18,15 +18,15 @@ runs:
       run: |
         echo "Disk usage before cleanup:"
         df -h /
-        # Remove large preinstalled toolchains the build never touches. Each
-        # `|| true` keeps the step succeeding even if a path is already absent
-        # (paths differ slightly between runner images).
-        sudo rm -rf /usr/share/dotnet || true
-        sudo rm -rf /usr/local/lib/android || true
-        sudo rm -rf /opt/ghc || true
-        sudo rm -rf /usr/local/.ghcup || true
-        sudo rm -rf /opt/hostedtoolcache/CodeQL || true
-        # Reclaim space held by cached Docker images (none of these jobs use Docker).
-        sudo docker image prune --all --force || true
+        # Remove large preinstalled toolchains the build never touches, in
+        # parallel since each is an independent subtree. Each `|| true` keeps
+        # the step succeeding even if a path is already absent (paths differ
+        # slightly between runner images).
+        sudo rm -rf /usr/share/dotnet || true &
+        sudo rm -rf /usr/local/lib/android || true &
+        sudo rm -rf /opt/ghc || true &
+        sudo rm -rf /usr/local/.ghcup || true &
+        sudo rm -rf /opt/hostedtoolcache/CodeQL || true &
+        wait
         echo "Disk usage after cleanup:"
         df -h /

--- a/.github/workflows/index-interop.yml
+++ b/.github/workflows/index-interop.yml
@@ -39,7 +39,10 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "stable-aarch64-apple-darwin"
+          # -ci suffix: this leg builds with --profile ci (no LTO), which
+          # must not share a cache entry with release.yml's full-LTO
+          # release build for the same target triple.
+          shared-key: "stable-aarch64-apple-darwin-ci"
 
       - name: Cache HuggingFace models
         uses: actions/cache@v6
@@ -49,19 +52,19 @@ jobs:
 
       - name: Build laurus CLI
         run: |
-          cargo build --release --target aarch64-apple-darwin \
+          cargo build --profile ci --target aarch64-apple-darwin \
             -p laurus-cli --bin laurus --features embeddings-candle
 
       - name: Create index and ingest fixtures
         run: |
-          BIN="target/aarch64-apple-darwin/release/laurus"
+          BIN="target/aarch64-apple-darwin/ci/laurus"
           INDEX_DIR=".interop-work/index"
           "$BIN" --index-dir "$INDEX_DIR" --format json create index --schema .github/interop/schema.toml
           "$BIN" --index-dir "$INDEX_DIR" --format json add docs --file .github/interop/documents.jsonl
 
       - name: Generate expected query results
         run: |
-          BIN="target/aarch64-apple-darwin/release/laurus"
+          BIN="target/aarch64-apple-darwin/ci/laurus"
           bash .github/interop/run-queries.sh "$BIN" .interop-work/index .interop-work/expected
 
       - name: Package index and expected results
@@ -103,7 +106,10 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "stable-x86_64-unknown-linux-gnu"
+          # -ci suffix: this leg builds with --profile ci (no LTO), which
+          # must not share a cache entry with the debug-profile test jobs
+          # or the full-LTO release.yml build for the same target triple.
+          shared-key: "stable-x86_64-unknown-linux-gnu-ci"
 
       - name: Cache HuggingFace models
         uses: actions/cache@v6
@@ -113,7 +119,7 @@ jobs:
 
       - name: Build laurus CLI
         run: |
-          cargo build --release --target x86_64-unknown-linux-gnu \
+          cargo build --profile ci --target x86_64-unknown-linux-gnu \
             -p laurus-cli --bin laurus --features embeddings-candle
 
       - name: Download macOS-built index
@@ -128,7 +134,7 @@ jobs:
 
       - name: Generate actual query results and compare
         run: |
-          BIN="target/x86_64-unknown-linux-gnu/release/laurus"
+          BIN="target/x86_64-unknown-linux-gnu/ci/laurus"
           bash .github/interop/run-queries.sh "$BIN" .interop-work/index .interop-work/actual
           python3 .github/interop/compare-results.py \
             .interop-work/expected .interop-work/actual .github/interop/queries.tsv
@@ -136,7 +142,7 @@ jobs:
       - name: Verify write compatibility
         run: |
           set -euo pipefail
-          BIN="target/x86_64-unknown-linux-gnu/release/laurus"
+          BIN="target/x86_64-unknown-linux-gnu/ci/laurus"
           INDEX_DIR=".interop-work/index"
 
           "$BIN" --index-dir "$INDEX_DIR" --format json add doc \

--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -459,7 +459,10 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "stable-${{ matrix.platform.target }}"
+          # -ci suffix: this leg builds with --profile ci (no LTO), which
+          # must not share a cache entry with the debug-profile test jobs
+          # or the full-LTO release.yml builds using the same target triple.
+          shared-key: "stable-${{ matrix.platform.target }}-ci"
 
       - name: Build PHP extension
         shell: bash
@@ -468,9 +471,9 @@ jobs:
             export RUSTFLAGS="-C link-args=-Wl,-undefined,dynamic_lookup"
           fi
           if [ "${{ matrix.platform.skip_embedding_features }}" == "true" ]; then
-            cargo build --release -p laurus-php
+            cargo build --profile ci -p laurus-php
           else
-            cargo build --release -p laurus-php --features embeddings-all
+            cargo build --profile ci -p laurus-php --features embeddings-all
           fi
 
       - name: Run tests
@@ -478,7 +481,7 @@ jobs:
         shell: bash
         run: |
           composer install
-          php -d extension=../target/release/liblaurus_php.so vendor/bin/phpunit tests/LaurusTest.php
+          php -d extension=../target/ci/liblaurus_php.so vendor/bin/phpunit tests/LaurusTest.php
 
   # ============================================================
   # Cross-platform index interop (Issue #947)

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   # ============================================================
   # Detect Changes
@@ -181,7 +185,7 @@ jobs:
   # ============================================================
   clippy:
     name: Clippy
-    needs: [changes, format]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -239,7 +243,7 @@ jobs:
   # ============================================================
   test-laurus:
     name: Test laurus
-    needs: [changes, clippy]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.laurus == 'true' }}
     strategy:
       fail-fast: false
@@ -252,6 +256,9 @@ jobs:
             skip_embedding_features: true
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            # Windows x embeddings-all is covered weekly by periodic.yml;
+            # skipping it here keeps this leg off the PR critical path.
+            skip_embedding_features: true
         toolchain: [stable]
     runs-on: ${{ matrix.platform.runner }}
     steps:
@@ -293,7 +300,7 @@ jobs:
   # ============================================================
   test-server:
     name: Test laurus-server
-    needs: [changes, test-laurus]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.server == 'true' }}
     strategy:
       fail-fast: false
@@ -346,7 +353,7 @@ jobs:
   # ============================================================
   test-mcp:
     name: Test laurus-mcp
-    needs: [changes, test-laurus, test-server]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.mcp == 'true' }}
     strategy:
       fail-fast: false
@@ -399,7 +406,7 @@ jobs:
   # ============================================================
   test-cli:
     name: Test laurus-cli
-    needs: [changes, test-laurus, test-server, test-mcp]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.cli == 'true' }}
     strategy:
       fail-fast: false
@@ -452,7 +459,7 @@ jobs:
   # ============================================================
   test-python:
     name: Test laurus-python
-    needs: [changes, test-laurus]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.python == 'true' }}
     strategy:
       fail-fast: false
@@ -511,7 +518,7 @@ jobs:
   # ============================================================
   test-nodejs:
     name: Test laurus-nodejs
-    needs: [changes, test-laurus]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.nodejs == 'true' }}
     strategy:
       fail-fast: false
@@ -558,7 +565,7 @@ jobs:
   # ============================================================
   test-wasm:
     name: Test laurus-wasm
-    needs: [changes, test-laurus]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.wasm == 'true' }}
     runs-on: ubuntu-latest
     steps:
@@ -587,7 +594,7 @@ jobs:
   # ============================================================
   test-ruby:
     name: Test laurus-ruby
-    needs: [changes, test-laurus]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.ruby == 'true' }}
     strategy:
       fail-fast: false
@@ -637,7 +644,7 @@ jobs:
   # ============================================================
   test-php:
     name: Test laurus-php
-    needs: [changes, test-laurus]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.php == 'true' }}
     strategy:
       fail-fast: false
@@ -671,7 +678,10 @@ jobs:
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "stable-${{ matrix.platform.target }}"
+          # -ci suffix: this leg builds with --profile ci (no LTO), which
+          # must not share a cache entry with the debug-profile test jobs
+          # or the full-LTO release.yml builds using the same target triple.
+          shared-key: "stable-${{ matrix.platform.target }}-ci"
 
       - name: Build PHP extension
         shell: bash
@@ -680,9 +690,9 @@ jobs:
             export RUSTFLAGS="-C link-args=-Wl,-undefined,dynamic_lookup"
           fi
           if [ "${{ matrix.platform.skip_embedding_features }}" == "true" ]; then
-            cargo build --release -p laurus-php
+            cargo build --profile ci -p laurus-php
           else
-            cargo build --release -p laurus-php --features embeddings-all
+            cargo build --profile ci -p laurus-php --features embeddings-all
           fi
 
       - name: Run tests
@@ -690,7 +700,7 @@ jobs:
         shell: bash
         run: |
           composer install
-          php -d extension=../target/release/liblaurus_php.so vendor/bin/phpunit tests/LaurusTest.php
+          php -d extension=../target/ci/liblaurus_php.so vendor/bin/phpunit tests/LaurusTest.php
 
   # ============================================================
   # Cross-platform index interop (Issue #947)
@@ -700,7 +710,7 @@ jobs:
   # ============================================================
   index-interop:
     name: Index Interop
-    needs: [changes, test-laurus]
+    needs: [changes]
     if: ${{ !failure() && !cancelled() && needs.changes.outputs.interop == 'true' }}
     uses: ./.github/workflows/index-interop.yml
 
@@ -709,9 +719,17 @@ jobs:
   # ============================================================
   test-all:
     name: Test All
-    if: ${{ !failure() && !cancelled() }}
+    # DAG jobs above depend only on `changes`, so a lint failure no longer
+    # skips them transitively -- format/clippy must be listed explicitly to
+    # keep gating on lint. `!cancelled()` (rather than `!failure() &&
+    # !cancelled()`) lets this step run even when a need was cancelled, so
+    # the explicit result check below can tell "cancelled" apart from
+    # "succeeded" instead of both silently passing.
+    if: ${{ !cancelled() }}
     needs:
       [
+        format,
+        clippy,
         test-laurus,
         test-cli,
         test-server,
@@ -725,5 +743,14 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: All tests passed
-        run: echo "All tests passed"
+      - name: Check that no required job failed or was cancelled
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "ERROR: at least one required job failed" >&2
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "ERROR: at least one required job was cancelled" >&2
+            exit 1
+          fi
+          echo "All tests passed"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,17 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 
 [profile.release]
 lto = true
+
+# Verification-only builds (CI interop/extension checks that never ship):
+# same optimizations as release minus full LTO, which dominates build time
+# for a throwaway binary.
+[profile.ci]
+inherits = "release"
+lto = false
+
+# Speeds up the HNSW/PQ recall integration tests (laurus/tests/), which spend
+# most of their time in unoptimized numeric kernels. Scoped to this package
+# only: laurus/tests/ compiles 88 separate test binaries, and bumping the
+# dev profile's opt-level globally would add more compile time than it saves.
+[profile.dev.package.laurus]
+opt-level = 2


### PR DESCRIPTION
## Summary

`regression.yml` took 41m30s on its last completed run ([34158074414](https://github.com/mosuka/laurus/actions/runs/34158074414)) because of an artificial serial job chain plus avoidable build cost, not test volume. Full investigation and decision log in #1094.

- Flatten the job DAG: every test job + `index-interop` now depends only on `changes` instead of chaining off each other and off `clippy`; `test-all` gates explicitly on `format`/`clippy` and correctly fails when a dependency is cancelled (previously `!failure()` alone let a cancelled run slip through)
- Add a `concurrency` group so superseded PR pushes cancel their old run instead of occupying runner slots
- Drop `embeddings-all` on `test-laurus`'s `windows-latest` leg, matching the `aarch64` leg — `periodic.yml` already covers Windows x embeddings weekly
- Add `[profile.dev.package.laurus] opt-level = 2` so the HNSW/PQ recall integration tests stop running unoptimized kernels — locally, `vector_recall_test` drops from ~270s to ~3.4s, with `debug-assertions` left on
- Add a non-LTO `[profile.ci]` for verification-only builds (`test-php`, `index-interop`) that never ship, each with its own `rust-cache` `shared-key` suffix so they stop fighting `release.yml`'s cache entry
- Parallelize `free-disk-space`'s `rm -rf` calls and drop the unused `docker image prune`

Expected wall clock: ~15-20m, down from 41m30s.

## Test plan

- [x] `actionlint` on the three touched workflow files (no new issues beyond pre-existing shellcheck style warnings)
- [x] `cargo build --profile ci -p laurus-php` locally, confirmed `target/ci/liblaurus_php.dylib` is produced
- [x] `cargo test --package laurus --features embeddings-all,pq-fastscan --test vector_recall_test` locally: all 9 recall-gate tests pass, runtime ~3.4s (down from ~270s)
- [ ] Confirm on this PR's own regression.yml run: jobs start in parallel off `changes`, recall gates pass on both x86_64 and aarch64, `test-all` gates correctly, and total wall clock is materially below 41m30s

Closes #1094
