### PR TITLE
fix(lexical): handle terms removed entirely by analysis

### DIFF
--- a/laurus/src/lexical/query/parser.rs
+++ b/laurus/src/lexical/query/parser.rs
@@ -8,6 +8,7 @@
 //! - Bare terms that the analyzer splits into several tokens are OR'd
 //!   (`BooleanQuery` with `Should` clauses), matching Lucene's `match`
 //!   query. Use quotes for phrase semantics.
+//! - Terms removed entirely by analysis match no documents in that field.
 //! - Proximity search: `"hello world"~10`
 //! - Fuzzy search: `roam~2`
 //! - Range queries: `[100 TO 500]`, `{A TO Z}`
@@ -787,7 +788,11 @@ impl LexicalQueryParser {
             let terms = self.analyze_term(Some(field_name), &term)?;
 
             if terms.is_empty() {
-                return Err(LaurusError::parse("No terms after analysis".to_string()));
+                // An empty phrase already matches nothing and retains the field
+                // reference for schema validation, unlike an empty BooleanQuery.
+                return Ok(Box::new(
+                    PhraseQuery::new(field_name, terms).with_boost(boost),
+                ));
             }
 
             if terms.len() == 1 {

--- a/laurus/tests/lexical_stop_word_query_test.rs
+++ b/laurus/tests/lexical_stop_word_query_test.rs
@@ -1,0 +1,168 @@
+//! Regression tests for #1098: a term removed by its field's analyzer
+//! matches nothing in that field instead of aborting the whole query.
+
+use std::sync::Arc;
+
+use laurus::analysis::analyzer::analyzer::Analyzer;
+use laurus::analysis::analyzer::per_field::PerFieldAnalyzer;
+use laurus::analysis::analyzer::standard::StandardAnalyzer;
+use laurus::analysis::token::TokenStream;
+use laurus::lexical::query::LexicalQueryParser;
+use laurus::storage::memory::MemoryStorageConfig;
+use laurus::storage::{StorageConfig, StorageFactory};
+use laurus::{Document, Engine, LaurusError, Result, Schema, SearchRequestBuilder};
+
+async fn test_engine(body_analyzer: &str) -> Result<Engine> {
+    let storage = StorageFactory::create(StorageConfig::Memory(MemoryStorageConfig::default()))?;
+    let schema: Schema = serde_json::from_value(serde_json::json!({
+        "default_fields": ["title", "body"],
+        "fields": {
+            "title": { "Text": { "analyzer": "standard" } },
+            "body": { "Text": { "analyzer": body_analyzer } }
+        }
+    }))
+    .unwrap();
+    let engine = Engine::new(storage, schema).await?;
+    for (id, title, body) in [
+        ("title-book", "book", "other"),
+        ("body-book", "other", "book"),
+        ("body-all", "other", "all"),
+    ] {
+        engine
+            .put_document(
+                id,
+                Document::builder()
+                    .add_text("title", title)
+                    .add_text("body", body)
+                    .build(),
+            )
+            .await?;
+    }
+    engine.commit().await?;
+    Ok(engine)
+}
+
+async fn search(engine: &Engine, dsl: &str) -> Result<Vec<(String, f32)>> {
+    let results = engine
+        .search(SearchRequestBuilder::new().query_dsl(dsl).limit(10).build())
+        .await?;
+    let mut hits: Vec<_> = results.into_iter().map(|hit| (hit.id, hit.score)).collect();
+    hits.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(hits)
+}
+
+#[tokio::test]
+async fn test_stop_words_match_nothing_without_failing() -> Result<()> {
+    let engine = test_engine("standard").await?;
+    for dsl in [
+        "all",
+        "the",
+        "a",
+        "title:all",
+        "body:all",
+        "all^4",
+        "\"all\"",
+    ] {
+        assert!(search(&engine, dsl).await?.is_empty(), "{dsl}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stop_words_preserve_boolean_semantics_and_scores() -> Result<()> {
+    let engine = test_engine("standard").await?;
+    let book = search(&engine, "book").await?;
+    let book_ids: Vec<_> = book.iter().map(|hit| hit.0.as_str()).collect();
+    assert_eq!(book_ids, vec!["body-book", "title-book"]);
+    for dsl in [
+        "all book",
+        "book all",
+        "all OR book",
+        "book -all",
+        "-all book",
+    ] {
+        let hits = search(&engine, dsl).await?;
+        assert_eq!(
+            hits.iter().map(|hit| hit.0.as_str()).collect::<Vec<_>>(),
+            book_ids,
+            "{dsl}"
+        );
+        // Compare scores with the existing empty-phrase path: a bare term
+        // and a nested BooleanQuery have different field-length handling.
+        assert_eq!(
+            hits,
+            search(&engine, &dsl.replace("all", "\"all\"")).await?,
+            "{dsl}"
+        );
+    }
+    for dsl in ["all AND book", "book AND all", "+all book", "all -book"] {
+        assert!(search(&engine, dsl).await?.is_empty(), "{dsl}");
+    }
+    assert_eq!(search(&engine, "-all").await?.len(), 3);
+    assert_eq!(
+        search(&engine, "book^2 all^4").await?,
+        search(&engine, "book^2 \"all\"").await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stop_word_is_empty_only_in_fields_that_remove_it() -> Result<()> {
+    let engine = test_engine("keyword").await?;
+    let expected = search(&engine, "body:all").await?;
+    assert_eq!(expected.len(), 1);
+    assert_eq!(expected[0].0, "body-all");
+    let hits = search(&engine, "all").await?;
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].0, expected[0].0);
+    assert!(search(&engine, "title:all").await?.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stop_words_keep_unknown_field_validation() -> Result<()> {
+    let engine = test_engine("standard").await?;
+    for dsl in ["missing:all", "missing:all OR title:book"] {
+        let error = search(&engine, dsl).await.unwrap_err().to_string();
+        assert!(error.contains("unknown field"), "{error}");
+        assert!(error.contains("missing"), "{error}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_stop_word_keeps_field_and_boost() {
+    let parser = LexicalQueryParser::with_standard_analyzer()
+        .unwrap()
+        .with_default_field("body");
+    let query = parser.parse("title:all^3").unwrap();
+    assert_eq!(query.field(), Some("title"));
+    assert_eq!(query.boost(), 3.0);
+}
+
+#[test]
+fn test_stop_word_does_not_hide_another_fields_analysis_error() {
+    #[derive(Debug)]
+    struct FailingAnalyzer;
+
+    impl Analyzer for FailingAnalyzer {
+        fn analyze(&self, _text: &str) -> Result<TokenStream> {
+            Err(LaurusError::parse("test analyzer failure".to_string()))
+        }
+
+        fn name(&self) -> &str {
+            "failing"
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+    }
+
+    let analyzer = PerFieldAnalyzer::new(Arc::new(StandardAnalyzer::new().unwrap()));
+    analyzer.add_analyzer("body", Arc::new(FailingAnalyzer));
+    let parser = LexicalQueryParser::new(Arc::new(analyzer))
+        .with_default_fields(vec!["title".to_string(), "body".to_string()]);
+    let error = parser.parse("all").unwrap_err().to_string();
+    assert!(error.contains("test analyzer failure"), "{error}");
+}


### PR DESCRIPTION
A bare stop word such as `all` currently aborts lexical query parsing with `No terms after analysis`, including mixed queries such as `all book`. Return the existing empty `PhraseQuery` when a field analyzer successfully removes every token, implementing the field-level match-none option from #1098. Keeping the field and boost preserves unknown-field validation and Boolean behavior; actual analyzer errors still propagate.

Six regression tests exercise indexed searches, OR/AND/required/prohibited clauses, mixed standard/keyword fields, boosts, unknown fields, and analyzer failures. The exact final tests fail against the unchanged parser and pass with this change.

Validation on Windows x86_64 MSVC, Rust/Cargo 1.98.0, based on `62f6b9731406add288002afbd89af060171acf97`:

- `cargo test --locked -p laurus --features pq-fastscan --no-fail-fast -j 2`: 1,917 passed, 0 failed, 24 ignored doctests (1,412 unit, 380 integration, 125 doctests passed).
- `cargo test --locked -p laurus --all-features --lib --test lexical_stop_word_query_test -j 2`: 1,418 passed, 0 failed.
- `cargo fmt --all -- --check`: passed.
- `cargo clippy --locked -p laurus --all-targets --all-features -j 2 -- -D warnings`: passed.
- `git diff --check`: passed.

All-feature runtime coverage is core unit tests plus the new regression target; the complete integration/doc-test run uses native defaults plus `pq-fastscan`. Other workspace crates, language-binding runtime tests, WASM, Linux/ARM, and release-platform checks were not run locally. Embedding-feature checks used an isolated offline cache; live model/API behavior was not exercised.

Hosted validation is pending maintainer action: [Regression run 34242083949](https://github.com/mosuka/laurus/actions/runs/34242083949) reports `action_required` with zero jobs at 2026-09-08T15:03:23Z. This is unvalidated, not a test pass or failure.

Prepared and submitted autonomously by OpenAI Codex. No human pre-submission review was performed or is claimed.

Fixes #1098
