### PR TITLE
fix(wasm): pass the missing unk argument to WasmJapaneseAnalyzer::from_bytes in tests

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -587,7 +587,7 @@ jobs:
         run: cargo build -p laurus-wasm --target wasm32-unknown-unknown
 
       - name: Run clippy
-        run: cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings
+        run: cargo clippy -p laurus-wasm --target wasm32-unknown-unknown --tests -- -D warnings
 
   # ============================================================
   # Test laurus-ruby

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,7 +498,7 @@ jobs:
         run: cargo build -p laurus-wasm --target wasm32-unknown-unknown
 
       - name: Run clippy
-        run: cargo clippy -p laurus-wasm --target wasm32-unknown-unknown -- -D warnings
+        run: cargo clippy -p laurus-wasm --target wasm32-unknown-unknown --tests -- -D warnings
 
   # ============================================================
   # Gate: ensure all tests pass before proceeding to build

--- a/laurus-wasm/src/analysis.rs
+++ b/laurus-wasm/src/analysis.rs
@@ -309,6 +309,7 @@ mod tests {
             empty,
             empty,
             empty,
+            empty,
             None,
         );
         assert!(result.is_err());
@@ -334,6 +335,7 @@ mod tests {
         let empty: &[u8] = &[];
         let result = WasmJapaneseAnalyzer::from_bytes(
             b"{}",
+            empty,
             empty,
             empty,
             empty,


### PR DESCRIPTION
## Summary

`cargo check -p laurus-wasm --target wasm32-unknown-unknown --tests` fails on `main`: two `#[wasm_bindgen_test]` calls to `WasmJapaneseAnalyzer::from_bytes` (`laurus-wasm/src/analysis.rs:303`, `:335`) are missing the `unk: &[u8]` argument (position 9 of 10), so the trailing `mode` value lands in `unk`'s slot instead. CI never caught this because `regression.yml`/`release.yml`'s wasm jobs only run `cargo build`/`cargo clippy` without `--tests`.

## Changes

- Add the missing `empty` slice at both call sites so argument count/positions match the current `from_bytes` signature.
- Add `--tests` to the existing `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown` step in `regression.yml` and `release.yml` (the only two workflows with a wasm job), so the test target's compile errors are caught going forward without adding a new CI step.

## Test plan

- [x] `cargo check -p laurus-wasm --target wasm32-unknown-unknown --tests` passes
- [x] `cargo clippy -p laurus-wasm --target wasm32-unknown-unknown --tests -- -D warnings` passes, zero warnings
- [x] `cargo fmt -p laurus-wasm -- --check` clean

Closes #1065
