### PR TITLE
perf(ci): flatten periodic.yml and release.yml job DAG

### DIFF
--- a/.github/workflows/periodic.yml
+++ b/.github/workflows/periodic.yml
@@ -30,7 +30,6 @@ jobs:
   # ============================================================
   clippy:
     name: Clippy
-    needs: [format]
     runs-on: ubuntu-latest
     steps:
       - name: Run checkout
@@ -69,7 +68,6 @@ jobs:
   # ============================================================
   test-laurus:
     name: Test laurus
-    needs: [clippy]
     strategy:
       fail-fast: false
       matrix:
@@ -118,7 +116,6 @@ jobs:
   # ============================================================
   test-server:
     name: Test laurus-server
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -170,7 +167,6 @@ jobs:
   # ============================================================
   test-mcp:
     name: Test laurus-mcp
-    needs: [test-laurus, test-server]
     strategy:
       fail-fast: false
       matrix:
@@ -222,7 +218,6 @@ jobs:
   # ============================================================
   test-cli:
     name: Test laurus-cli
-    needs: [test-laurus, test-server, test-mcp]
     strategy:
       fail-fast: false
       matrix:
@@ -274,7 +269,6 @@ jobs:
   # ============================================================
   test-python:
     name: Test laurus-python
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -332,7 +326,6 @@ jobs:
   # ============================================================
   test-nodejs:
     name: Test laurus-nodejs
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -378,7 +371,6 @@ jobs:
   # ============================================================
   test-ruby:
     name: Test laurus-ruby
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -426,7 +418,6 @@ jobs:
   # ============================================================
   test-php:
     name: Test laurus-php
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -491,5 +482,4 @@ jobs:
   # ============================================================
   index-interop:
     name: Index Interop
-    needs: [test-laurus]
     uses: ./.github/workflows/index-interop.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
   # ============================================================
   clippy:
     name: Clippy
-    needs: [format]
     runs-on: ubuntu-latest
     steps:
       - name: Run checkout
@@ -70,7 +69,6 @@ jobs:
   # ============================================================
   test-laurus:
     name: Test laurus
-    needs: [clippy]
     strategy:
       fail-fast: false
       matrix:
@@ -119,7 +117,6 @@ jobs:
   # ============================================================
   test-server:
     name: Test laurus-server
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -171,7 +168,6 @@ jobs:
   # ============================================================
   test-mcp:
     name: Test laurus-mcp
-    needs: [test-laurus, test-server]
     strategy:
       fail-fast: false
       matrix:
@@ -223,7 +219,6 @@ jobs:
   # ============================================================
   test-cli:
     name: Test laurus-cli
-    needs: [test-laurus, test-server, test-mcp]
     strategy:
       fail-fast: false
       matrix:
@@ -275,7 +270,6 @@ jobs:
   # ============================================================
   test-python:
     name: Test laurus-python
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -333,7 +327,6 @@ jobs:
   # ============================================================
   test-nodejs:
     name: Test laurus-nodejs
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -379,7 +372,6 @@ jobs:
   # ============================================================
   test-ruby:
     name: Test laurus-ruby
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -428,7 +420,6 @@ jobs:
   # ============================================================
   test-php:
     name: Test laurus-php
-    needs: [test-laurus]
     strategy:
       fail-fast: false
       matrix:
@@ -487,7 +478,6 @@ jobs:
   # ============================================================
   test-wasm:
     name: Test laurus-wasm
-    needs: [test-laurus]
     runs-on: ubuntu-latest
     steps:
       - name: Run checkout
@@ -515,9 +505,17 @@ jobs:
   # ============================================================
   test-all:
     name: Test All
-    if: ${{ !failure() && !cancelled() }}
+    # DAG jobs above no longer depend on each other, so a lint failure no
+    # longer skips them transitively -- format/clippy must be listed
+    # explicitly to keep gating on lint. `!cancelled()` (rather than
+    # `!failure() && !cancelled()`) lets this step run even when a need was
+    # cancelled, so the explicit result check below can tell "cancelled"
+    # apart from "succeeded" instead of both silently passing.
+    if: ${{ !cancelled() }}
     needs:
       [
+        format,
+        clippy,
         test-laurus,
         test-cli,
         test-server,
@@ -530,8 +528,17 @@ jobs:
       ]
     runs-on: ubuntu-latest
     steps:
-      - name: All tests passed
-        run: echo "All tests passed"
+      - name: Check that no required job failed or was cancelled
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "ERROR: at least one required job failed" >&2
+            exit 1
+          fi
+          if [[ "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "ERROR: at least one required job was cancelled" >&2
+            exit 1
+          fi
+          echo "All tests passed"
 
   # ============================================================
   # Build release binaries


### PR DESCRIPTION
Closes #1105

## Summary

The `clippy -> test-laurus -> test-server -> test-mcp -> test-cli` needs chain
(and every other test job's dependency on `test-laurus`) in periodic.yml and
release.yml mirrored regression.yml's pre-#1095 state: each job builds what
it needs on its own via cargo, so the chain only serialized runs to warm
rust-cache within a single workflow run, at the cost of unnecessary wall-clock
waiting.

- Flatten periodic.yml: `clippy`, `test-laurus`, `test-server`, `test-mcp`,
  `test-cli`, `test-python`, `test-nodejs`, `test-ruby`, `test-php`, and
  `index-interop` now have no `needs` and run in parallel from workflow start
- Flatten release.yml the same way, including `test-wasm`
- release.yml's `test-all` gate previously relied on the `needs` chain to
  transitively skip test jobs when `format`/`clippy` failed. Removing the
  chain would have silently let `build-binary` and the publish jobs proceed
  even on a lint failure, so `test-all` now lists `format`/`clippy`
  explicitly in `needs`, switches its `if` to `!cancelled()`, and checks
  `contains(needs.*.result, 'failure'/'cancelled')` explicitly — the same
  fix applied to regression.yml in #1095
- periodic.yml has no downstream job consuming its test results, so no
  equivalent gate change was needed there

## Test plan

- [x] `actionlint` on both workflow files (only pre-existing shellcheck
  info/style notices remain, same category already present in
  regression.yml; no structural/dependency errors)
- [ ] Confirm the next scheduled/dispatched periodic.yml run and the next
  tagged release.yml run parallelize as expected