### PR TITLE
fix(engine): make Schema serialization deterministic (HashMap -> BTreeMap)

### DIFF
--- a/laurus-cli/src/commands/create.rs
+++ b/laurus-cli/src/commands/create.rs
@@ -11,7 +11,7 @@
 //! including lexical fields (Text, Integer, Float, etc.) and vector index
 //! fields (HNSW, Flat, IVF).
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use anyhow::{Context, Result};
@@ -137,8 +137,10 @@ pub async fn run_index(
 /// Collect the fields eligible for create-time codebook training: HNSW
 /// fields configuring `ProductQuantization` (or, with the `pq-fastscan`
 /// feature, `ProductQuantizationFastScan` — Issue #920) with a
-/// `pq_codebook_path`, sorted by field name (`Schema::fields` is a
-/// HashMap, so iteration order alone would be nondeterministic).
+/// `pq_codebook_path`, sorted by field name. `Schema::fields` is a
+/// `BTreeMap` (Issue #1060) so iteration is already in that order; the
+/// explicit sort is kept to make the ordering guarantee obvious here
+/// rather than relying on that implicit fact.
 fn eligible_pq_fields(schema: &Schema) -> Vec<String> {
     use laurus::vector::core::quantization::QuantizationMethod;
     fn is_pq_variant(quantizer: &QuantizationMethod) -> bool {
@@ -236,7 +238,7 @@ pub fn run_schema(output: &Path) -> Result<()> {
 pub fn build_schema_interactive() -> Result<Schema> {
     println!("\n=== Laurus Schema Generator ===\n");
 
-    let mut fields: HashMap<String, FieldOption> = HashMap::new();
+    let mut fields: BTreeMap<String, FieldOption> = BTreeMap::new();
     let mut field_order: Vec<String> = Vec::new();
 
     loop {
@@ -276,8 +278,8 @@ pub fn build_schema_interactive() -> Result<Schema> {
     };
 
     Ok(Schema {
-        analyzers: std::collections::HashMap::new(),
-        embedders: std::collections::HashMap::new(),
+        analyzers: BTreeMap::new(),
+        embedders: BTreeMap::new(),
         fields,
         default_fields,
         dynamic_field_policy: Default::default(),
@@ -286,7 +288,7 @@ pub fn build_schema_interactive() -> Result<Schema> {
 }
 
 /// Prompt for a unique field name.
-fn prompt_field_name(existing: &HashMap<String, FieldOption>) -> Result<String> {
+fn prompt_field_name(existing: &BTreeMap<String, FieldOption>) -> Result<String> {
     loop {
         let name: String = Input::new().with_prompt("Field name").interact_text()?;
 

--- a/laurus-python/src/schema.rs
+++ b/laurus-python/src/schema.rs
@@ -679,9 +679,10 @@ impl PySchema {
     /// from Python can also be opened with ``laurus-cli``.
     ///
     /// Note:
-    ///     Table order in the output is not stable across calls (the
-    ///     underlying maps are unordered); compare parsed structures
-    ///     rather than raw text when round-tripping.
+    ///     Table order in the output is stable and sorted by key across
+    ///     calls (Issue #1060). Comparing parsed structures rather than
+    ///     raw text is still recommended when round-tripping, since it
+    ///     doesn't depend on this ordering guarantee.
     pub fn to_toml(&self) -> PyResult<String> {
         self.inner.to_toml().map_err(schema_toml_err)
     }

--- a/laurus-python/tests/test_schema_analyzer.py
+++ b/laurus-python/tests/test_schema_analyzer.py
@@ -224,8 +224,9 @@ def test_to_toml_then_from_toml_round_trip():
     toml_str = schema.to_toml()
     restored = laurus.Schema.from_toml(toml_str)
 
-    # Compare parsed structure, not raw text: the underlying maps are
-    # unordered, so table order in the TOML text is not stable.
+    # Compare parsed structure rather than raw text: it's the more direct
+    # check for round-tripping, even though table order in the TOML text
+    # is now stable and sorted by key (Issue #1060).
     assert restored.field_names() == schema.field_names()
     assert restored.analyzer_names() == schema.analyzer_names()
 

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -4,7 +4,7 @@
 //! datetime, geo, bytes, HNSW, flat, IVF), distance metrics, and quantization
 //! configuration.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use laurus::vector::core::rerank::RerankStorageKind;
 use laurus::{
@@ -46,17 +46,17 @@ pub fn to_proto(schema: &Schema) -> v1::Schema {
 
 /// Convert a proto Schema into a laurus Schema.
 pub fn from_proto(proto: &v1::Schema) -> Result<Schema, String> {
-    let mut fields = HashMap::new();
+    let mut fields = BTreeMap::new();
     for (name, fo) in &proto.fields {
         let option = field_option_from_proto(fo)
             .ok_or_else(|| format!("Field '{name}' has no option set"))?;
         fields.insert(name.clone(), option);
     }
-    let mut analyzers = HashMap::new();
+    let mut analyzers = BTreeMap::new();
     for (name, ad) in &proto.analyzers {
         analyzers.insert(name.clone(), analyzer_definition_from_proto(ad)?);
     }
-    let mut embedders = HashMap::new();
+    let mut embedders = BTreeMap::new();
     for (name, ed) in &proto.embedders {
         embedders.insert(name.clone(), embedder_definition_from_proto(ed)?);
     }
@@ -590,8 +590,12 @@ fn char_filter_to_proto(config: &CharFilterConfig) -> v1::ComponentConfig {
             ("pattern_replace", p)
         }
         CharFilterConfig::Mapping { mapping } => {
-            // Encode mapping as key=value pairs in params.
-            let p: HashMap<String, String> = mapping.clone();
+            // Encode mapping as key=value pairs in params. `mapping` is a
+            // `BTreeMap` (Issue #1060); `params` is the proto's `HashMap`.
+            let p: HashMap<String, String> = mapping
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
             ("mapping", p)
         }
         CharFilterConfig::JapaneseIterationMark { kanji, kana } => {
@@ -625,7 +629,11 @@ fn char_filter_from_proto(proto: &v1::ComponentConfig) -> Result<CharFilterConfi
             replacement: proto.params.get("replacement").cloned().unwrap_or_default(),
         }),
         "mapping" => Ok(CharFilterConfig::Mapping {
-            mapping: proto.params.clone(),
+            mapping: proto
+                .params
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
         }),
         "japanese_iteration_mark" => Ok(CharFilterConfig::JapaneseIterationMark {
             kanji: proto.params.get("kanji").is_none_or(|v| v != "false"),

--- a/laurus/src/analysis/analyzer/registry.rs
+++ b/laurus/src/analysis/analyzer/registry.rs
@@ -126,7 +126,7 @@ pub fn create_analyzer_by_name(name: &str) -> Result<Arc<dyn Analyzer>> {
 /// [`EngineBuilder::register_runtime_analyzer`]: crate::engine::EngineBuilder::register_runtime_analyzer
 pub fn create_analyzer_from_spec(
     spec: &AnalyzerSpec,
-    schema_analyzers: &std::collections::HashMap<String, AnalyzerDefinition>,
+    schema_analyzers: &std::collections::BTreeMap<String, AnalyzerDefinition>,
     runtime_analyzers: &std::collections::HashMap<String, Arc<dyn Analyzer>>,
 ) -> Result<Arc<dyn Analyzer>> {
     match spec {
@@ -324,7 +324,7 @@ mod tests {
     #[test]
     fn test_create_named_from_spec_falls_back_to_schema_analyzers() {
         let spec = AnalyzerSpec::Named("my_custom".into());
-        let mut analyzers = std::collections::HashMap::new();
+        let mut analyzers = std::collections::BTreeMap::new();
         analyzers.insert(
             "my_custom".to_string(),
             AnalyzerDefinition {

--- a/laurus/src/analysis/char_filter/mapping.rs
+++ b/laurus/src/analysis/char_filter/mapping.rs
@@ -1,5 +1,5 @@
 use aho_corasick::{AhoCorasick, MatchKind};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use super::{CharFilter, Transformation};
 
@@ -9,7 +9,7 @@ pub struct MappingCharFilter {
 }
 
 impl MappingCharFilter {
-    pub fn new(mapping: HashMap<String, String>) -> crate::error::Result<Self> {
+    pub fn new(mapping: BTreeMap<String, String>) -> crate::error::Result<Self> {
         let mut keys = Vec::new();
         let mut replacements = Vec::new();
 
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn test_mapping_char_filter() {
-        let mut mapping = HashMap::new();
+        let mut mapping = BTreeMap::new();
         mapping.insert("ph".to_string(), "f".to_string());
         mapping.insert("qu".to_string(), "k".to_string());
 
@@ -105,7 +105,7 @@ mod tests {
 
     #[test]
     fn test_mapping_expansion() {
-        let mut mapping = HashMap::new();
+        let mut mapping = BTreeMap::new();
         mapping.insert("a".to_string(), "aaa".to_string());
         let filter = MappingCharFilter::new(mapping).unwrap();
         let (output, trans) = filter.filter("bab");
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_mapping_deletion() {
-        let mut mapping = HashMap::new();
+        let mut mapping = BTreeMap::new();
         mapping.insert("foo".to_string(), "".to_string());
         let filter = MappingCharFilter::new(mapping).unwrap();
         let (output, trans) = filter.filter("afoob");
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_mapping_overlap() {
-        let mut mapping = HashMap::new();
+        let mut mapping = BTreeMap::new();
         mapping.insert("ab".to_string(), "1".to_string());
         mapping.insert("abc".to_string(), "2".to_string());
         let filter = MappingCharFilter::new(mapping).unwrap();
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn test_mapping_multibyte() {
-        let mut mapping = HashMap::new();
+        let mut mapping = BTreeMap::new();
         mapping.insert("壱".to_string(), "1".to_string());
         let filter = MappingCharFilter::new(mapping).unwrap();
 

--- a/laurus/src/engine/schema.rs
+++ b/laurus/src/engine/schema.rs
@@ -2,7 +2,7 @@ pub mod analyzer;
 pub mod embedder;
 
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use self::analyzer::AnalyzerDefinition;
 use self::embedder::EmbedderDefinition;
@@ -123,14 +123,22 @@ pub fn validate_field_name(name: &str) -> crate::error::Result<()> {
 pub struct Schema {
     /// Custom analyzer definitions, keyed by name.
     /// These can be referenced from text field `analyzer` settings.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub analyzers: HashMap<String, AnalyzerDefinition>,
+    ///
+    /// A `BTreeMap` (not `HashMap`), so serialization (`to_toml`/`to_json`)
+    /// always emits keys in the same sorted order (Issue #1060) instead of
+    /// varying with `HashMap`'s per-process hash seed.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub analyzers: BTreeMap<String, AnalyzerDefinition>,
     /// Embedder definitions, keyed by name.
     /// These can be referenced from vector field `embedder` settings.
-    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
-    pub embedders: HashMap<String, EmbedderDefinition>,
+    ///
+    /// A `BTreeMap` for the same determinism reason as [`Self::analyzers`].
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub embedders: BTreeMap<String, EmbedderDefinition>,
     /// Options for each field.
-    pub fields: HashMap<String, FieldOption>,
+    ///
+    /// A `BTreeMap` for the same determinism reason as [`Self::analyzers`].
+    pub fields: BTreeMap<String, FieldOption>,
     /// Default fields for search.
     #[serde(default)]
     pub default_fields: Vec<String>,
@@ -160,9 +168,9 @@ pub struct Schema {
 impl Schema {
     pub fn new() -> Self {
         Self {
-            analyzers: HashMap::new(),
-            embedders: HashMap::new(),
-            fields: HashMap::new(),
+            analyzers: BTreeMap::new(),
+            embedders: BTreeMap::new(),
+            fields: BTreeMap::new(),
             default_fields: Vec::new(),
             dynamic_field_policy: DynamicFieldPolicy::default(),
             pending_reindex: BTreeSet::new(),
@@ -565,9 +573,9 @@ fn classify_ivf_specific(old: &IvfOption, new: &IvfOption) -> FieldChangeKind {
 
 #[derive(Default)]
 pub struct SchemaBuilder {
-    analyzers: HashMap<String, AnalyzerDefinition>,
-    embedders: HashMap<String, EmbedderDefinition>,
-    fields: HashMap<String, FieldOption>,
+    analyzers: BTreeMap<String, AnalyzerDefinition>,
+    embedders: BTreeMap<String, EmbedderDefinition>,
+    fields: BTreeMap<String, FieldOption>,
     default_fields: Vec<String>,
     dynamic_field_policy: DynamicFieldPolicy,
 }
@@ -1261,6 +1269,87 @@ mod tests {
 
         for (desc, old, new, expected) in cases {
             assert_eq!(classify_change(&old, &new), expected, "case failed: {desc}");
+        }
+    }
+
+    /// Issue #1060: `Schema`'s `analyzers`/`embedders`/`fields` are
+    /// `BTreeMap`s, not `HashMap`s, so `to_toml()` must produce
+    /// byte-identical output across repeated calls on the same schema.
+    /// With `HashMap`, table order would instead vary with the
+    /// process's per-instance hash seed.
+    #[test]
+    fn schema_toml_serialization_is_deterministic_across_calls() {
+        use crate::engine::schema::analyzer::{AnalyzerDefinition, TokenizerConfig};
+        use crate::engine::schema::embedder::EmbedderDefinition;
+        use crate::lexical::core::field::{BooleanOption, DateTimeOption, IntegerOption};
+
+        let schema = Schema::builder()
+            .add_text_field("title", TextOption::default())
+            .add_text_field("body", TextOption::default())
+            .add_integer_field("year", IntegerOption::default())
+            .add_boolean_field("published", BooleanOption::default())
+            .add_datetime_field("created_at", DateTimeOption::default())
+            .add_analyzer(
+                "analyzer_z",
+                AnalyzerDefinition {
+                    char_filters: vec![],
+                    tokenizer: TokenizerConfig::Whitespace,
+                    token_filters: vec![],
+                },
+            )
+            .add_analyzer(
+                "analyzer_a",
+                AnalyzerDefinition {
+                    char_filters: vec![],
+                    tokenizer: TokenizerConfig::Whitespace,
+                    token_filters: vec![],
+                },
+            )
+            .add_embedder("embedder_z", EmbedderDefinition::Precomputed)
+            .add_embedder("embedder_a", EmbedderDefinition::Precomputed)
+            .build();
+
+        let first = schema.to_toml().unwrap();
+        for _ in 0..10 {
+            assert_eq!(
+                schema.to_toml().unwrap(),
+                first,
+                "TOML output must be byte-identical across repeated calls"
+            );
+        }
+    }
+
+    /// Issue #1060: a `CharFilterConfig::Mapping`'s dictionary is also a
+    /// `BTreeMap` for the same reason -- it's serialized as part of the
+    /// schema's `analyzers` table.
+    #[test]
+    fn schema_toml_serialization_is_deterministic_with_mapping_char_filter() {
+        use crate::CharFilterConfig;
+        use crate::engine::schema::analyzer::{AnalyzerDefinition, TokenizerConfig};
+
+        let mut mapping = std::collections::BTreeMap::new();
+        mapping.insert("z".to_string(), "zed".to_string());
+        mapping.insert("a".to_string(), "ay".to_string());
+        mapping.insert("m".to_string(), "em".to_string());
+
+        let schema = Schema::builder()
+            .add_analyzer(
+                "with_mapping",
+                AnalyzerDefinition {
+                    char_filters: vec![CharFilterConfig::Mapping { mapping }],
+                    tokenizer: TokenizerConfig::Whitespace,
+                    token_filters: vec![],
+                },
+            )
+            .build();
+
+        let first = schema.to_toml().unwrap();
+        for _ in 0..10 {
+            assert_eq!(
+                schema.to_toml().unwrap(),
+                first,
+                "TOML output must be byte-identical across repeated calls"
+            );
         }
     }
 }

--- a/laurus/src/engine/schema/analyzer.rs
+++ b/laurus/src/engine/schema/analyzer.rs
@@ -15,7 +15,7 @@
 //! }
 //! ```
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -185,8 +185,9 @@ pub enum CharFilterConfig {
 
     /// Replaces strings using a mapping dictionary.
     Mapping {
-        /// Key-value pairs for replacement.
-        mapping: HashMap<String, String>,
+        /// Key-value pairs for replacement. A `BTreeMap` (not `HashMap`)
+        /// so schema serialization stays deterministic (Issue #1060).
+        mapping: BTreeMap<String, String>,
     },
 
     /// Expands Japanese iteration marks (踊り字).


### PR DESCRIPTION
## Summary

`Schema`'s `analyzers`/`embedders`/`fields` maps were `std::collections::HashMap`, which has no stable iteration order (`RandomState`). As a result, `toml::to_string_pretty(&schema)` -- used by `laurus-cli`'s `save_schema` and `laurus-python`'s `Schema.to_toml` -- emitted tables in a different order on every process run for an identical schema, producing spurious diffs when regenerating `schema.toml` and making raw-text serialization comparisons inherently flaky.

## Fix

Changed `Schema`'s three map fields (and the mirroring `SchemaBuilder` fields, `laurus/src/engine/schema.rs`) from `HashMap` to `BTreeMap`, so serialization always emits keys in sorted order -- the same pattern `Schema.pending_reindex` already used (`BTreeSet`) and that `laurus/src/vector/index/multi_field.rs` already uses for the identical reason ("iteration order feeds ... which must not depend on hash seed").

While implementing, found `CharFilterConfig::Mapping`'s dictionary (`laurus/src/engine/schema/analyzer.rs`) has the exact same issue -- it's nested inside `Schema.analyzers` and serialized as part of the schema, so it's in scope too. Fixed it the same way, plus its two downstream construction sites: `MappingCharFilter::new()` (`laurus/src/analysis/char_filter/mapping.rs`) and `laurus-server`'s proto <-> `Schema` conversions (`laurus-server/src/convert/schema.rs`, both directions).

Two more direct `Schema { .. }` constructors beyond `Schema::new()`/`SchemaBuilder` needed updating: `laurus-cli/src/commands/create.rs`'s interactive schema builder, and `laurus-server/src/convert/schema.rs`'s `from_proto`.

Surveyed every read/write site of these fields across the whole workspace (all crates, including every language binding) before making the change: all of them use only generic map API (`.get`/`.insert`/`.iter`/`.keys`/`.contains_key`/`.remove`) with zero use of `HashMap`-specific behavior, and neither `Schema` nor `SchemaBuilder` derive/implement `Hash`/`PartialEq`/`Eq`/`Ord` manually -- so this is a pure type change with no logic changes required anywhere.

**Docs**: fixed the one stale docstring (`laurus-python/src/schema.rs`'s `Schema.to_toml`) that explicitly documented the old nondeterminism as expected behavior, and a test comment in `laurus-python/tests/test_schema_analyzer.py` making the same claim. No other binding (ruby/nodejs/php/wasm) had this docstring.

## Out of scope

A few other `HashMap`-in-a-`Serialize`-struct candidates turned up during the survey (`Hit.fields`, `ProcessedSearchResults.aggregations`, `Document.fields`) but the issue only names `Schema`, and `Document.fields` in particular is hot-path code where a `BTreeMap` swap deserves its own performance consideration -- left for a separate issue if wanted.

`laurus-cli`'s existing `eligible_pq_fields` already worked around today's `HashMap` nondeterminism with an explicit `.sort()` (comment: "Schema::fields is a HashMap, so iteration order alone would be nondeterministic"). Left the `.sort()` call in place (now redundant but harmless, and self-documenting) and just corrected the comment.

## Test plan

- [x] New test `schema_toml_serialization_is_deterministic_across_calls`: builds a `Schema` with several fields/analyzers/embedders, calls `to_toml()` 10 times, asserts byte-identical output every time
- [x] New test `schema_toml_serialization_is_deterministic_with_mapping_char_filter`: same check for a schema using a `CharFilterConfig::Mapping`
- [x] Manually verified via `laurus-python`: 20 calls to `Schema.to_toml()` on a schema with out-of-alphabetical-order field/analyzer names produce 1 unique output, sorted by key
- [x] `cargo test -p laurus` (1407 tests) / `cargo test -p laurus-cli` (35) / `cargo test -p laurus-server` (54) all pass, zero regressions
- [x] `laurus-python`'s existing TOML round-trip tests (19) pass unchanged
- [x] `cargo check` on every binding crate (python/ruby/nodejs/php/mcp) + `cargo check --target wasm32-unknown-unknown --tests` for wasm: all compile with no changes needed
- [x] `cargo fmt --all -- --check` / `cargo clippy --all-targets --features embeddings-all -- -D warnings` clean across the workspace

Closes #1060
