### PR TITLE
fix(lexical): fall back to the stored document when sorting a field with no DocValues column

### DIFF
--- a/laurus/src/lexical/index/inverted/writer.rs
+++ b/laurus/src/lexical/index/inverted/writer.rs
@@ -929,15 +929,22 @@ impl InvertedIndexWriter {
     /// Check if we should flush the current segment.
     /// Whether a stored value is worth a DocValues column (#1047).
     ///
-    /// DocValues serves sorting and faceting only. Sorting cannot order
-    /// `Bytes` or `Vector` values — [`sort_type_rank`] gives each variant a
-    /// single rank with no inner comparison, so every value of such a field
-    /// compares equal — and faceting reads the stored document when a column
-    /// is absent. Copying these payloads into a second on-disk structure
-    /// therefore doubles what the segment writes and buys nothing; a
-    /// thumbnail or an embedding is often the largest value in the document.
+    /// DocValues serves sorting and faceting only, and both fall back to
+    /// reading the stored document when a column is absent
+    /// ([`TopFieldCollector::get_field_value`], `FacetCollector::collect_doc`)
+    /// — so excluding a value from DocValues costs a stored-document decode
+    /// per hit, not correctness (#1053). `Vector` values genuinely have no
+    /// ordering ([`sort_type_rank`] gives every `Vector` the same rank, so
+    /// they always compare as ties regardless of where the value comes
+    /// from); `Bytes` *does* order lexicographically (`compare_sort_key`'s
+    /// explicit `Bytes` arm) but is excluded anyway, purely because copying
+    /// it into a second on-disk structure doubles what the segment writes
+    /// for no benefit — a thumbnail or a small blob is often the largest
+    /// value in the document, and the stored-document fallback already
+    /// recovers correct ordering when one is needed.
     ///
     /// [`sort_type_rank`]: crate::lexical::query::collector
+    /// [`TopFieldCollector::get_field_value`]: crate::lexical::query::collector::TopFieldCollector
     fn is_doc_values_candidate(value: &crate::data::DataValue) -> bool {
         !matches!(
             value,

--- a/laurus/src/lexical/query/collector.rs
+++ b/laurus/src/lexical/query/collector.rs
@@ -117,6 +117,14 @@ pub struct TopFieldCollector<'a> {
     total_hits: u64,
     /// Reference to the index reader for accessing field values.
     reader: &'a dyn crate::lexical::reader::LexicalIndexReader,
+    /// Whether `field_name` has a DocValues column, resolved once at
+    /// construction (Issue #1053). `field_name` is fixed for the whole
+    /// collector's lifetime, so caching this here -- rather than
+    /// re-probing per document -- avoids paying a lock-guarded
+    /// `has_doc_values` check on every hit for no benefit; mirrors the
+    /// same per-field caching `FacetCollector::collect_doc` does for the
+    /// same reason (#597).
+    has_dv: bool,
 }
 
 impl<'a> TopFieldCollector<'a> {
@@ -127,6 +135,7 @@ impl<'a> TopFieldCollector<'a> {
         ascending: bool,
         reader: &'a dyn crate::lexical::reader::LexicalIndexReader,
     ) -> Self {
+        let has_dv = reader.has_doc_values(&field_name);
         TopFieldCollector {
             max_docs,
             min_score: 0.0,
@@ -135,6 +144,7 @@ impl<'a> TopFieldCollector<'a> {
             hits: BinaryHeap::new(),
             total_hits: 0,
             reader,
+            has_dv,
         }
     }
 
@@ -146,6 +156,7 @@ impl<'a> TopFieldCollector<'a> {
         ascending: bool,
         reader: &'a dyn crate::lexical::reader::LexicalIndexReader,
     ) -> Self {
+        let has_dv = reader.has_doc_values(&field_name);
         TopFieldCollector {
             max_docs,
             min_score,
@@ -154,18 +165,33 @@ impl<'a> TopFieldCollector<'a> {
             hits: BinaryHeap::new(),
             total_hits: 0,
             reader,
+            has_dv,
         }
     }
 
-    /// Get the field value for a document using DocValues.
-    /// DocValues provide efficient column-oriented storage for field values.
+    /// Get the field value for a document, preferring DocValues.
+    ///
+    /// When `field_name` has no DocValues column, falls back to the
+    /// stored document (Issue #1053) instead of yielding `Null` --
+    /// otherwise every value compares equal and sorting silently
+    /// degrades to doc-id order. Mirrors `FacetCollector::collect_doc`'s
+    /// stored-document fallback for the same absent-column case.
     fn get_field_value(&self, doc_id: u64) -> crate::lexical::core::field::FieldValue {
-        // Get field value from DocValues (efficient column-oriented storage)
-        if let Ok(Some(value)) = self.reader.get_doc_value(&self.field_name, doc_id) {
-            value
-        } else {
-            // Return Null if field not found
-            crate::lexical::core::field::FieldValue::Null
+        use crate::lexical::core::field::FieldValue;
+
+        if self.has_dv {
+            return match self.reader.get_doc_value(&self.field_name, doc_id) {
+                Ok(Some(value)) => value,
+                _ => FieldValue::Null,
+            };
+        }
+
+        match self.reader.document(doc_id) {
+            Ok(Some(document)) => document
+                .get(&self.field_name)
+                .cloned()
+                .unwrap_or(FieldValue::Null),
+            _ => FieldValue::Null,
         }
     }
 
@@ -987,6 +1013,12 @@ mod tests {
         ) -> Result<Option<crate::lexical::core::field::FieldValue>> {
             Ok(self.values.get(&doc_id).cloned())
         }
+        fn has_doc_values(&self, _field: &str) -> bool {
+            // This mock exists to exercise the DocValues path -- see
+            // `DocFallbackMockReader` below for the stored-document
+            // fallback path (Issue #1053).
+            true
+        }
     }
 
     /// Build a `TopFieldCollector` over an `Int64` field named `"value"`
@@ -1202,5 +1234,132 @@ mod tests {
             );
             assert_eq!(compare_sort_key(&other, &FieldValue::Null), Ordering::Less);
         }
+    }
+
+    /// Reader with no DocValues at all, serving field values from stored
+    /// documents instead (Issue #1053). Mirrors the shape of `DvMockReader`
+    /// in `lexical::search::features::facet`, minus the per-field DocValues
+    /// toggle -- `TopFieldCollector` tests here only need the
+    /// no-DocValues-at-all case, since `has_dv` is resolved once for the
+    /// single sort field, not per document.
+    #[derive(Debug)]
+    struct DocFallbackMockReader {
+        docs: Vec<crate::Document>,
+    }
+
+    impl DocFallbackMockReader {
+        fn new(docs: Vec<crate::Document>) -> Self {
+            Self { docs }
+        }
+    }
+
+    impl crate::lexical::reader::LexicalIndexReader for DocFallbackMockReader {
+        fn doc_count(&self) -> u64 {
+            self.docs.len() as u64
+        }
+        fn max_doc(&self) -> u64 {
+            self.docs.len() as u64
+        }
+        fn is_deleted(&self, _doc_id: u64) -> bool {
+            false
+        }
+        fn document(&self, doc_id: u64) -> Result<Option<crate::Document>> {
+            Ok(self.docs.get(doc_id as usize).cloned())
+        }
+        fn term_info(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> Result<Option<crate::lexical::reader::ReaderTermInfo>> {
+            Ok(None)
+        }
+        fn postings(
+            &self,
+            _field: &str,
+            _term: &str,
+        ) -> Result<Option<Box<dyn crate::lexical::reader::PostingIterator>>> {
+            Ok(None)
+        }
+        fn field_stats(&self, _field: &str) -> Result<Option<crate::lexical::reader::FieldStats>> {
+            Ok(None)
+        }
+        fn close(&mut self) -> Result<()> {
+            Ok(())
+        }
+        fn is_closed(&self) -> bool {
+            false
+        }
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+        // `get_doc_value`/`has_doc_values` deliberately left at the
+        // trait's defaults (`Ok(None)` / `false`): this reader simulates a
+        // field with no DocValues column at all.
+    }
+
+    /// Issue #1053 regression: sorting by a `Bytes` field with no
+    /// DocValues column must order by content, not silently degrade to
+    /// doc-id order. Three documents hold content `[2]`, `[3]`, `[1]` at
+    /// doc ids `0`, `1`, `2` respectively, so content order (`[1] < [2] <
+    /// [3]`, i.e. doc ids `2, 0, 1`) differs from doc-id order (`0, 1,
+    /// 2`) -- this one test is red before the stored-document fallback
+    /// (every value resolves to `Null`, yielding doc-id order `[0, 1,
+    /// 2]`) and green after (content order `[2, 0, 1]`), directly
+    /// distinguishing the two behaviors.
+    #[test]
+    fn test_top_field_collector_bytes_sort_falls_back_to_stored_document() {
+        let docs = vec![
+            crate::Document::builder()
+                .add_bytes("blob", vec![2])
+                .build(), // doc_id 0
+            crate::Document::builder()
+                .add_bytes("blob", vec![3])
+                .build(), // doc_id 1
+            crate::Document::builder()
+                .add_bytes("blob", vec![1])
+                .build(), // doc_id 2
+        ];
+        let reader = DocFallbackMockReader::new(docs);
+        let mut collector = TopFieldCollector::new(3, "blob".to_string(), true, &reader);
+        for doc_id in 0..3 {
+            collector.collect(doc_id, 0.0).unwrap();
+        }
+        let ids: Vec<u64> = collector.results().iter().map(|h| h.doc_id).collect();
+        assert_eq!(
+            ids,
+            vec![2, 0, 1],
+            "must order by content ([1] < [2] < [3]), not doc id"
+        );
+    }
+
+    /// Issue #1053 acceptance criterion: `Vector` fields genuinely have no
+    /// ordering (`compare_sort_key` falls through to `sort_type_rank`,
+    /// which gives every `Vector` the same rank), so the stored-document
+    /// fallback must not change their sort order -- it stays doc-id order
+    /// either way.
+    #[test]
+    fn test_top_field_collector_vector_sort_unaffected_by_stored_document_fallback() {
+        let docs = vec![
+            crate::Document::builder()
+                .add_vector("embedding", vec![3.0, 0.0])
+                .build(), // doc_id 0
+            crate::Document::builder()
+                .add_vector("embedding", vec![1.0, 0.0])
+                .build(), // doc_id 1
+            crate::Document::builder()
+                .add_vector("embedding", vec![2.0, 0.0])
+                .build(), // doc_id 2
+        ];
+        let reader = DocFallbackMockReader::new(docs);
+        let mut collector = TopFieldCollector::new(3, "embedding".to_string(), true, &reader);
+        for doc_id in 0..3 {
+            collector.collect(doc_id, 0.0).unwrap();
+        }
+        let ids: Vec<u64> = collector.results().iter().map(|h| h.doc_id).collect();
+        assert_eq!(
+            ids,
+            vec![0, 1, 2],
+            "Vector values always tie on rank, so order stays doc-id order"
+        );
     }
 }


### PR DESCRIPTION
## Summary

PR #1052 stopped copying `Bytes` and `Vector` values into DocValues, reasoning that sorting can't order either. That's true for `Vector` (`sort_type_rank` gives it a single rank with no inner comparison), but wrong for `Bytes`: `compare_sort_key` has an explicit arm, `(FieldValue::Bytes(a, _), FieldValue::Bytes(b, _)) => a.cmp(b)`, that orders lexicographically by content. As a result, sorting by a `Bytes` field silently degraded to doc-id order -- every value resolved to `Null`, and `Null == Null`.

## Fix

`TopFieldCollector::get_field_value` (`laurus/src/lexical/query/collector.rs`) now caches whether its sort field has a DocValues column -- resolved once at construction, mirroring the per-field caching `FacetCollector::collect_doc` already does for the same reason (#597: avoid a lock-guarded `has_doc_values` probe on every hit) -- and falls back to reading the stored document when it doesn't, exactly like `FacetCollector::collect_doc`'s existing stored-document branch. `Vector` fields are unaffected: `sort_type_rank` still ties every `Vector` regardless of where the value comes from.

Also fixed `is_doc_values_candidate`'s doc comment (`laurus/src/lexical/index/inverted/writer.rs`), which incorrectly claimed sorting can't order `Bytes` values. The actual reason `Bytes` stays excluded from DocValues is payload size (copying large blobs into a second on-disk structure for no benefit), not lack of ordering -- correctness is preserved by the stored-document fallback.

No change to `is_doc_values_candidate`'s actual logic; `Bytes`/`Vector` remain excluded from DocValues, so the #1052 payload-size gate is untouched.

## Tests

Added to `collector.rs`'s test module:
- `test_top_field_collector_bytes_sort_falls_back_to_stored_document`: reproduces the exact regression -- three documents with `Bytes` content `[2]`, `[3]`, `[1]` at doc ids `0`, `1`, `2` -- and asserts ascending sort returns content order (doc ids `2, 0, 1`), not doc-id order. Manually verified this test is red without the fallback (returns `[0, 1, 2]`) and green with it.
- `test_top_field_collector_vector_sort_unaffected_by_stored_document_fallback`: confirms `Vector` sort order is unchanged by the same fallback.
- New mock `DocFallbackMockReader` (mirrors `facet.rs`'s `DvMockReader`) simulating a field with no DocValues column at all.
- Added a `has_doc_values` override to the existing `FieldValueMockReader` (previously relied on the trait's `false` default, which would have silently broken every existing `TopFieldCollector` test once the fallback branch was added).

## Test plan

- [x] Sorting by a `Bytes` field orders by content again (new regression test, confirmed red before the fix)
- [x] The test distinguishes the two behaviors -- confirmed failing when the fallback is disabled
- [x] `Vector` fields, which genuinely have no ordering, are unaffected (new test)
- [x] The DocValues payload gate from #1052 still holds (`writer::tests::binary_payloads_are_kept_out_of_doc_values` and friends unchanged, still passing)
- [x] `cargo test -p laurus` -- 1405 lib tests + all doctests pass, zero regressions
- [x] `cargo fmt -p laurus -- --check` / `cargo clippy -p laurus --all-targets -- -D warnings` clean

Closes #1053
