### PR TITLE
feat(bindings): add a cheap disk-only peek at commit_generation, without a full Engine rebuild

### DIFF
--- a/laurus-nodejs/README.md
+++ b/laurus-nodejs/README.md
@@ -94,6 +94,26 @@ index — especially before reopening the same path — rather than relying on
 the JS garbage collector, whose timing is not deterministic. `close()` is
 idempotent; every other method throws after it has been called.
 
+To cheaply check whether another process committed since you last looked —
+without opening (or reopening) the index at all — use the exported
+`peekCommitGeneration(path)`:
+
+```javascript
+import { peekCommitGeneration } from "laurus-nodejs";
+
+const before = peekCommitGeneration(path);
+// ... later ...
+if (peekCommitGeneration(path) !== before) {
+  // something changed on disk; reopen the index to pick it up
+}
+```
+
+It reads the persisted commit generation directly off disk, with no `Engine`
+construction at all — no storage lock, no WAL recovery, no embedder
+loading — so it works even before any `Index` for that path has been created
+in this process. Throws if `path` isn't a laurus index directory (no
+persisted schema).
+
 ### Durability / WAL
 
 A persistent index writes every change to a write-ahead log (WAL). By default

--- a/laurus-nodejs/README_ja.md
+++ b/laurus-nodejs/README_ja.md
@@ -92,6 +92,26 @@ index.close();
 前に）`close()` を呼んでください。`close()` は冪等で、呼び出し後は他の全ての
 メソッドが例外を投げます。
 
+インデックスを開き直す（あるいは開く）ことすらせずに、別プロセスが変更を
+コミットしたかを安く確認したい場合は、エクスポートされている
+`peekCommitGeneration(path)` を使ってください:
+
+```javascript
+import { peekCommitGeneration } from "laurus-nodejs";
+
+const before = peekCommitGeneration(path);
+// ... しばらく経過 ...
+if (peekCommitGeneration(path) !== before) {
+  // ディスク上で何かが変わった。取り込むにはインデックスを開き直す
+}
+```
+
+これはディスク上の永続化されたcommit世代を直接読むだけで、`Engine`の構築
+（ストレージロック・WALリカバリ・Embedder読み込み）を一切行わないため、
+このプロセスでそのパスの`Index`をまだ一度も作っていなくても使えます。
+`path`がlaurusのインデックスディレクトリでない（永続化されたスキーマが
+無い）場合は例外を投げます。
+
 ### 永続性 / WAL
 
 永続インデックスはすべての変更を先行書き込みログ（WAL）に書き込みます。

--- a/laurus-nodejs/__tests__/peek_commit_generation.spec.mjs
+++ b/laurus-nodejs/__tests__/peek_commit_generation.spec.mjs
@@ -1,0 +1,63 @@
+// Tests for `peekCommitGeneration()` (Issue #1101).
+//
+// Unlike `Index.stats()`, this is a module-level export, not tied to any
+// `Index` instance: it reads `commit_generation.json` directly from disk
+// without building an `Engine` at all, so it works even when no `Index` for
+// the given path has ever been constructed in this process -- the point
+// being to let a caller cheaply decide whether opening (or reloading) the
+// index is worth doing at all.
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Index, Schema, peekCommitGeneration } from "../index.js";
+
+function freshDir() {
+  return mkdtempSync(join(tmpdir(), "laurus-peek-"));
+}
+
+describe("peekCommitGeneration (#1101)", () => {
+  it("rejects a directory with no schema.toml", () => {
+    const dir = freshDir();
+    expect(() => peekCommitGeneration(dir)).toThrow(/not a laurus index directory/);
+  });
+
+  it("is zero before any commit", async () => {
+    const dir = freshDir();
+    const schema = new Schema();
+    schema.addTextField("title");
+    await Index.create(dir, schema);
+
+    expect(peekCommitGeneration(dir)).toBe(0);
+  });
+
+  it("advances after a commit", async () => {
+    // stats() doesn't expose a commitGeneration key yet in this binding
+    // (that's currently laurus-python-only), so this only checks the raw
+    // counter.
+    const dir = freshDir();
+    const index = await Index.create(dir);
+    await index.putDocument("doc1", { title: "hello world" });
+    await index.commit();
+
+    expect(peekCommitGeneration(dir)).toBe(1);
+  });
+
+  it("sees a commit made by another handle", async () => {
+    const dir = freshDir();
+    const a = await Index.create(dir);
+    await a.putDocument("doc1", {});
+    await a.commit();
+    a.close();
+
+    const before = peekCommitGeneration(dir);
+
+    const b = await Index.create(dir);
+    await b.putDocument("doc2", {});
+    await b.commit();
+    b.close();
+
+    expect(peekCommitGeneration(dir)).not.toBe(before);
+  });
+});

--- a/laurus-nodejs/src/errors.rs
+++ b/laurus-nodejs/src/errors.rs
@@ -24,15 +24,17 @@ pub fn laurus_err(err: LaurusError) -> napi::Error {
 
 /// Convert a [`laurus::index_dir::IndexDirError`] into a napi [`napi::Error`].
 ///
-/// `SchemaConflict`/`LegacyFlatLayout` are caller-fixable misuse, so they
-/// map to `InvalidArg` (matching how [`laurus_err`] treats
-/// `LaurusError::Schema`/`Query`/`Field`). `Io` matches the
-/// `LaurusError::Io` treatment above (`GenericFailure`, `"IO error: "`
+/// `SchemaConflict`/`LegacyFlatLayout`/`NotAnIndexDirectory` are
+/// caller-fixable misuse, so they map to `InvalidArg` (matching how
+/// [`laurus_err`] treats `LaurusError::Schema`/`Query`/`Field`). `Io` matches
+/// the `LaurusError::Io` treatment above (`GenericFailure`, `"IO error: "`
 /// prefix) for consistency.
 pub fn index_dir_err(err: laurus::index_dir::IndexDirError) -> napi::Error {
     use laurus::index_dir::IndexDirError;
     match err {
-        IndexDirError::SchemaConflict { .. } | IndexDirError::LegacyFlatLayout { .. } => {
+        IndexDirError::SchemaConflict { .. }
+        | IndexDirError::LegacyFlatLayout { .. }
+        | IndexDirError::NotAnIndexDirectory { .. } => {
             napi::Error::new(Status::InvalidArg, err.to_string())
         }
         IndexDirError::Io { .. } => {

--- a/laurus-nodejs/src/index.rs
+++ b/laurus-nodejs/src/index.rs
@@ -546,6 +546,43 @@ fn pairs_to_documents(docs: Vec<(String, Value)>) -> Result<Vec<(String, laurus:
 }
 
 // ---------------------------------------------------------------------------
+// Module-level functions
+// ---------------------------------------------------------------------------
+
+/// Read the persisted commit generation for `path` directly from disk,
+/// without building an `Engine` -- no storage lock, no WAL recovery, no
+/// embedder loading (Issue #1101).
+///
+/// Unlike `Index.stats()`, this is not tied to any `Index` instance: it
+/// works even when no `Index` for `path` has ever been constructed in this
+/// process, which is the point -- it lets a caller cheaply decide whether
+/// opening the index is worth doing at all.
+///
+/// Returned as `number` (not `bigint`), matching every other numeric value
+/// this binding exposes (e.g. `stats()`'s `documentCount`); a commit
+/// generation will never realistically approach 2^53.
+///
+/// # Arguments
+///
+/// * `path` - Directory path of a file-backed index (the same value passed
+///   to `Index.create(path, ...)`).
+///
+/// # Returns
+///
+/// `0` if the index exists but nothing has been committed yet.
+///
+/// # Errors
+///
+/// Throws if `path` has no persisted schema at all (not a laurus index
+/// directory).
+#[napi]
+pub fn peek_commit_generation(path: String) -> Result<f64> {
+    laurus::index_dir::peek_commit_generation(Path::new(&path))
+        .map(|generation| generation as f64)
+        .map_err(index_dir_err)
+}
+
+// ---------------------------------------------------------------------------
 // Storage factory helper
 // ---------------------------------------------------------------------------
 

--- a/laurus-php/README.md
+++ b/laurus-php/README.md
@@ -117,6 +117,24 @@ method throws after it has been called.
 $index->close();
 ```
 
+To cheaply check whether another process committed since you last looked --
+without opening (or reopening) the index at all -- use the namespaced
+`Laurus\peek_commit_generation($path)`:
+
+```php
+$before = Laurus\peek_commit_generation($path);
+// ... later ...
+if (Laurus\peek_commit_generation($path) !== $before) {
+    // something changed on disk; reopen the index to pick it up
+}
+```
+
+It reads the persisted commit generation directly off disk, with no
+`Engine` construction at all -- no storage lock, no WAL recovery, no
+embedder loading -- so it works even before any `Index` for that path has
+been created in this process. Throws a `ValueError` if `$path` isn't a
+laurus index directory (no persisted schema).
+
 ## Schema
 
 The `Schema` class defines the structure of your index. Use the following methods to add fields:

--- a/laurus-php/README_ja.md
+++ b/laurus-php/README_ja.md
@@ -116,6 +116,24 @@ $index = new Index("./myindex");
 $index->close();
 ```
 
+インデックスを開き直す（あるいは開く）ことすらせずに、別プロセスが変更を
+コミットしたかを安く確認したい場合は、名前空間付きの
+`Laurus\peek_commit_generation($path)` を使ってください:
+
+```php
+$before = Laurus\peek_commit_generation($path);
+// ... しばらく経過 ...
+if (Laurus\peek_commit_generation($path) !== $before) {
+    // ディスク上で何かが変わった。取り込むにはインデックスを開き直す
+}
+```
+
+これはディスク上の永続化されたcommit世代を直接読むだけで、`Engine`の構築
+（ストレージロック・WALリカバリ・Embedder読み込み）を一切行わないため、
+このプロセスでそのパスの`Index`をまだ一度も作っていなくても使えます。
+`$path`がlaurusのインデックスディレクトリでない（永続化されたスキーマが
+無い）場合は`ValueError`を投げます。
+
 ## スキーマ
 
 `Schema` クラスはインデックスの構造を定義します。以下のメソッドでフィールドを追加できます:

--- a/laurus-php/src/errors.rs
+++ b/laurus-php/src/errors.rs
@@ -39,17 +39,19 @@ pub fn laurus_err(err: LaurusError) -> PhpException {
 
 /// Convert a [`laurus::index_dir::IndexDirError`] into a PHP exception.
 ///
-/// `SchemaConflict`/`LegacyFlatLayout` are both caller-fixable misuse, so
-/// they map to `ValueError` (matching how [`laurus_err`] treats
-/// `LaurusError::Schema`/`Query`/`Field`). `Io` maps to `Exception`, same as
-/// `LaurusError::Io` in [`laurus_err`]; there is no PHP-specific
-/// path-preserving I/O exception in this crate, so `err.to_string()` (which
-/// already formats as `"{path}: {source}"`) carries the path in the message
-/// instead. `Core` delegates to [`laurus_err`].
+/// `SchemaConflict`/`LegacyFlatLayout`/`NotAnIndexDirectory` are all
+/// caller-fixable misuse, so they map to `ValueError` (matching how
+/// [`laurus_err`] treats `LaurusError::Schema`/`Query`/`Field`). `Io` maps to
+/// `Exception`, same as `LaurusError::Io` in [`laurus_err`]; there is no
+/// PHP-specific path-preserving I/O exception in this crate, so
+/// `err.to_string()` (which already formats as `"{path}: {source}"`) carries
+/// the path in the message instead. `Core` delegates to [`laurus_err`].
 pub fn index_dir_err(err: laurus::index_dir::IndexDirError) -> PhpException {
     use laurus::index_dir::IndexDirError;
     match err {
-        IndexDirError::SchemaConflict { .. } | IndexDirError::LegacyFlatLayout { .. } => {
+        IndexDirError::SchemaConflict { .. }
+        | IndexDirError::LegacyFlatLayout { .. }
+        | IndexDirError::NotAnIndexDirectory { .. } => {
             PhpException::new(err.to_string(), 0, ce::value_error())
         }
         IndexDirError::Io { .. } => PhpException::new(err.to_string(), 0, ce::exception()),

--- a/laurus-php/src/index.rs
+++ b/laurus-php/src/index.rs
@@ -711,6 +711,44 @@ fn pairs_to_documents(docs: &Zval) -> PhpResult<Vec<(String, laurus::Document)>>
     Ok(batch)
 }
 
+/// Read the persisted commit generation for `path` directly from disk,
+/// without building an `Engine` -- no storage lock, no WAL recovery, no
+/// embedder loading (Issue #1101).
+///
+/// Unlike `Index::stats()`, this is not tied to any `Index` instance: it
+/// works even when no `Index` for `path` has ever been constructed in this
+/// process, which is the point -- it lets a caller cheaply decide whether
+/// opening the index is worth doing at all.
+///
+/// # Arguments
+///
+/// * `path` - Directory path of a file-backed index (the same value passed
+///   as the first argument to `new Index(...)`).
+///
+/// # Returns
+///
+/// `0` if the index exists but nothing has been committed yet.
+///
+/// # Exceptions
+///
+/// Throws a `ValueError` if `path` has no persisted schema at all (not a
+/// laurus index directory).
+#[php_function]
+#[php(name = "Laurus\\peek_commit_generation")]
+pub fn peek_commit_generation(path: String) -> PhpResult<u64> {
+    laurus::index_dir::peek_commit_generation(Path::new(&path)).map_err(index_dir_err)
+}
+
+/// Build the PHP function entry for [`peek_commit_generation`], for
+/// `lib.rs`'s `#[php_module]` registration.
+///
+/// `wrap_function!` expands to a reference to a `#[doc(hidden)]` struct
+/// that `#[php_function]` generates in *this* module, so it must be called
+/// from here rather than from `lib.rs` directly.
+pub fn peek_commit_generation_function_entry() -> ext_php_rs::builders::FunctionBuilder<'static> {
+    wrap_function!(peek_commit_generation)
+}
+
 /// Resolve the `(Schema, Storage)` pair for [`PhpIndex::__construct`].
 ///
 /// `path=None` keeps the pre-existing in-memory behavior (schema defaults

--- a/laurus-php/src/lib.rs
+++ b/laurus-php/src/lib.rs
@@ -31,6 +31,7 @@ pub fn get_module(module: ModuleBuilder) -> ModuleBuilder {
         .class::<index::PhpWalSyncPolicy>()
         .class::<index::PhpCommitPolicy>()
         .class::<schema::PhpSchema>()
+        .function(index::peek_commit_generation_function_entry())
         // Search result & request, fusion algorithms
         .class::<search::PhpRRF>()
         .class::<search::PhpWeightedSum>()

--- a/laurus-php/tests/LaurusTest.php
+++ b/laurus-php/tests/LaurusTest.php
@@ -976,4 +976,69 @@ class LaurusTest extends TestCase
         $idx->close();
         $this->assertNotNull($idx);
     }
+
+    // ── peek_commit_generation (Issue #1101) ──────────────────────────────
+    //
+    // Unlike Index::stats(), this is a namespaced global function, not tied
+    // to any Index instance: it reads commit_generation.json directly from
+    // disk without building an Engine at all, so it works even when no
+    // Index for the given path has ever been constructed in this process --
+    // the point being to let a caller cheaply decide whether opening (or
+    // reopening) the index is worth doing at all.
+
+    public function testPeekCommitGenerationRejectsANonIndexDirectory(): void
+    {
+        $dir = sys_get_temp_dir() . "/laurus_peek_" . uniqid();
+        mkdir($dir);
+
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessageMatches('/not a laurus index directory/');
+        Laurus\peek_commit_generation($dir);
+    }
+
+    public function testPeekCommitGenerationIsZeroBeforeAnyCommit(): void
+    {
+        $dir = sys_get_temp_dir() . "/laurus_peek_" . uniqid();
+        mkdir($dir);
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+        new Laurus\Index($dir, $schema);
+
+        $this->assertEquals(0, Laurus\peek_commit_generation($dir));
+    }
+
+    public function testPeekCommitGenerationAdvancesAfterACommit(): void
+    {
+        // Index::stats() doesn't expose a commitGeneration key yet in this
+        // binding (that's currently laurus-python-only), so this only
+        // checks the raw counter.
+        $dir = sys_get_temp_dir() . "/laurus_peek_" . uniqid();
+        mkdir($dir);
+        $schema = new Laurus\Schema();
+        $schema->addTextField("title");
+        $idx = new Laurus\Index($dir, $schema);
+        $idx->putDocument("doc1", ["title" => "hello world"]);
+        $idx->commit();
+
+        $this->assertEquals(1, Laurus\peek_commit_generation($dir));
+    }
+
+    public function testPeekCommitGenerationSeesACommitMadeByAnotherHandle(): void
+    {
+        $dir = sys_get_temp_dir() . "/laurus_peek_" . uniqid();
+        mkdir($dir);
+        $a = new Laurus\Index($dir);
+        $a->putDocument("doc1", []);
+        $a->commit();
+        $a->close();
+
+        $before = Laurus\peek_commit_generation($dir);
+
+        $b = new Laurus\Index($dir);
+        $b->putDocument("doc2", []);
+        $b->commit();
+        $b->close();
+
+        $this->assertNotEquals($before, Laurus\peek_commit_generation($dir));
+    }
 }

--- a/laurus-python/README.md
+++ b/laurus-python/README.md
@@ -116,6 +116,23 @@ call -- so it confirms whether `reload()` (or your own `commit()`) actually
 advanced the state, but it cannot by itself tell you whether *another*
 process has committed something new; only `reload()` picks that up.
 
+To cheaply check for another process's changes *without* paying `reload()`'s
+cost, use the module-level `laurus.peek_commit_generation(path)`. Unlike
+`index.commit_generation()`, it isn't tied to any `Index` object -- it reads
+`commit_generation.json` straight off disk, with no `Engine` construction at
+all, so it works even before you've opened an `Index` for that path in this
+process:
+
+```python
+before = laurus.peek_commit_generation(path)
+# ... later ...
+if laurus.peek_commit_generation(path) != before:
+    index.reload()
+```
+
+Raises `ValueError` if `path` isn't a laurus index directory (no persisted
+schema).
+
 ## Durability / WAL
 
 A persistent index writes every change to a write-ahead log (WAL). By default

--- a/laurus-python/README_ja.md
+++ b/laurus-python/README_ja.md
@@ -116,6 +116,22 @@ changed = index.reload()  # commit世代が実際に進んでいればTrue
 かどうかをこれ単体で安く検知することはできません -- それを拾えるのは
 `reload()`だけです。
 
+`reload()`のコストを払わずに別プロセスの変更を安く確認したい場合は、
+モジュールレベルの`laurus.peek_commit_generation(path)`を使ってください。
+`index.commit_generation()`と異なり`Index`オブジェクトに紐付かず、
+`Engine`を一切構築せず`commit_generation.json`をディスクから直接読むため、
+このプロセスでまだ該当パスの`Index`を一度も開いていなくても使えます:
+
+```python
+before = laurus.peek_commit_generation(path)
+# ... しばらく経過 ...
+if laurus.peek_commit_generation(path) != before:
+    index.reload()
+```
+
+`path`がlaurusのインデックスディレクトリでない（永続化されたスキーマが
+無い）場合は`ValueError`を送出します。
+
 ## 永続性 / WAL
 
 永続インデックスはすべての変更を先行書き込みログ（WAL）に書き込みます。

--- a/laurus-python/src/errors.rs
+++ b/laurus-python/src/errors.rs
@@ -54,9 +54,9 @@ pub fn io_err_with_path(path: &Path, e: io::Error) -> PyErr {
 pub fn index_dir_err(err: laurus::index_dir::IndexDirError) -> PyErr {
     use laurus::index_dir::IndexDirError;
     match err {
-        IndexDirError::SchemaConflict { .. } | IndexDirError::LegacyFlatLayout { .. } => {
-            PyValueError::new_err(err.to_string())
-        }
+        IndexDirError::SchemaConflict { .. }
+        | IndexDirError::LegacyFlatLayout { .. }
+        | IndexDirError::NotAnIndexDirectory { .. } => PyValueError::new_err(err.to_string()),
         IndexDirError::Io { path, source } => io_err_with_path(&path, source),
         IndexDirError::Core(e) => laurus_err(e),
     }

--- a/laurus-python/src/index.rs
+++ b/laurus-python/src/index.rs
@@ -860,6 +860,34 @@ fn resolve_storage_and_schema(
 }
 
 // ---------------------------------------------------------------------------
+// Module-level functions
+// ---------------------------------------------------------------------------
+
+/// Read the persisted commit generation for `path` directly from disk,
+/// without building an `Engine` -- no storage lock, no WAL recovery, no
+/// embedder loading (Issue #1101).
+///
+/// Unlike [`PyIndex.reload`], this is not an `Index` method: it works even
+/// when no `Index` for `path` has ever been constructed in this process,
+/// which is the point -- it lets a caller cheaply decide whether opening
+/// (or [`PyIndex.reload`]-ing) the index is worth doing at all.
+///
+/// Args:
+///     path: Directory path of a file-backed index (the same value passed
+///         to `Index(path=...)`).
+///
+/// Returns:
+///     `0` if the index exists but nothing has been committed yet.
+///
+/// Raises:
+///     ValueError: if `path` has no persisted schema at all (not a laurus
+///         index directory).
+#[pyfunction]
+pub fn peek_commit_generation(path: String) -> PyResult<u64> {
+    laurus::index_dir::peek_commit_generation(Path::new(&path)).map_err(index_dir_err)
+}
+
+// ---------------------------------------------------------------------------
 // Reload helper
 // ---------------------------------------------------------------------------
 

--- a/laurus-python/src/lib.rs
+++ b/laurus-python/src/lib.rs
@@ -17,8 +17,9 @@ mod schema;
 mod search;
 
 use analysis::{PySynonymDictionary, PySynonymGraphFilter, PyToken, PyWhitespaceTokenizer};
-use index::{PyCommitPolicy, PyIndex, PyWalSyncPolicy};
+use index::{PyCommitPolicy, PyIndex, PyWalSyncPolicy, peek_commit_generation};
 use pyo3::prelude::*;
+use pyo3::wrap_pyfunction;
 use query::{
     PyBooleanQuery, PyFuzzyQuery, PyGeo3dBoundingBoxQuery, PyGeo3dDistanceQuery,
     PyGeo3dNearestQuery, PyGeoBoundingBoxQuery, PyGeoDistanceQuery, PyNumericRangeQuery,
@@ -55,6 +56,7 @@ fn laurus(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySchema>()?;
     m.add_class::<PyWalSyncPolicy>()?;
     m.add_class::<PyCommitPolicy>()?;
+    m.add_function(wrap_pyfunction!(peek_commit_generation, m)?)?;
 
     // ── Search result & request ───────────────────────────────────────────
     m.add_class::<PySearchResult>()?;

--- a/laurus-python/tests/test_peek_commit_generation.py
+++ b/laurus-python/tests/test_peek_commit_generation.py
@@ -1,0 +1,55 @@
+"""Tests for `laurus.peek_commit_generation()` (Issue #1101).
+
+Unlike `Index.commit_generation()`, this is a module-level function, not an
+`Index` method: it reads `commit_generation.json` directly from disk without
+building an `Engine` at all, so it works even when no `Index` for the given
+path has ever been constructed in this process -- the point being to let a
+caller cheaply decide whether opening (or reloading) the index is worth
+doing at all.
+"""
+
+import pytest
+import laurus
+
+
+def test_peek_commit_generation_rejects_a_non_index_directory(tmp_path):
+    with pytest.raises(ValueError, match="not a laurus index directory"):
+        laurus.peek_commit_generation(str(tmp_path))
+
+
+def test_peek_commit_generation_is_zero_before_any_commit(tmp_path):
+    path = str(tmp_path)
+    schema = laurus.Schema()
+    schema.add_text_field("title")
+    laurus.Index(path=path, schema=schema)
+
+    assert laurus.peek_commit_generation(path) == 0
+
+
+def test_peek_commit_generation_matches_commit_generation_after_a_commit(tmp_path):
+    path = str(tmp_path)
+    schema = laurus.Schema()
+    schema.add_text_field("title")
+    index = laurus.Index(path=path, schema=schema)
+    index.put_document("doc1", {"title": "hello world"})
+    index.commit()
+
+    assert laurus.peek_commit_generation(path) == index.commit_generation()
+    assert laurus.peek_commit_generation(path) == 1
+
+
+def test_peek_commit_generation_sees_a_commit_made_by_another_handle(tmp_path):
+    path = str(tmp_path)
+    a = laurus.Index(path=path)
+    a.put_document("doc1", {})
+    a.commit()
+    a.close()
+
+    before = laurus.peek_commit_generation(path)
+
+    b = laurus.Index(path=path)
+    b.put_document("doc2", {})
+    b.commit()
+    b.close()
+
+    assert laurus.peek_commit_generation(path) != before

--- a/laurus-ruby/src/errors.rs
+++ b/laurus-ruby/src/errors.rs
@@ -46,11 +46,13 @@ pub fn laurus_err(err: LaurusError) -> Error {
 /// |--------------------------|-----------------|
 /// | `SchemaConflict`         | `ArgumentError` |
 /// | `LegacyFlatLayout`       | `ArgumentError` |
+/// | `NotAnIndexDirectory`    | `ArgumentError` |
 /// | `Io`                     | `IOError`       |
 /// | `Core`                   | see [`laurus_err`] |
 ///
-/// `SchemaConflict`/`LegacyFlatLayout` are both caller-fixable misuse, so
-/// they map to `ArgumentError` — the same class [`laurus_err`] uses for
+/// `SchemaConflict`/`LegacyFlatLayout`/`NotAnIndexDirectory` are all
+/// caller-fixable misuse, so they map to `ArgumentError` — the same class
+/// [`laurus_err`] uses for
 /// `LaurusError::Schema`/`Query`/`Field`. `Io` maps to `IOError` like
 /// `LaurusError::Io` above; unlike the Python binding, there is no
 /// path-preserving exception hierarchy to lose here, and
@@ -60,7 +62,9 @@ pub fn index_dir_err(err: laurus::index_dir::IndexDirError) -> Error {
     use laurus::index_dir::IndexDirError;
     let ruby = Ruby::get().expect("called from Ruby thread");
     match err {
-        IndexDirError::SchemaConflict { .. } | IndexDirError::LegacyFlatLayout { .. } => {
+        IndexDirError::SchemaConflict { .. }
+        | IndexDirError::LegacyFlatLayout { .. }
+        | IndexDirError::NotAnIndexDirectory { .. } => {
             Error::new(ruby.exception_arg_error(), err.to_string())
         }
         IndexDirError::Io { .. } => Error::new(ruby.exception_io_error(), err.to_string()),

--- a/laurus-ruby/src/index.rs
+++ b/laurus-ruby/src/index.rs
@@ -535,6 +535,36 @@ fn resolve_storage_and_schema(
 }
 
 // ---------------------------------------------------------------------------
+// Module-level functions
+// ---------------------------------------------------------------------------
+
+/// Read the persisted commit generation for `path` directly from disk,
+/// without building an `Engine` -- no storage lock, no WAL recovery, no
+/// embedder loading (Issue #1101).
+///
+/// Unlike `Index#stats`, this is not tied to any `Index` instance: it works
+/// even when no `Index` for `path` has ever been constructed in this
+/// process, which is the point -- it lets a caller cheaply decide whether
+/// opening the index is worth doing at all.
+///
+/// # Arguments
+///
+/// * `path` - Directory path of a file-backed index (the same value passed
+///   as `path:` to `Laurus::Index.new`).
+///
+/// # Returns
+///
+/// `0` if the index exists but nothing has been committed yet.
+///
+/// # Errors
+///
+/// Raises a Ruby `ArgumentError` if `path` has no persisted schema at all
+/// (not a laurus index directory).
+fn peek_commit_generation(path: String) -> Result<u64, Error> {
+    laurus::index_dir::peek_commit_generation(Path::new(&path)).map_err(index_dir_err)
+}
+
+// ---------------------------------------------------------------------------
 // Class registration
 // ---------------------------------------------------------------------------
 
@@ -564,5 +594,9 @@ pub fn define(ruby: &Ruby, module: &RModule) -> Result<(), Error> {
     class.define_method("close", magnus::method!(RbIndex::close, 0))?;
     class.define_method("inspect", magnus::method!(RbIndex::inspect, 0))?;
     class.define_method("to_s", magnus::method!(RbIndex::inspect, 0))?;
+    module.define_module_function(
+        "peek_commit_generation",
+        magnus::function!(peek_commit_generation, 1),
+    )?;
     Ok(())
 }

--- a/laurus-ruby/test/test_peek_commit_generation.rb
+++ b/laurus-ruby/test/test_peek_commit_generation.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+require "tmpdir"
+
+# Tests for `Laurus.peek_commit_generation()` (Issue #1101).
+#
+# Unlike `Index#stats`, this is a module function, not tied to any `Index`
+# instance: it reads `commit_generation.json` directly from disk without
+# building an `Engine` at all, so it works even when no `Index` for the
+# given path has ever been constructed in this process -- the point being
+# to let a caller cheaply decide whether opening (or reloading) the index
+# is worth doing at all.
+class TestPeekCommitGeneration < Minitest::Test
+  def test_rejects_a_non_index_directory
+    Dir.mktmpdir do |dir|
+      err = assert_raises(ArgumentError) do
+        Laurus.peek_commit_generation(dir)
+      end
+      assert_match(/not a laurus index directory/, err.message)
+    end
+  end
+
+  def test_is_zero_before_any_commit
+    Dir.mktmpdir do |dir|
+      schema = Laurus::Schema.new
+      schema.add_text_field("title")
+      Laurus::Index.new(path: dir, schema: schema)
+
+      assert_equal 0, Laurus.peek_commit_generation(dir)
+    end
+  end
+
+  def test_advances_after_a_commit
+    # laurus-ruby's `stats` doesn't expose a `commit_generation` key (that's
+    # currently laurus-python-only), so this only checks the raw counter.
+    Dir.mktmpdir do |dir|
+      schema = Laurus::Schema.new
+      schema.add_text_field("title")
+      idx = Laurus::Index.new(path: dir, schema: schema)
+      idx.put_document("doc1", { "title" => "hello world" })
+      idx.commit
+
+      assert_equal 1, Laurus.peek_commit_generation(dir)
+    end
+  end
+
+  def test_sees_a_commit_made_by_another_handle
+    Dir.mktmpdir do |dir|
+      a = Laurus::Index.new(path: dir)
+      a.put_document("doc1", {})
+      a.commit
+      a.close
+
+      before = Laurus.peek_commit_generation(dir)
+
+      b = Laurus::Index.new(path: dir)
+      b.put_document("doc2", {})
+      b.commit
+      b.close
+
+      refute_equal before, Laurus.peek_commit_generation(dir)
+    end
+  end
+end

--- a/laurus/src/engine.rs
+++ b/laurus/src/engine.rs
@@ -315,15 +315,18 @@ async fn run_commit_ladder(
 /// Storage-root file name for the persisted commit generation counter
 /// (Issue #1088). Lives alongside `schema.toml`, outside any
 /// `PrefixedStorage` sub-namespace, since it represents the whole engine.
-const COMMIT_GENERATION_FILE: &str = "commit_generation.json";
+///
+/// `pub(crate)` so [`crate::index_dir::peek_commit_generation`] (Issue
+/// #1101) can read it directly without building an `Engine`.
+pub(crate) const COMMIT_GENERATION_FILE: &str = "commit_generation.json";
 
 /// On-disk payload for [`COMMIT_GENERATION_FILE`], written/read via
 /// [`crate::storage::manifest::save_checksummed_json`]/`load_checksummed_json`
 /// -- the same crash-atomic, checksummed framing every other small control
 /// file in laurus uses (Issue #1022).
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-struct CommitGenerationFile {
-    generation: u64,
+pub(crate) struct CommitGenerationFile {
+    pub(crate) generation: u64,
 }
 
 /// Tracks and persists the cross-process commit generation counter (Issue

--- a/laurus/src/index_dir.rs
+++ b/laurus/src/index_dir.rs
@@ -84,6 +84,18 @@ pub enum IndexDirError {
         source: std::io::Error,
     },
 
+    /// `path` has no `schema.toml`, so it isn't a laurus index directory at
+    /// all (Issue #1101's [`peek_commit_generation`], unlike
+    /// [`open_or_create`], never creates one on the caller's behalf).
+    #[error(
+        "{path} is not a laurus index directory (no {SCHEMA_FILE} found); \
+         check the path, or create the index first"
+    )]
+    NotAnIndexDirectory {
+        /// The path that was checked.
+        path: PathBuf,
+    },
+
     /// Schema (de)serialization or storage creation/opening failed.
     #[error(transparent)]
     Core(#[from] LaurusError),
@@ -135,6 +147,52 @@ pub fn open_or_create(
     }?;
 
     Ok((resolved_schema, storage))
+}
+
+/// Read the persisted commit generation (Issue #1088) for `index_dir`
+/// directly from disk, without building an `Engine` -- no storage lock, no
+/// WAL recovery, no embedder loading (Issue #1101). Lets a caller cheaply
+/// decide whether reopening or reloading the index is worth doing at all.
+///
+/// # Returns
+///
+/// * `0` if the index exists but no commit has happened yet (matches the
+///   fallback `Engine::builder`'s own generation tracker uses when
+///   `commit_generation.json` doesn't exist).
+///
+/// # Errors
+///
+/// Returns [`IndexDirError::NotAnIndexDirectory`] if `index_dir` has no
+/// `schema.toml` -- unlike [`open_or_create`], this function never creates
+/// one. Returns [`IndexDirError::Core`] if the persisted file exists but is
+/// corrupt (checksum mismatch or malformed JSON).
+pub fn peek_commit_generation(index_dir: &Path) -> Result<u64, IndexDirError> {
+    let schema_path = index_dir.join(SCHEMA_FILE);
+    if !schema_path.is_file() {
+        return Err(IndexDirError::NotAnIndexDirectory {
+            path: index_dir.to_path_buf(),
+        });
+    }
+
+    let store_path = index_dir.join(STORE_DIR);
+    if !store_path.is_dir() {
+        // schema.toml was written but no Engine has been built over this
+        // directory yet, so there's nothing to read -- and constructing a
+        // `FileStorage` here would create an empty `store/` as a side
+        // effect of merely peeking.
+        return Ok(0);
+    }
+
+    let storage = StorageFactory::open(StorageConfig::File(FileStorageConfig::new(&store_path)))?;
+    let generation =
+        crate::storage::manifest::load_checksummed_json::<crate::engine::CommitGenerationFile>(
+            storage.as_ref(),
+            crate::engine::COMMIT_GENERATION_FILE,
+            None,
+        )?
+        .map(|(value, _format)| value.generation)
+        .unwrap_or_default();
+    Ok(generation)
 }
 
 #[cfg(test)]
@@ -190,5 +248,59 @@ mod tests {
 
         let err = open_or_create(dir.path(), None).unwrap_err();
         assert!(matches!(err, IndexDirError::LegacyFlatLayout { .. }));
+    }
+
+    #[test]
+    fn peek_commit_generation_rejects_a_directory_with_no_schema_toml() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let err = peek_commit_generation(dir.path()).unwrap_err();
+        assert!(matches!(err, IndexDirError::NotAnIndexDirectory { .. }));
+    }
+
+    #[test]
+    fn peek_commit_generation_is_zero_before_any_engine_is_built() {
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(
+            dir.path().join(SCHEMA_FILE),
+            Schema::new().to_toml().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(peek_commit_generation(dir.path()).unwrap(), 0);
+    }
+
+    #[test]
+    fn peek_commit_generation_is_zero_before_any_commit() {
+        let dir = tempfile::TempDir::new().unwrap();
+        open_or_create(dir.path(), Some(Schema::new())).unwrap();
+
+        // `store/` now exists (created by `open_or_create`), but no Engine
+        // has ever committed, so `commit_generation.json` doesn't exist yet.
+        assert_eq!(peek_commit_generation(dir.path()).unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn peek_commit_generation_matches_a_real_engine_after_a_commit() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let (schema, storage) = open_or_create(dir.path(), Some(Schema::new())).unwrap();
+        let engine = crate::Engine::builder(storage, schema)
+            .build()
+            .await
+            .unwrap();
+        engine
+            .put_document(
+                "doc1",
+                crate::Document::builder()
+                    .add_text("title", "hello")
+                    .build(),
+            )
+            .await
+            .unwrap();
+        engine.commit().await.unwrap();
+        let expected = engine.commit_generation();
+        drop(engine);
+
+        assert_eq!(peek_commit_generation(dir.path()).unwrap(), expected);
+        assert_eq!(expected, 1);
     }
 }


### PR DESCRIPTION
## Summary

Adds a cheap, disk-only way to read the persisted commit generation (#1088) without building an `Engine` at all -- no storage lock, no WAL recovery, no embedder loading. `Engine::commit_generation()`/`stats()` only reflect the in-memory value of the currently-loaded `Engine`, so a long-lived reader process can never detect another process's commits by polling them; this closes that gap, letting a caller cheaply decide whether opening (or `reload()`-ing, in `laurus-python`) the index is worth doing at all.

- Core `laurus`: new `laurus::index_dir::peek_commit_generation(index_dir: &Path) -> Result<u64, IndexDirError>` and a new `IndexDirError::NotAnIndexDirectory` variant. 3-tier fallback: no `schema.toml` -> error; `schema.toml` but no `store/` yet -> `0`; `store/` but no `commit_generation.json` yet -> `0` (matches `CommitGenerationTracker::load`'s own fallback). Checks `store/`'s existence before ever constructing a `FileStorage` there, since `FileStorage::new` creates the directory as a side effect otherwise.
- All 4 bindings gained a free/module-level function (not an `Index` method, since the whole point is working without ever opening one), each reusing the existing `index_dir_err` helper: `laurus.peek_commit_generation(path)` (Python), `Laurus.peek_commit_generation(path)` (Ruby), `peekCommitGeneration(path)` returning `number` (Node.js), `Laurus\peek_commit_generation($path)` (PHP).

Full investigation/plan/report: #1101.

### Implementation notes beyond the plan

- PHP's `#[php_function]` macro generates a module-private internal struct, so `wrap_function!` can only be called from the same module the function is defined in -- added a small `peek_commit_generation_function_entry()` helper in `index.rs` for `lib.rs` to call instead of invoking `wrap_function!` directly.
- PHP functions register globally by default; needed an explicit `#[php(name = "Laurus\\peek_commit_generation")]` to place it under the `Laurus\` namespace alongside the classes. Confirmed empirically.
- napi-rs auto-generates the camelCase export and `.d.ts` declaration for the Node.js function -- no manual edits needed there.

Closes #1101

## Test plan

- [x] `cargo build`/`fmt --check`/`clippy --all-targets -- -D warnings` clean for `laurus` and all 4 bindings
- [x] `cargo test -p laurus --lib`: 1403 passing (4 new)
- [x] Built and tested natively on the implementer's machine for all 4 bindings, each with a new test exercising the realistic "another process committed" scenario (open/commit/close on one handle, then another, simulating a second process, then `peek_commit_generation` sees the second handle's change):
  - `laurus-python` (`maturin develop --release` + `pytest`): 97/97 passing
  - `laurus-ruby` (`bundle exec rake compile test`): 71/71 passing
  - `laurus-nodejs` (`npm run build:debug` + `npm test`): 72/72 passing
  - `laurus-php` (`RUSTFLAGS="-C link-arg=-Wl,-undefined,dynamic_lookup" cargo build --release` + PHPUnit): 73/73 passing
- [x] README (EN/JA) updated for `laurus-python`/`laurus-nodejs`/`laurus-php` (`laurus-ruby` has no top-level README, same as prior work)
