### PR TITLE
feat(vector): wire FieldOption::base_weight into VectorStore scoring

### DIFF
--- a/docs/ja/src/concepts/schema_and_fields.md
+++ b/docs/ja/src/concepts/schema_and_fields.md
@@ -108,7 +108,7 @@ let opt = HnswOption {
     m: 16,                                           // max connections per layer
     ef_construction: 200,                            // construction search width
     default_ef_search: Some(100),                    // schema-level ef_search default (issue #644)
-    base_weight: 1.0,                                // default scoring weight
+    base_weight: 1.0,                                // 他の vector フィールドに対する相対的な優先度（issue #1084）
     quantizer: QuantizationMethod::Scalar8Bit,       // 必須（デフォルト Scalar8Bit）
     embedder: None,                                  // 任意の embedder 名
 };

--- a/docs/ja/src/concepts/search/vector_search.md
+++ b/docs/ja/src/concepts/search/vector_search.md
@@ -166,6 +166,18 @@ text_vec:"cute kitten"^1.0 image_vec:"fluffy cat"^0.5
 
 これは、テキストの類似度が画像の類似度の 2 倍の重みを持つことを意味します。
 
+vector フィールドのスキーマレベルの `base_weight`（Issue #1084）も同様に
+機能しますが、クエリ単位の上書きではなくフィールド単位のデフォルト値
+である点が異なります。上記のクエリ重みに乗算されるため、`base_weight`
+と `^`/`weight` は組み合わさります。どちらも vector 側自体のスコアリング
+にしか影響しないため、ハイブリッド検索の lexical-vs-vector のバランス
+を変えることはできません。`FusionAlgorithm::RRF` はランクのみを見て元の
+スコアを完全に無視しますし、`FusionAlgorithm::WeightedSum` は
+`lexical_weight`/`vector_weight` を適用する前に各側を min-max 正規化
+するため、フィールド単位の一様なスカラー倍は打ち消されます。両方の
+重み付け機構が実際に影響するのは、1 回のクエリで複数の vector フィール
+ドを対象にしたときの、フィールド間の相対的な優先度です。
+
 ### フィールドルーティング
 
 マルチフィールドスキーマでは、各 vector フィールドが独自の HNSW graph を

--- a/docs/ja/src/laurus-cli/schema_format.md
+++ b/docs/ja/src/laurus-cli/schema_format.md
@@ -181,7 +181,7 @@ base_weight = 1.0
 | `distance` | `string` | `"Cosine"` | 距離メトリクス（[距離メトリクス](#距離メトリクス)を参照） |
 | `m` | `integer` | `16` | ノードあたりの最大双方向接続数。大きいほど再現率が向上するがメモリ使用量が増加 |
 | `ef_construction` | `integer` | `200` | インデックス構築時の探索幅。大きいほど品質が向上するが構築が遅くなる |
-| `base_weight` | `float` | `1.0` | ハイブリッド検索のスコア融合における重み |
+| `base_weight` | `float` | `1.0` | 同時に検索する他の vector フィールドに対する相対的な優先度。ハイブリッド検索の lexical-vs-vector 融合のバランスには影響しない（[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照） |
 | `quantizer` | `object` | `"Scalar8Bit"` | 量子化方式（[量子化](#量子化)を参照）。必須。デフォルトは Issue #481 Stage 1 で導入された int8 形式を保つ。 |
 | `rerank_storage` | `string` | *（省略）* | Stage 2 rerank sidecar（[Rerank Storage](#rerank-storage)）。`"F32"` でフィールド単位の f32 sidecar を有効化し、検索時に int8 候補を元のベクトルで再スコアできるようにする。省略すると Stage 1 int8-only の挙動を維持。 |
 | `pq_codebook_path` | `string` | *（省略）* | 共有 PQ codebook のストレージ相対ファイル名（Issue #631）。`ProductQuantization` quantizer との組み合わせでのみ意味を持つ。`laurus train pq-codebook` で学習すると、以後の commit は segment ごとの k-means 再学習の代わりにこの codebook で encode する。設定済みで未学習の場合、commit は明示的にエラーになる（無言のフォールバック無し）。省略すると segment ごとに学習。 |
@@ -207,7 +207,7 @@ base_weight = 1.0
 | :--- | :--- | :--- | :--- |
 | `dimension` | `integer` | `128` | ベクトルの次元数 |
 | `distance` | `string` | `"Cosine"` | 距離メトリクス（[距離メトリクス](#距離メトリクス)を参照） |
-| `base_weight` | `float` | `1.0` | ハイブリッド検索のスコア融合における重み |
+| `base_weight` | `float` | `1.0` | 同時に検索する他の vector フィールドに対する相対的な優先度。ハイブリッド検索の lexical-vs-vector 融合のバランスには影響しない（[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照） |
 | `quantizer` | `object` | `"Scalar8Bit"` | 量子化方式（[量子化](#量子化)を参照）。必須。デフォルトは Issue #481 Stage 1 で導入された int8 形式を保つ。 |
 | `rerank_storage` | `string` | *（省略）* | Stage 2 rerank sidecar（[Rerank Storage](#rerank-storage)）。#932 以降、3 つのベクトルインデックスタイプすべてでサポート。`"F32"` でフィールド単位の f32 sidecar を有効化し、検索時に int8 候補を元のベクトルで再スコアできる。 |
 
@@ -230,7 +230,7 @@ base_weight = 1.0
 | `distance` | `string` | `"Cosine"` | 距離メトリクス（[距離メトリクス](#距離メトリクス)を参照） |
 | `n_clusters` | `integer` | `100` | クラスタ数。多いほど細かい分割が可能 |
 | `n_probe` | `integer` | `1` | クエリ時に検索するクラスタ数。大きいほど再現率が向上するが遅くなる |
-| `base_weight` | `float` | `1.0` | ハイブリッド検索のスコア融合における重み |
+| `base_weight` | `float` | `1.0` | 同時に検索する他の vector フィールドに対する相対的な優先度。ハイブリッド検索の lexical-vs-vector 融合のバランスには影響しない（[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照） |
 | `quantizer` | `object` | `"Scalar8Bit"` | 量子化方式（[量子化](#量子化)を参照）。必須。デフォルトは Issue #481 Stage 1 で導入された int8 形式を保つ。 |
 | `rerank_storage` | `string` | *（省略）* | Stage 2 rerank sidecar（[Rerank Storage](#rerank-storage)）。#932 以降、3 つのベクトルインデックスタイプすべてでサポート。`"F32"` でフィールド単位の f32 sidecar を有効化し、検索時に int8 候補を元のベクトルで再スコアできる。 |
 

--- a/docs/ja/src/laurus-nodejs/api_reference.md
+++ b/docs/ja/src/laurus-nodejs/api_reference.md
@@ -204,9 +204,9 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | 地理座標フィールド。 |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(name, stored?, indexed?)` | UTC 日時フィールド。 |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW ベクトルフィールド。 |
-| `addFlatField(name, dimension, distance?, embedder?)` | Flat（全探索）ベクトルフィールド。 |
-| `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF ベクトルフィールド。 |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?, baseWeight?)` | HNSW ベクトルフィールド。`baseWeight` は他の vector フィールドと同時に検索されたときの相対的なスコアリング優先度（Issue #1084）。[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照。 |
+| `addFlatField(name, dimension, distance?, embedder?, baseWeight?)` | Flat（全探索）ベクトルフィールド。 |
+| `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?, baseWeight?)` | IVF ベクトルフィールド。 |
 | `addEmbedder(name, config)` | 名前付き Embedder を登録。 |
 | `setDefaultFields(fields)` | デフォルト検索フィールドを設定。 |
 | `setDynamicFieldPolicy(policy)` | 未宣言フィールドの扱いを設定。`policy` は `"strict"` / `"dynamic"`（デフォルト）/ `"ignore"`。詳細は下記を参照。 |

--- a/docs/ja/src/laurus-php/api_reference.md
+++ b/docs/ja/src/laurus-php/api_reference.md
@@ -171,9 +171,9 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | 地理座標フィールド（緯度/経度）。 |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC 日時フィールド。 |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?int $defaultEfSearch = null, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW 近似最近傍ベクトルフィールド。 |
-| `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat（総当たり）ベクトルフィールド。 |
-| `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF 近似最近傍ベクトルフィールド。 |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?int $defaultEfSearch = null, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null, float $baseWeight = 1.0): void` | HNSW 近似最近傍ベクトルフィールド。`$baseWeight` は他の vector フィールドと同時に検索されたときの相対的なスコアリング優先度（Issue #1084）。[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照。 |
+| `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null, float $baseWeight = 1.0): void` | Flat（総当たり）ベクトルフィールド。 |
+| `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null, float $baseWeight = 1.0): void` | IVF 近似最近傍ベクトルフィールド。 |
 
 **ベクトル量子化とリランクストレージ**（HNSW フィールド）:
 

--- a/docs/ja/src/laurus-python/api_reference.md
+++ b/docs/ja/src/laurus-python/api_reference.md
@@ -200,9 +200,9 @@ class Schema:
 | `add_geo_field(name, *, stored=True, indexed=True)` | 地理座標フィールド（緯度/経度）。 |
 | `add_geo3d_field(name, *, stored=True, indexed=True)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `add_datetime_field(name, *, stored=True, indexed=True)` | UTC 日時フィールド。 |
-| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None)` | HNSW 近似最近傍ベクトルフィールド。 |
-| `add_flat_field(name, dimension, *, distance="cosine", embedder=None)` | Flat（総当たり）ベクトルフィールド。 |
-| `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None)` | IVF 近似最近傍ベクトルフィールド。 |
+| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None, base_weight=1.0)` | HNSW 近似最近傍ベクトルフィールド。`base_weight` は他の vector フィールドと同時に検索されたときの相対的なスコアリング優先度（Issue #1084）。[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照。 |
+| `add_flat_field(name, dimension, *, distance="cosine", embedder=None, base_weight=1.0)` | Flat（総当たり）ベクトルフィールド。 |
+| `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None, base_weight=1.0)` | IVF 近似最近傍ベクトルフィールド。 |
 
 **ベクトル量子化とリランクストレージ**（HNSW フィールド）:
 

--- a/docs/ja/src/laurus-ruby/api_reference.md
+++ b/docs/ja/src/laurus-ruby/api_reference.md
@@ -163,9 +163,9 @@ Laurus::Schema.new
 | `add_geo_field(name, stored: true, indexed: true)` | 地理座標フィールド（緯度/経度）。 |
 | `add_geo3d_field(name, stored: true, indexed: true)` | 3D ECEF カルテシアン座標フィールド（x, y, z はメートル）。詳細は [Geo3d の概念](../concepts/geo3d.md)。 |
 | `add_datetime_field(name, stored: true, indexed: true)` | UTC 日時フィールド。 |
-| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil, pq_codebook_path: nil)` | HNSW 近似最近傍ベクトルフィールド。 |
-| `add_flat_field(name, dimension, distance: "cosine", embedder: nil)` | Flat（総当たり）ベクトルフィールド。 |
-| `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil)` | IVF 近似最近傍ベクトルフィールド。 |
+| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil, pq_codebook_path: nil, base_weight: 1.0)` | HNSW 近似最近傍ベクトルフィールド。`base_weight` は他の vector フィールドと同時に検索されたときの相対的なスコアリング優先度（Issue #1084）。[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照。 |
+| `add_flat_field(name, dimension, distance: "cosine", embedder: nil, base_weight: 1.0)` | Flat（総当たり）ベクトルフィールド。 |
+| `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil, base_weight: 1.0)` | IVF 近似最近傍ベクトルフィールド。 |
 
 **ベクトル量子化とリランクストレージ**（HNSW フィールド）:
 

--- a/docs/ja/src/laurus-server/grpc_api.md
+++ b/docs/ja/src/laurus-server/grpc_api.md
@@ -121,6 +121,8 @@ message AnalyzerDefinition {
 
 **共有 PQ codebook:** `HnswOption` のオプションフィールド `pq_codebook_path`（Issue #631）は、`laurus train pq-codebook` CLI コマンドで一度だけ学習するストレージ相対の共有 PQ codebook ファイルを指定します。設定すると segment は commit / merge のたびに k-means を再学習する代わりに、学習済み codebook で encode されます。`PRODUCT_QUANTIZATION` quantizer との組み合わせでのみ意味を持ち、設定済みで未学習の場合、commit は学習コマンドを示すエラーで失敗します（per-segment 学習への無言のフォールバック無し）。未設定なら per-segment 学習のままです。
 
+**Base weight:** `HnswOption`/`FlatOption`/`IvfOption` の `base_weight` は `optional float`（Issue #1084）です。クライアントが省略するとエンジンのデフォルト（`1.0`）が使われ、これは明示的な `0.0` とは区別されます。他の vector フィールドと同時にクエリ対象になったときの、そのフィールドの相対的なスコアリング優先度を設定します。何に効いて何に効かないかは[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照してください。
+
 **QuantizationConfig 構造:**
 
 | フィールド | 型 | 説明 |

--- a/docs/ja/src/laurus-wasm/api_reference.md
+++ b/docs/ja/src/laurus-wasm/api_reference.md
@@ -406,7 +406,7 @@ WASM バインディングは `Geo3dDistanceQuery` / `Geo3dBoundingBoxQuery` /
 
 バイナリデータフィールドを追加します。
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?, baseWeight?)`
 
 HNSW ベクトルインデックスフィールドを追加します。
 
@@ -418,12 +418,13 @@ HNSW ベクトルインデックスフィールドを追加します。
 - `subvectorCount`: PQ サブベクトル数。`dimension` を割り切れる値を指定します
 - `rerankStorage`: 省略（デフォルト）するか、`"f32"` を指定して完全精度のリランクサイドカーを保存します
 - `pqCodebookPath`: 省略（デフォルト）するか、segment 間で再利用する共有 PQ codebook のストレージ相対ファイル名（Issue #631）を指定します（segment ごとの学習の代替）
+- `baseWeight`: 他の vector フィールドと同時に検索されたときの、このフィールドの相対的なスコアリング優先度（デフォルト `1.0`、Issue #1084）。[ウェイト](../concepts/search/vector_search.md#ウェイト)を参照してください
 
-#### `addFlatField(name, dimension, distance?, embedder?)`
+#### `addFlatField(name, dimension, distance?, embedder?, baseWeight?)`
 
 全探索ベクトルインデックスフィールドを追加します。
 
-#### `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)`
+#### `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?, baseWeight?)`
 
 IVF ベクトルインデックスフィールドを追加します。
 

--- a/docs/src/concepts/schema_and_fields.md
+++ b/docs/src/concepts/schema_and_fields.md
@@ -109,7 +109,7 @@ let opt = HnswOption {
     m: 16,                                           // max connections per layer
     ef_construction: 200,                            // construction search width
     default_ef_search: Some(100),                    // schema-level ef_search default (issue #644)
-    base_weight: 1.0,                                // default scoring weight
+    base_weight: 1.0,                                // relative priority vs. other vector fields (issue #1084)
     quantizer: QuantizationMethod::Scalar8Bit,       // mandatory; default Scalar8Bit
     embedder: None,                                  // optional named embedder
 };

--- a/docs/src/concepts/search/vector_search.md
+++ b/docs/src/concepts/search/vector_search.md
@@ -197,6 +197,18 @@ text_vec:"cute kitten"^1.0 image_vec:"fluffy cat"^0.5
 
 This means text similarity counts twice as much as image similarity.
 
+A vector field's schema-level `base_weight` (Issue #1084) works the same
+way but is a per-field default rather than a per-query override: it is
+multiplied into the query weight above, so `base_weight` and `^`/`weight`
+compose. Because both only affect the vector side's own scoring, neither
+can rebalance a hybrid search's lexical-vs-vector split —
+`FusionAlgorithm::RRF` is rank-only and ignores the underlying score
+entirely, and `FusionAlgorithm::WeightedSum` min-max normalizes each side
+before applying `lexical_weight`/`vector_weight`, which cancels out a
+uniform per-field scalar. What both weighting mechanisms DO affect is the
+relative priority *among* vector fields when a query targets two or more
+at once.
+
 ### Field Routing
 
 In a multi-field schema, each vector field has its own HNSW graph. By

--- a/docs/src/laurus-cli/schema_format.md
+++ b/docs/src/laurus-cli/schema_format.md
@@ -181,7 +181,7 @@ base_weight = 1.0
 | `distance` | `string` | `"Cosine"` | Distance metric (see [Distance Metrics](#distance-metrics)) |
 | `m` | `integer` | `16` | Max bi-directional connections per node. Higher = better recall, more memory |
 | `ef_construction` | `integer` | `200` | Search width during index construction. Higher = better quality, slower build |
-| `base_weight` | `float` | `1.0` | Scoring weight in hybrid search fusion |
+| `base_weight` | `float` | `1.0` | Relative priority vs. other vector fields searched together; no effect on lexical-vs-vector fusion balance (see [Vector Search → Weights](../concepts/search/vector_search.md#weights)) |
 | `quantizer` | `object` | `"Scalar8Bit"` | Quantization method (see [Quantization](#quantization)). Mandatory; default keeps the int8 format introduced in Issue #481 Stage 1. |
 | `rerank_storage` | `string` | *(omit)* | Optional Stage 2 rerank sidecar (see [Rerank Storage](#rerank-storage)). `"F32"` enables a per-field f32 sidecar so search can rescore int8 candidates against the original vectors. Omit to keep Stage 1 int8-only behavior. |
 | `pq_codebook_path` | `string` | *(omit)* | Storage-relative file name of a shared PQ codebook (Issue #631); only meaningful with a `ProductQuantization` quantizer. Train it with `laurus train pq-codebook`; commits then encode against it instead of re-training k-means per segment. When set but not yet trained, commits fail loudly (no silent fallback). Omit to train per segment. |
@@ -207,7 +207,7 @@ base_weight = 1.0
 | :--- | :--- | :--- | :--- |
 | `dimension` | `integer` | `128` | Vector dimensionality |
 | `distance` | `string` | `"Cosine"` | Distance metric (see [Distance Metrics](#distance-metrics)) |
-| `base_weight` | `float` | `1.0` | Scoring weight in hybrid search fusion |
+| `base_weight` | `float` | `1.0` | Relative priority vs. other vector fields searched together; no effect on lexical-vs-vector fusion balance (see [Vector Search → Weights](../concepts/search/vector_search.md#weights)) |
 | `quantizer` | `object` | `"Scalar8Bit"` | Quantization method (see [Quantization](#quantization)). Mandatory; default keeps the int8 format introduced in Issue #481 Stage 1. |
 | `rerank_storage` | `string` | *(omit)* | Optional Stage 2 rerank sidecar (see [Rerank Storage](#rerank-storage)); supported by all three vector index types since #932. `"F32"` enables the per-field f32 sidecar so search can rescore int8 candidates against the original vectors. |
 
@@ -230,7 +230,7 @@ base_weight = 1.0
 | `distance` | `string` | `"Cosine"` | Distance metric (see [Distance Metrics](#distance-metrics)) |
 | `n_clusters` | `integer` | `100` | Number of clusters. More clusters = finer partitioning |
 | `n_probe` | `integer` | `1` | Number of clusters to search at query time. Higher = better recall, slower |
-| `base_weight` | `float` | `1.0` | Scoring weight in hybrid search fusion |
+| `base_weight` | `float` | `1.0` | Relative priority vs. other vector fields searched together; no effect on lexical-vs-vector fusion balance (see [Vector Search → Weights](../concepts/search/vector_search.md#weights)) |
 | `quantizer` | `object` | `"Scalar8Bit"` | Quantization method (see [Quantization](#quantization)). Mandatory; default keeps the int8 format introduced in Issue #481 Stage 1. |
 | `rerank_storage` | `string` | *(omit)* | Optional Stage 2 rerank sidecar (see [Rerank Storage](#rerank-storage)); supported by all three vector index types since #932. `"F32"` enables the per-field f32 sidecar so search can rescore int8 candidates against the original vectors. |
 

--- a/docs/src/laurus-nodejs/api_reference.md
+++ b/docs/src/laurus-nodejs/api_reference.md
@@ -202,9 +202,9 @@ class Schema {
 | `addGeoField(name, stored?, indexed?)` | Geographic coordinate field. |
 | `addGeo3dField(name, stored?, indexed?)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(name, stored?, indexed?)` | UTC datetime field. |
-| `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)` | HNSW vector field. |
-| `addFlatField(name, dimension, distance?, embedder?)` | Flat (brute-force) vector field. |
-| `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)` | IVF vector field. |
+| `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?, baseWeight?)` | HNSW vector field. `baseWeight` sets this field's relative scoring priority when searched alongside other vector fields (Issue #1084); see [Vector Search → Weights](../concepts/search/vector_search.md#weights). |
+| `addFlatField(name, dimension, distance?, embedder?, baseWeight?)` | Flat (brute-force) vector field. |
+| `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?, baseWeight?)` | IVF vector field. |
 | `addEmbedder(name, config)` | Register a named embedder. |
 | `setDefaultFields(fields)` | Set default search fields. |
 | `setDynamicFieldPolicy(policy)` | Set how undeclared fields are handled. `policy` is `"strict"`, `"dynamic"` (default), or `"ignore"`. See notes below. |

--- a/docs/src/laurus-php/api_reference.md
+++ b/docs/src/laurus-php/api_reference.md
@@ -169,9 +169,9 @@ new \Laurus\Schema()
 | `addGeoField(string $name, bool $stored = true, bool $indexed = true): void` | Geographic coordinate field (lat/lon). |
 | `addGeo3dField(string $name, bool $stored = true, bool $indexed = true): void` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `addDatetimeField(string $name, bool $stored = true, bool $indexed = true): void` | UTC datetime field. |
-| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?int $defaultEfSearch = null, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null): void` | HNSW approximate nearest-neighbor vector field. |
-| `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null): void` | Flat (brute-force) vector field. |
-| `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null): void` | IVF approximate nearest-neighbor vector field. |
+| `addHnswField(string $name, int $dimension, ?string $distance = "cosine", int $m = 16, int $efConstruction = 200, ?int $defaultEfSearch = null, ?string $embedder = null, ?string $quantizer = null, ?int $subvectorCount = null, ?string $rerankStorage = null, ?string $pqCodebookPath = null, float $baseWeight = 1.0): void` | HNSW approximate nearest-neighbor vector field. `$baseWeight` sets this field's relative scoring priority when searched alongside other vector fields (Issue #1084); see [Vector Search → Weights](../concepts/search/vector_search.md#weights). |
+| `addFlatField(string $name, int $dimension, ?string $distance = "cosine", ?string $embedder = null, float $baseWeight = 1.0): void` | Flat (brute-force) vector field. |
+| `addIvfField(string $name, int $dimension, ?string $distance = "cosine", int $nClusters = 100, int $nProbe = 1, ?string $embedder = null, float $baseWeight = 1.0): void` | IVF approximate nearest-neighbor vector field. |
 
 **Vector quantization & rerank storage** (HNSW fields):
 

--- a/docs/src/laurus-python/api_reference.md
+++ b/docs/src/laurus-python/api_reference.md
@@ -197,9 +197,9 @@ class Schema:
 | `add_geo_field(name, *, stored=True, indexed=True)` | Geographic coordinate field (lat/lon). |
 | `add_geo3d_field(name, *, stored=True, indexed=True)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `add_datetime_field(name, *, stored=True, indexed=True)` | UTC datetime field. |
-| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None)` | HNSW approximate nearest-neighbor vector field. |
-| `add_flat_field(name, dimension, *, distance="cosine", embedder=None)` | Flat (brute-force) vector field. |
-| `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None)` | IVF approximate nearest-neighbor vector field. |
+| `add_hnsw_field(name, dimension, *, distance="cosine", m=16, ef_construction=200, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None, base_weight=1.0)` | HNSW approximate nearest-neighbor vector field. `base_weight` sets this field's relative scoring priority when searched alongside other vector fields (Issue #1084); see [Vector Search → Weights](../concepts/search/vector_search.md#weights). |
+| `add_flat_field(name, dimension, *, distance="cosine", embedder=None, base_weight=1.0)` | Flat (brute-force) vector field. |
+| `add_ivf_field(name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None, base_weight=1.0)` | IVF approximate nearest-neighbor vector field. |
 
 **Vector quantization & rerank storage** (HNSW fields):
 

--- a/docs/src/laurus-ruby/api_reference.md
+++ b/docs/src/laurus-ruby/api_reference.md
@@ -161,9 +161,9 @@ Laurus::Schema.new
 | `add_geo_field(name, stored: true, indexed: true)` | Geographic coordinate field (lat/lon). |
 | `add_geo3d_field(name, stored: true, indexed: true)` | 3D ECEF Cartesian point field (x, y, z in metres). See [Geo3d concepts](../concepts/geo3d.md). |
 | `add_datetime_field(name, stored: true, indexed: true)` | UTC datetime field. |
-| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil, pq_codebook_path: nil)` | HNSW approximate nearest-neighbor vector field. |
-| `add_flat_field(name, dimension, distance: "cosine", embedder: nil)` | Flat (brute-force) vector field. |
-| `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil)` | IVF approximate nearest-neighbor vector field. |
+| `add_hnsw_field(name, dimension, distance: "cosine", m: 16, ef_construction: 200, quantizer: nil, subvector_count: nil, rerank_storage: nil, embedder: nil, pq_codebook_path: nil, base_weight: 1.0)` | HNSW approximate nearest-neighbor vector field. `base_weight` sets this field's relative scoring priority when searched alongside other vector fields (Issue #1084); see [Vector Search → Weights](../concepts/search/vector_search.md#weights). |
+| `add_flat_field(name, dimension, distance: "cosine", embedder: nil, base_weight: 1.0)` | Flat (brute-force) vector field. |
+| `add_ivf_field(name, dimension, distance: "cosine", n_clusters: 100, n_probe: 1, embedder: nil, base_weight: 1.0)` | IVF approximate nearest-neighbor vector field. |
 
 **Vector quantization & rerank storage** (HNSW fields):
 

--- a/docs/src/laurus-server/grpc_api.md
+++ b/docs/src/laurus-server/grpc_api.md
@@ -121,6 +121,8 @@ The `embedder` field in vector options specifies the name of an embedder defined
 
 **Shared PQ codebook:** the optional `pq_codebook_path` field on `HnswOption` (Issue #631) names a storage-relative shared PQ codebook file, trained once via the `laurus train pq-codebook` CLI command. Segments are then encoded against the pre-trained codebook instead of re-training k-means on every commit and merge. Only meaningful with a `PRODUCT_QUANTIZATION` quantizer; when set but not yet trained, commits fail with an error naming the training command (no silent fallback to per-segment training). Unset keeps per-segment training.
 
+**Base weight:** `base_weight` on `HnswOption`/`FlatOption`/`IvfOption` is `optional float` (Issue #1084): a client that omits it gets the engine's default (`1.0`), distinguishable from an explicit `0.0`. It sets the field's relative scoring priority when a query targets it alongside other vector fields — see [Vector Search → Weights](../concepts/search/vector_search.md#weights) for what it does and does not affect.
+
 **QuantizationConfig structure:**
 
 | Field | Type | Description |

--- a/docs/src/laurus-wasm/api_reference.md
+++ b/docs/src/laurus-wasm/api_reference.md
@@ -406,7 +406,7 @@ above.
 
 Add a binary data field.
 
-#### `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?)`
+#### `addHnswField(name, dimension, distance?, m?, efConstruction?, defaultEfSearch?, embedder?, quantizer?, subvectorCount?, rerankStorage?, pqCodebookPath?, baseWeight?)`
 
 Add an HNSW vector index field.
 
@@ -424,12 +424,15 @@ Add an HNSW vector index field.
 - `pqCodebookPath`: omit (default) or the storage-relative file name of
   a shared PQ codebook (Issue #631) to reuse across segments instead of
   per-segment training
+- `baseWeight`: this field's relative scoring priority when searched
+  alongside other vector fields (default `1.0`, Issue #1084); see
+  [Vector Search → Weights](../concepts/search/vector_search.md#weights)
 
-#### `addFlatField(name, dimension, distance?, embedder?)`
+#### `addFlatField(name, dimension, distance?, embedder?, baseWeight?)`
 
 Add a brute-force vector index field.
 
-#### `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?)`
+#### `addIvfField(name, dimension, distance?, nClusters?, nProbe?, embedder?, baseWeight?)`
 
 Add an IVF vector index field.
 

--- a/laurus-cli/src/commands/create.rs
+++ b/laurus-cli/src/commands/create.rs
@@ -473,6 +473,19 @@ fn prompt_usize(prompt: &str, default: usize) -> Result<usize> {
     Ok(val)
 }
 
+/// Prompt for a vector field's `base_weight` (Issue #1084): this field's
+/// relative scoring priority when searched alongside other vector fields.
+/// Defaults to `1.0`. Only matters when a query targets two or more
+/// specific vector fields at once; has no effect on the lexical-vs-vector
+/// balance of a hybrid search.
+fn prompt_base_weight() -> Result<f32> {
+    let val: f64 = Input::new()
+        .with_prompt("Base weight (relative priority vs. other vector fields in this schema)")
+        .default(1.0)
+        .interact_text()?;
+    Ok(val as f32)
+}
+
 /// Prompt for HnswOption.
 fn prompt_hnsw_option() -> Result<FieldOption> {
     let dimension = prompt_usize("Dimension", 128)?;
@@ -482,6 +495,7 @@ fn prompt_hnsw_option() -> Result<FieldOption> {
     let quantizer = prompt_quantization_method(dimension)?;
     let pq_codebook_path = prompt_pq_codebook_path(&quantizer)?;
     let rerank_storage = prompt_rerank_storage()?;
+    let base_weight = prompt_base_weight()?;
 
     Ok(FieldOption::Hnsw(HnswOption {
         dimension,
@@ -489,7 +503,7 @@ fn prompt_hnsw_option() -> Result<FieldOption> {
         m,
         ef_construction,
         default_ef_search: None,
-        base_weight: 1.0,
+        base_weight,
         quantizer,
         rerank_storage,
         embedder: None,
@@ -589,11 +603,12 @@ fn prompt_rerank_storage() -> Result<Option<RerankStorageKind>> {
 fn prompt_flat_option() -> Result<FieldOption> {
     let dimension = prompt_usize("Dimension", 128)?;
     let distance = prompt_distance_metric()?;
+    let base_weight = prompt_base_weight()?;
 
     Ok(FieldOption::Flat(FlatOption {
         dimension,
         distance,
-        base_weight: 1.0,
+        base_weight,
         quantizer: Default::default(),
         rerank_storage: None,
         embedder: None,
@@ -606,13 +621,14 @@ fn prompt_ivf_option() -> Result<FieldOption> {
     let distance = prompt_distance_metric()?;
     let n_clusters = prompt_usize("Number of clusters", 100)?;
     let n_probe = prompt_usize("Number of probes", 1)?;
+    let base_weight = prompt_base_weight()?;
 
     Ok(FieldOption::Ivf(IvfOption {
         dimension,
         distance,
         n_clusters,
         n_probe,
-        base_weight: 1.0,
+        base_weight,
         quantizer: Default::default(),
         rerank_storage: None,
         embedder: None,

--- a/laurus-nodejs/src/schema.rs
+++ b/laurus-nodejs/src/schema.rs
@@ -328,6 +328,11 @@ impl JsSchema {
     ///   `quantizer` is "product_quantization"; commits then encode against
     ///   the pre-trained codebook instead of re-training k-means per
     ///   segment. Omitted (default) keeps per-segment training.
+    /// * `baseWeight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. Only matters when a query targets two or more specific
+    ///   vector fields at once; has no effect on the lexical-vs-vector
+    ///   balance of a hybrid search.
     #[napi]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -343,6 +348,7 @@ impl JsSchema {
         subvector_count: Option<u32>,
         rerank_storage: Option<String>,
         pq_codebook_path: Option<String>,
+        base_weight: Option<f64>,
     ) -> Result<()> {
         let opt = HnswOption {
             dimension: dimension as usize,
@@ -354,7 +360,7 @@ impl JsSchema {
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             pq_codebook_path,
-            ..Default::default()
+            base_weight: base_weight.unwrap_or(1.0) as f32,
         };
         self.inner.fields.insert(name, FieldOption::Hnsw(opt));
         Ok(())
@@ -368,6 +374,9 @@ impl JsSchema {
     /// * `dimension` - Vector dimensionality.
     /// * `distance` - Distance metric — "cosine" (default), "euclidean", "dot_product".
     /// * `embedder` - Optional embedder name registered via `addEmbedder`.
+    /// * `baseWeight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. See `addHnswField` for the full contract.
     #[napi]
     pub fn add_flat_field(
         &mut self,
@@ -375,11 +384,13 @@ impl JsSchema {
         dimension: u32,
         distance: Option<String>,
         embedder: Option<String>,
+        base_weight: Option<f64>,
     ) -> Result<()> {
         let opt = FlatOption {
             dimension: dimension as usize,
             distance: parse_distance(distance.as_deref().unwrap_or("cosine"))?,
             embedder,
+            base_weight: base_weight.unwrap_or(1.0) as f32,
             ..Default::default()
         };
         self.inner.fields.insert(name, FieldOption::Flat(opt));
@@ -396,7 +407,11 @@ impl JsSchema {
     /// * `n_clusters` - Number of Voronoi clusters (default 100).
     /// * `n_probe` - Number of clusters to probe at search time (default 1).
     /// * `embedder` - Optional embedder name registered via `addEmbedder`.
+    /// * `baseWeight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. See `addHnswField` for the full contract.
     #[napi]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_ivf_field(
         &mut self,
         name: String,
@@ -405,6 +420,7 @@ impl JsSchema {
         n_clusters: Option<u32>,
         n_probe: Option<u32>,
         embedder: Option<String>,
+        base_weight: Option<f64>,
     ) -> Result<()> {
         let opt = IvfOption {
             dimension: dimension as usize,
@@ -412,6 +428,7 @@ impl JsSchema {
             n_clusters: n_clusters.unwrap_or(100) as usize,
             n_probe: n_probe.unwrap_or(1) as usize,
             embedder,
+            base_weight: base_weight.unwrap_or(1.0) as f32,
             ..Default::default()
         };
         self.inner.fields.insert(name, FieldOption::Ivf(opt));

--- a/laurus-php/src/schema.rs
+++ b/laurus-php/src/schema.rs
@@ -294,7 +294,12 @@ impl PhpSchema {
     ///   `quantizer` is "product_quantization"; commits then encode against
     ///   the pre-trained codebook instead of re-training k-means per
     ///   segment. Omitted (default) keeps per-segment training.
-    #[php(defaults(m = 16, ef_construction = 200))]
+    /// * `base_weight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. Only matters when a query targets two or more specific
+    ///   vector fields at once; has no effect on the lexical-vs-vector
+    ///   balance of a hybrid search.
+    #[php(defaults(m = 16, ef_construction = 200, base_weight = 1.0))]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &self,
@@ -309,6 +314,7 @@ impl PhpSchema {
         subvector_count: Option<i64>,
         rerank_storage: Option<String>,
         pq_codebook_path: Option<String>,
+        base_weight: f64,
     ) -> PhpResult<()> {
         let dist_str = distance.unwrap_or_else(|| "cosine".to_string());
         let opt = HnswOption {
@@ -321,7 +327,7 @@ impl PhpSchema {
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             pq_codebook_path,
-            ..Default::default()
+            base_weight: base_weight as f32,
         };
         self.inner
             .borrow_mut()
@@ -338,18 +344,24 @@ impl PhpSchema {
     /// * `dimension` - Vector dimensionality.
     /// * `distance` - Distance metric (default: "cosine").
     /// * `embedder` - Embedder name registered via `addEmbedder` (default: "" for none).
+    /// * `base_weight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. See `add_hnsw_field` for the full contract.
+    #[php(defaults(base_weight = 1.0))]
     pub fn add_flat_field(
         &self,
         name: String,
         dimension: i64,
         distance: Option<String>,
         embedder: Option<String>,
+        base_weight: f64,
     ) -> PhpResult<()> {
         let dist_str = distance.unwrap_or_else(|| "cosine".to_string());
         let opt = laurus::FlatOption {
             dimension: dimension as usize,
             distance: parse_distance(&dist_str)?,
             embedder,
+            base_weight: base_weight as f32,
             ..Default::default()
         };
         self.inner
@@ -369,7 +381,11 @@ impl PhpSchema {
     /// * `n_clusters` - Number of Voronoi clusters (default: 100).
     /// * `n_probe` - Number of clusters to probe at search time (default: 1).
     /// * `embedder` - Embedder name registered via `addEmbedder` (default: "" for none).
-    #[php(defaults(n_clusters = 100, n_probe = 1))]
+    /// * `base_weight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. See `add_hnsw_field` for the full contract.
+    #[php(defaults(n_clusters = 100, n_probe = 1, base_weight = 1.0))]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_ivf_field(
         &self,
         name: String,
@@ -378,6 +394,7 @@ impl PhpSchema {
         n_clusters: i64,
         n_probe: i64,
         embedder: Option<String>,
+        base_weight: f64,
     ) -> PhpResult<()> {
         let dist_str = distance.unwrap_or_else(|| "cosine".to_string());
         let opt = IvfOption {
@@ -386,6 +403,7 @@ impl PhpSchema {
             n_clusters: n_clusters as usize,
             n_probe: n_probe as usize,
             embedder,
+            base_weight: base_weight as f32,
             ..Default::default()
         };
         self.inner

--- a/laurus-python/src/schema.rs
+++ b/laurus-python/src/schema.rs
@@ -378,7 +378,12 @@ impl PySchema {
     ///         `quantizer="product_quantization"`; commits then encode
     ///         against the pre-trained codebook instead of re-training
     ///         k-means per segment. None (default) keeps per-segment training.
-    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, default_ef_search=None, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None))]
+    ///     base_weight: This field's relative scoring priority when
+    ///         searched alongside other vector fields (Issue #1084).
+    ///         Defaults to 1.0. Only matters when a query targets two or
+    ///         more specific vector fields at once; has no effect on the
+    ///         lexical-vs-vector balance of a hybrid search.
+    #[pyo3(signature = (name, dimension, *, distance="cosine", m=16, ef_construction=200, default_ef_search=None, quantizer=None, subvector_count=None, rerank_storage=None, embedder=None, pq_codebook_path=None, base_weight=1.0))]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
         &mut self,
@@ -393,6 +398,7 @@ impl PySchema {
         rerank_storage: Option<String>,
         embedder: Option<String>,
         pq_codebook_path: Option<String>,
+        base_weight: f32,
     ) -> PyResult<()> {
         let opt = HnswOption {
             dimension,
@@ -404,7 +410,7 @@ impl PySchema {
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             pq_codebook_path,
-            ..Default::default()
+            base_weight,
         };
         self.inner
             .fields
@@ -420,18 +426,23 @@ impl PySchema {
     ///     distance: Distance metric — "cosine" (default), "euclidean", "dot_product".
     ///     embedder: Optional embedder name registered via `add_embedder`.
     ///         When set, text payloads are automatically embedded by the Rust engine.
-    #[pyo3(signature = (name, dimension, *, distance="cosine", embedder=None))]
+    ///     base_weight: This field's relative scoring priority when
+    ///         searched alongside other vector fields (Issue #1084).
+    ///         Defaults to 1.0. See `add_hnsw_field` for the full contract.
+    #[pyo3(signature = (name, dimension, *, distance="cosine", embedder=None, base_weight=1.0))]
     pub fn add_flat_field(
         &mut self,
         name: &str,
         dimension: usize,
         distance: &str,
         embedder: Option<String>,
+        base_weight: f32,
     ) -> PyResult<()> {
         let opt = FlatOption {
             dimension,
             distance: parse_distance(distance)?,
             embedder,
+            base_weight,
             ..Default::default()
         };
         self.inner
@@ -450,7 +461,11 @@ impl PySchema {
     ///     n_probe: Number of clusters to probe at search time (default 1).
     ///     embedder: Optional embedder name registered via `add_embedder`.
     ///         When set, text payloads are automatically embedded by the Rust engine.
-    #[pyo3(signature = (name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None))]
+    ///     base_weight: This field's relative scoring priority when
+    ///         searched alongside other vector fields (Issue #1084).
+    ///         Defaults to 1.0. See `add_hnsw_field` for the full contract.
+    #[pyo3(signature = (name, dimension, *, distance="cosine", n_clusters=100, n_probe=1, embedder=None, base_weight=1.0))]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_ivf_field(
         &mut self,
         name: &str,
@@ -459,6 +474,7 @@ impl PySchema {
         n_clusters: usize,
         n_probe: usize,
         embedder: Option<String>,
+        base_weight: f32,
     ) -> PyResult<()> {
         let opt = IvfOption {
             dimension,
@@ -466,6 +482,7 @@ impl PySchema {
             n_clusters,
             n_probe,
             embedder,
+            base_weight,
             ..Default::default()
         };
         self.inner

--- a/laurus-python/tests/test_vector_base_weight.py
+++ b/laurus-python/tests/test_vector_base_weight.py
@@ -1,0 +1,78 @@
+"""Tests for the `base_weight` vector field option (Issue #1084).
+
+Confirms `base_weight` reaches the Rust core and actually affects search
+scores, using a deterministic observable rather than only that search
+succeeds: two HNSW fields holding the SAME query-matching vector, with
+different `base_weight`, must produce scores whose ratio tracks the
+`base_weight` ratio.
+"""
+
+import laurus
+
+
+def test_base_weight_defaults_to_one():
+    schema = laurus.Schema()
+    schema.add_hnsw_field("embedding", dimension=4)
+    idx = laurus.Index(schema=schema)
+    idx.put_document("doc1", {"embedding": [1.0, 0.0, 0.0, 0.0]})
+    idx.commit()
+
+    results = idx.search(laurus.VectorQuery("embedding", [1.0, 0.0, 0.0, 0.0]), limit=1)
+    assert len(results) == 1
+
+    schema2 = laurus.Schema()
+    schema2.add_hnsw_field("embedding", dimension=4, base_weight=1.0)
+    idx2 = laurus.Index(schema=schema2)
+    idx2.put_document("doc1", {"embedding": [1.0, 0.0, 0.0, 0.0]})
+    idx2.commit()
+
+    results2 = idx2.search(laurus.VectorQuery("embedding", [1.0, 0.0, 0.0, 0.0]), limit=1)
+    assert abs(results[0].score - results2[0].score) < 1e-6, (
+        "an unset base_weight must score identically to an explicit 1.0"
+    )
+
+
+def test_base_weight_affects_vector_score():
+    same_vector = [1.0, 0.0, 0.0, 0.0]
+
+    schema_a = laurus.Schema()
+    schema_a.add_hnsw_field("vec_a", dimension=4, base_weight=1.0)
+    idx_a = laurus.Index(schema=schema_a)
+    idx_a.put_document("doc1", {"vec_a": same_vector})
+    idx_a.commit()
+    score_a = idx_a.search(laurus.VectorQuery("vec_a", same_vector), limit=1)[0].score
+
+    schema_b = laurus.Schema()
+    schema_b.add_hnsw_field("vec_b", dimension=4, base_weight=3.0)
+    idx_b = laurus.Index(schema=schema_b)
+    idx_b.put_document("doc1", {"vec_b": same_vector})
+    idx_b.commit()
+    score_b = idx_b.search(laurus.VectorQuery("vec_b", same_vector), limit=1)[0].score
+
+    assert score_b > score_a, (
+        f"base_weight=3.0 must score higher than base_weight=1.0: a={score_a}, b={score_b}"
+    )
+    ratio = score_b / score_a
+    assert abs(ratio - 3.0) < 0.05, f"score ratio must track base_weight ratio (~3.0), got {ratio}"
+
+
+def test_non_positive_base_weight_falls_back_to_one():
+    same_vector = [1.0, 0.0, 0.0, 0.0]
+
+    schema_zero = laurus.Schema()
+    schema_zero.add_hnsw_field("embedding", dimension=4, base_weight=0.0)
+    idx_zero = laurus.Index(schema=schema_zero)
+    idx_zero.put_document("doc1", {"embedding": same_vector})
+    idx_zero.commit()
+    score_zero = idx_zero.search(laurus.VectorQuery("embedding", same_vector), limit=1)[0].score
+
+    schema_one = laurus.Schema()
+    schema_one.add_hnsw_field("embedding", dimension=4, base_weight=1.0)
+    idx_one = laurus.Index(schema=schema_one)
+    idx_one.put_document("doc1", {"embedding": same_vector})
+    idx_one.commit()
+    score_one = idx_one.search(laurus.VectorQuery("embedding", same_vector), limit=1)[0].score
+
+    assert abs(score_zero - score_one) < 1e-6, (
+        "base_weight=0.0 must clamp to 1.0 rather than zeroing the score"
+    )

--- a/laurus-ruby/src/schema.rs
+++ b/laurus-ruby/src/schema.rs
@@ -10,7 +10,7 @@ use laurus::{
 };
 use magnus::prelude::*;
 use magnus::scan_args::{get_kwargs, scan_args};
-use magnus::{Error, RArray, RHash, RModule, Ruby, Value};
+use magnus::{Error, RArray, RHash, RModule, Ruby, TryConvert, Value};
 
 /// Parse a distance metric string into [`DistanceMetric`].
 fn parse_distance(s: &str) -> Result<DistanceMetric, Error> {
@@ -29,6 +29,24 @@ fn parse_distance(s: &str) -> Result<DistanceMetric, Error> {
             ),
         )),
     }
+}
+
+/// Extract `base_weight:` from a splat `RHash` of otherwise-unrecognized
+/// keyword arguments, defaulting to `1.0` when absent.
+///
+/// `base_weight` is pulled out via the `get_kwargs` `Splat` slot (an
+/// `RHash` of everything not already named in `optional`) rather than
+/// being added directly to the `Opt` tuple, because `magnus::scan_args`'s
+/// `ScanArgsOpt` is only implemented for tuples up to 9 elements
+/// (Issue #1084) and the HNSW field builder's existing option list
+/// already uses all 9.
+fn base_weight_from_splat(splat: RHash) -> Result<f32, Error> {
+    let ruby = Ruby::get().expect("called from Ruby thread");
+    let value: Option<f64> = splat
+        .get(ruby.to_symbol("base_weight"))
+        .map(TryConvert::try_convert)
+        .transpose()?;
+    Ok(value.unwrap_or(1.0) as f32)
 }
 
 /// Parse a quantizer name plus optional `subvector_count` into a
@@ -380,6 +398,11 @@ impl RbSchema {
     ///     `quantizer:` "product_quantization"; commits then encode against
     ///     the pre-trained codebook instead of re-training k-means per
     ///     segment. Omitted (default) keeps per-segment training.
+    ///   - `base_weight:` (Float, default 1.0): This field's relative
+    ///     scoring priority when searched alongside other vector fields
+    ///     (Issue #1084). Only matters when a query targets two or more
+    ///     specific vector fields at once; has no effect on the
+    ///     lexical-vs-vector balance of a hybrid search.
     fn add_hnsw_field(&self, args: &[Value]) -> Result<(), Error> {
         let args = scan_args::<(String, usize), (), (), (), RHash, ()>(args)?;
         let (name, dimension) = args.required;
@@ -397,7 +420,7 @@ impl RbSchema {
                 Option<String>,
                 Option<String>,
             ),
-            (),
+            RHash,
         >(
             args.keywords,
             &[],
@@ -435,7 +458,7 @@ impl RbSchema {
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder: embedder.flatten(),
             pq_codebook_path,
-            ..Default::default()
+            base_weight: base_weight_from_splat(kwargs.splat)?,
         };
         self.inner
             .borrow_mut()
@@ -453,20 +476,24 @@ impl RbSchema {
     ///   - `dimension` (usize): Vector dimensionality.
     ///   - `distance:` (String, default "cosine"): Distance metric.
     ///   - `embedder:` (String, optional): Embedder name registered via `add_embedder`.
+    ///   - `base_weight:` (Float, default 1.0): This field's relative
+    ///     scoring priority when searched alongside other vector fields
+    ///     (Issue #1084). See `add_hnsw_field` for the full contract.
     fn add_flat_field(&self, args: &[Value]) -> Result<(), Error> {
         let args = scan_args::<(String, usize), (), (), (), RHash, ()>(args)?;
         let (name, dimension) = args.required;
-        let kwargs = get_kwargs::<_, (), (Option<String>, Option<Option<String>>), ()>(
+        let kwargs = get_kwargs::<_, (), (Option<String>, Option<Option<String>>, Option<f64>), ()>(
             args.keywords,
             &[],
-            &["distance", "embedder"],
+            &["distance", "embedder", "base_weight"],
         )?;
-        let (distance, embedder) = kwargs.optional;
+        let (distance, embedder, base_weight) = kwargs.optional;
         let distance_str = distance.as_deref().unwrap_or("cosine");
         let opt = laurus::FlatOption {
             dimension,
             distance: parse_distance(distance_str)?,
             embedder: embedder.flatten(),
+            base_weight: base_weight.unwrap_or(1.0) as f32,
             ..Default::default()
         };
         self.inner
@@ -487,6 +514,9 @@ impl RbSchema {
     ///   - `n_clusters:` (usize, default 100): Number of Voronoi clusters.
     ///   - `n_probe:` (usize, default 1): Number of clusters to probe at search time.
     ///   - `embedder:` (String, optional): Embedder name registered via `add_embedder`.
+    ///   - `base_weight:` (Float, default 1.0): This field's relative
+    ///     scoring priority when searched alongside other vector fields
+    ///     (Issue #1084). See `add_hnsw_field` for the full contract.
     fn add_ivf_field(&self, args: &[Value]) -> Result<(), Error> {
         let args = scan_args::<(String, usize), (), (), (), RHash, ()>(args)?;
         let (name, dimension) = args.required;
@@ -498,14 +528,21 @@ impl RbSchema {
                 Option<usize>,
                 Option<usize>,
                 Option<Option<String>>,
+                Option<f64>,
             ),
             (),
         >(
             args.keywords,
             &[],
-            &["distance", "n_clusters", "n_probe", "embedder"],
+            &[
+                "distance",
+                "n_clusters",
+                "n_probe",
+                "embedder",
+                "base_weight",
+            ],
         )?;
-        let (distance, n_clusters, n_probe, embedder) = kwargs.optional;
+        let (distance, n_clusters, n_probe, embedder, base_weight) = kwargs.optional;
         let distance_str = distance.as_deref().unwrap_or("cosine");
         let opt = IvfOption {
             dimension,
@@ -513,6 +550,7 @@ impl RbSchema {
             n_clusters: n_clusters.unwrap_or(100),
             n_probe: n_probe.unwrap_or(1),
             embedder: embedder.flatten(),
+            base_weight: base_weight.unwrap_or(1.0) as f32,
             ..Default::default()
         };
         self.inner

--- a/laurus-ruby/test/test_vector_base_weight.rb
+++ b/laurus-ruby/test/test_vector_base_weight.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# Tests for the +base_weight+ vector field option (Issue #1084).
+#
+# Confirms +base_weight+ reaches the Rust core and actually affects search
+# scores, using a deterministic observable rather than only that search
+# succeeds: two HNSW fields holding the SAME query-matching vector, with
+# different +base_weight+, must produce scores whose ratio tracks the
+# +base_weight+ ratio.
+class TestVectorBaseWeight < Minitest::Test
+  SAME_VECTOR = [1.0, 0.0, 0.0, 0.0].freeze
+
+  def test_base_weight_defaults_to_one
+    schema = Laurus::Schema.new
+    schema.add_hnsw_field("embedding", 4)
+    idx = Laurus::Index.new(schema: schema)
+    idx.put_document("doc1", { "embedding" => SAME_VECTOR })
+    idx.commit
+    score = idx.search(Laurus::VectorQuery.new("embedding", SAME_VECTOR), limit: 1).first.score
+
+    schema2 = Laurus::Schema.new
+    schema2.add_hnsw_field("embedding", 4, base_weight: 1.0)
+    idx2 = Laurus::Index.new(schema: schema2)
+    idx2.put_document("doc1", { "embedding" => SAME_VECTOR })
+    idx2.commit
+    score2 = idx2.search(Laurus::VectorQuery.new("embedding", SAME_VECTOR), limit: 1).first.score
+
+    assert_in_delta score, score2, 1e-6,
+                     "an unset base_weight must score identically to an explicit 1.0"
+  end
+
+  def test_base_weight_affects_vector_score
+    schema_a = Laurus::Schema.new
+    schema_a.add_hnsw_field("vec_a", 4, base_weight: 1.0)
+    idx_a = Laurus::Index.new(schema: schema_a)
+    idx_a.put_document("doc1", { "vec_a" => SAME_VECTOR })
+    idx_a.commit
+    score_a = idx_a.search(Laurus::VectorQuery.new("vec_a", SAME_VECTOR), limit: 1).first.score
+
+    schema_b = Laurus::Schema.new
+    schema_b.add_hnsw_field("vec_b", 4, base_weight: 3.0)
+    idx_b = Laurus::Index.new(schema: schema_b)
+    idx_b.put_document("doc1", { "vec_b" => SAME_VECTOR })
+    idx_b.commit
+    score_b = idx_b.search(Laurus::VectorQuery.new("vec_b", SAME_VECTOR), limit: 1).first.score
+
+    assert score_b > score_a,
+           "base_weight=3.0 must score higher than base_weight=1.0: a=#{score_a}, b=#{score_b}"
+    ratio = score_b / score_a
+    assert_in_delta 3.0, ratio, 0.05,
+                     "score ratio must track base_weight ratio (~3.0), got #{ratio}"
+  end
+
+  def test_non_positive_base_weight_falls_back_to_one
+    schema_zero = Laurus::Schema.new
+    schema_zero.add_hnsw_field("embedding", 4, base_weight: 0.0)
+    idx_zero = Laurus::Index.new(schema: schema_zero)
+    idx_zero.put_document("doc1", { "embedding" => SAME_VECTOR })
+    idx_zero.commit
+    score_zero = idx_zero.search(Laurus::VectorQuery.new("embedding", SAME_VECTOR), limit: 1).first.score
+
+    schema_one = Laurus::Schema.new
+    schema_one.add_hnsw_field("embedding", 4, base_weight: 1.0)
+    idx_one = Laurus::Index.new(schema: schema_one)
+    idx_one.put_document("doc1", { "embedding" => SAME_VECTOR })
+    idx_one.commit
+    score_one = idx_one.search(Laurus::VectorQuery.new("embedding", SAME_VECTOR), limit: 1).first.score
+
+    assert_in_delta score_zero, score_one, 1e-6,
+                     "base_weight=0.0 must clamp to 1.0 rather than zeroing the score"
+  end
+end

--- a/laurus-server/proto/laurus/v1/index.proto
+++ b/laurus-server/proto/laurus/v1/index.proto
@@ -238,7 +238,13 @@ message HnswOption {
   DistanceMetric distance = 2;
   uint32 m = 3;
   uint32 ef_construction = 4;
-  float base_weight = 5;
+  // Relative priority of this field's similarity scores when multiple
+  // vector fields are searched together (issue #1084). Unset means "use
+  // the engine's default" (currently `1.0`) rather than an explicit
+  // `0.0` — a plain `float` cannot distinguish the two, which silently
+  // zeroed out every vector score for gRPC/REST-created fields that
+  // omitted it.
+  optional float base_weight = 5;
   optional QuantizationConfig quantizer = 6;
   // Embedder name (empty = no auto-embedding).
   string embedder = 7;
@@ -264,7 +270,8 @@ message HnswOption {
 message FlatOption {
   uint32 dimension = 1;
   DistanceMetric distance = 2;
-  float base_weight = 3;
+  // See `HnswOption.base_weight`.
+  optional float base_weight = 3;
   optional QuantizationConfig quantizer = 4;
   // Embedder name (empty = no auto-embedding).
   string embedder = 5;
@@ -279,7 +286,8 @@ message IvfOption {
   DistanceMetric distance = 2;
   uint32 n_clusters = 3;
   uint32 n_probe = 4;
-  float base_weight = 5;
+  // See `HnswOption.base_weight`.
+  optional float base_weight = 5;
   optional QuantizationConfig quantizer = 6;
   // Embedder name (empty = no auto-embedding).
   string embedder = 7;

--- a/laurus-server/src/convert/schema.rs
+++ b/laurus-server/src/convert/schema.rs
@@ -160,7 +160,7 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             distance: distance_to_proto(&o.distance) as i32,
             m: o.m as u32,
             ef_construction: o.ef_construction as u32,
-            base_weight: o.base_weight,
+            base_weight: Some(o.base_weight),
             quantizer: Some(quantization_to_proto(&o.quantizer)),
             embedder: o.embedder.clone().unwrap_or_default(),
             default_ef_search: o.default_ef_search.map(|v| v as u32),
@@ -170,7 +170,7 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
         FieldOption::Flat(o) => Some(Opt::Flat(v1::FlatOption {
             dimension: o.dimension as u32,
             distance: distance_to_proto(&o.distance) as i32,
-            base_weight: o.base_weight,
+            base_weight: Some(o.base_weight),
             quantizer: Some(quantization_to_proto(&o.quantizer)),
             embedder: o.embedder.clone().unwrap_or_default(),
             rerank_storage: o.rerank_storage.map(|k| rerank_storage_to_proto(k) as i32),
@@ -180,7 +180,7 @@ pub fn field_option_to_proto(fo: &FieldOption) -> v1::FieldOption {
             distance: distance_to_proto(&o.distance) as i32,
             n_clusters: o.n_clusters as u32,
             n_probe: o.n_probe as u32,
-            base_weight: o.base_weight,
+            base_weight: Some(o.base_weight),
             quantizer: Some(quantization_to_proto(&o.quantizer)),
             embedder: o.embedder.clone().unwrap_or_default(),
             rerank_storage: o.rerank_storage.map(|k| rerank_storage_to_proto(k) as i32),
@@ -240,7 +240,8 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
             m: o.m as usize,
             ef_construction: o.ef_construction as usize,
             default_ef_search: o.default_ef_search.map(|v| v as usize),
-            base_weight: o.base_weight,
+            // Unset means "use the engine's default" (#1084).
+            base_weight: o.base_weight.unwrap_or(1.0),
             quantizer: o
                 .quantizer
                 .as_ref()
@@ -260,7 +261,8 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
         Some(Opt::Flat(o)) => Some(FieldOption::Flat(FlatOption {
             dimension: o.dimension as usize,
             distance: distance_from_proto(o.distance),
-            base_weight: o.base_weight,
+            // Unset means "use the engine's default" (#1084).
+            base_weight: o.base_weight.unwrap_or(1.0),
             quantizer: o
                 .quantizer
                 .as_ref()
@@ -278,7 +280,8 @@ pub fn field_option_from_proto(fo: &v1::FieldOption) -> Option<FieldOption> {
             distance: distance_from_proto(o.distance),
             n_clusters: o.n_clusters as usize,
             n_probe: o.n_probe as usize,
-            base_weight: o.base_weight,
+            // Unset means "use the engine's default" (#1084).
+            base_weight: o.base_weight.unwrap_or(1.0),
             quantizer: o
                 .quantizer
                 .as_ref()
@@ -1028,6 +1031,97 @@ mod tests {
         match back.fields.get("embedding") {
             Some(FieldOption::Hnsw(h)) => {
                 assert_eq!(h.pq_codebook_path, None, "empty must normalize to None");
+            }
+            other => panic!("expected FieldOption::Hnsw, got {other:?}"),
+        }
+    }
+
+    /// Issue #1084: `base_weight` round-trips as `Some` through proto for
+    /// Hnsw/Flat/Ivf, and a gRPC client that omits it (proto `None`, the
+    /// zero-value before this fix) restores to the engine's default
+    /// (`1.0`) rather than the silent `0.0` a plain `float` produced.
+    #[test]
+    fn base_weight_round_trips_through_proto_and_unset_defaults_to_one() {
+        let schema = Schema::builder()
+            .add_field(
+                "hnsw_explicit",
+                FieldOption::Hnsw(HnswOption {
+                    dimension: 8,
+                    base_weight: 2.5,
+                    ..Default::default()
+                }),
+            )
+            .add_field(
+                "flat_explicit",
+                FieldOption::Flat(FlatOption {
+                    dimension: 8,
+                    base_weight: 3.5,
+                    ..Default::default()
+                }),
+            )
+            .add_field(
+                "ivf_explicit",
+                FieldOption::Ivf(laurus::IvfOption {
+                    dimension: 8,
+                    base_weight: 4.5,
+                    ..Default::default()
+                }),
+            )
+            .build();
+
+        let proto = to_proto(&schema);
+        for (name, expected) in [
+            ("hnsw_explicit", 2.5f32),
+            ("flat_explicit", 3.5f32),
+            ("ivf_explicit", 4.5f32),
+        ] {
+            let base_weight = match proto.fields.get(name).and_then(|f| f.option.as_ref()) {
+                Some(v1::field_option::Option::Hnsw(h)) => h.base_weight,
+                Some(v1::field_option::Option::Flat(f)) => f.base_weight,
+                Some(v1::field_option::Option::Ivf(i)) => i.base_weight,
+                other => panic!("unexpected proto option for {name}: {other:?}"),
+            };
+            assert_eq!(
+                base_weight,
+                Some(expected),
+                "to_proto must carry an explicit base_weight as Some for {name}"
+            );
+        }
+
+        let back = from_proto(&proto).expect("from_proto must succeed");
+        for (name, expected) in [
+            ("hnsw_explicit", 2.5f32),
+            ("flat_explicit", 3.5f32),
+            ("ivf_explicit", 4.5f32),
+        ] {
+            let base_weight = match back.fields.get(name) {
+                Some(FieldOption::Hnsw(h)) => h.base_weight,
+                Some(FieldOption::Flat(f)) => f.base_weight,
+                Some(FieldOption::Ivf(i)) => i.base_weight,
+                other => panic!("unexpected laurus option for {name}: {other:?}"),
+            };
+            assert_eq!(base_weight, expected, "round-trip mismatch for {name}");
+        }
+
+        // A gRPC client omitting base_weight entirely (proto `None`) must
+        // restore to the engine default, not the proto3 zero-value.
+        let mut unset = proto.clone();
+        if let Some(v1::field_option::Option::Hnsw(h)) = unset
+            .fields
+            .get_mut("hnsw_explicit")
+            .and_then(|f| f.option.as_mut())
+        {
+            h.base_weight = None;
+        } else {
+            panic!("hnsw_explicit must be an Hnsw proto option");
+        }
+        let back = from_proto(&unset).expect("from_proto must succeed");
+        match back.fields.get("hnsw_explicit") {
+            Some(FieldOption::Hnsw(h)) => {
+                assert_eq!(
+                    h.base_weight, 1.0,
+                    "unset base_weight must default to 1.0, not the proto3 zero-value"
+                );
             }
             other => panic!("expected FieldOption::Hnsw, got {other:?}"),
         }

--- a/laurus-server/src/gateway/convert.rs
+++ b/laurus-server/src/gateway/convert.rs
@@ -624,10 +624,14 @@ fn json_to_hnsw_option(json: &Value) -> Result<v1::HnswOption, String> {
             .get("ef_construction")
             .and_then(|v| v.as_u64())
             .unwrap_or(0) as u32,
+        // Unset (omitted by the client) means "use the engine's default"
+        // (#1084), unlike `dimension`/`m`/`ef_construction` above, which
+        // have no such tri-state and are left as their existing
+        // `unwrap_or(0)` behavior.
         base_weight: json
             .get("base_weight")
             .and_then(|v| v.as_f64())
-            .unwrap_or(0.0) as f32,
+            .map(|v| v as f32),
         quantizer: json.get("quantizer").and_then(json_to_quantizer),
         embedder: json
             .get("embedder")
@@ -660,10 +664,11 @@ fn json_to_flat_option(json: &Value) -> Result<v1::FlatOption, String> {
             .and_then(|v| v.as_str())
             .map(parse_distance_metric)
             .unwrap_or(v1::DistanceMetric::Cosine as i32),
+        // Unset means "use the engine's default" (#1084).
         base_weight: json
             .get("base_weight")
             .and_then(|v| v.as_f64())
-            .unwrap_or(0.0) as f32,
+            .map(|v| v as f32),
         quantizer: json.get("quantizer").and_then(json_to_quantizer),
         embedder: json
             .get("embedder")
@@ -685,10 +690,11 @@ fn json_to_ivf_option(json: &Value) -> Result<v1::IvfOption, String> {
             .unwrap_or(v1::DistanceMetric::Cosine as i32),
         n_clusters: json.get("n_clusters").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
         n_probe: json.get("n_probe").and_then(|v| v.as_u64()).unwrap_or(0) as u32,
+        // Unset means "use the engine's default" (#1084).
         base_weight: json
             .get("base_weight")
             .and_then(|v| v.as_f64())
-            .unwrap_or(0.0) as f32,
+            .map(|v| v as f32),
         quantizer: json.get("quantizer").and_then(json_to_quantizer),
         embedder: json
             .get("embedder")
@@ -706,8 +712,13 @@ fn hnsw_option_to_json(opt: &v1::HnswOption) -> Value {
         "distance": distance_metric_to_string(opt.distance),
         "m": opt.m,
         "ef_construction": opt.ef_construction,
-        "base_weight": opt.base_weight,
     });
+    // Surfaced only when explicitly set (#1084): an absent `base_weight`
+    // means "use the engine's default", same as `analyzer`/`term_vectors`
+    // elsewhere, rather than a `null` standing in for `0.0`.
+    if let Some(base_weight) = opt.base_weight {
+        obj["base_weight"] = json!(base_weight);
+    }
     if let Some(q) = &opt.quantizer {
         obj["quantizer"] = quantizer_to_json(q);
     }
@@ -727,8 +738,11 @@ fn flat_option_to_json(opt: &v1::FlatOption) -> Value {
     let mut obj = json!({
         "dimension": opt.dimension,
         "distance": distance_metric_to_string(opt.distance),
-        "base_weight": opt.base_weight,
     });
+    // Unset means "use the engine's default" (#1084).
+    if let Some(base_weight) = opt.base_weight {
+        obj["base_weight"] = json!(base_weight);
+    }
     if let Some(q) = &opt.quantizer {
         obj["quantizer"] = quantizer_to_json(q);
     }
@@ -747,8 +761,11 @@ fn ivf_option_to_json(opt: &v1::IvfOption) -> Value {
         "distance": distance_metric_to_string(opt.distance),
         "n_clusters": opt.n_clusters,
         "n_probe": opt.n_probe,
-        "base_weight": opt.base_weight,
     });
+    // Unset means "use the engine's default" (#1084).
+    if let Some(base_weight) = opt.base_weight {
+        obj["base_weight"] = json!(base_weight);
+    }
     if let Some(q) = &opt.quantizer {
         obj["quantizer"] = quantizer_to_json(q);
     }
@@ -1375,6 +1392,37 @@ mod tests {
         let empty =
             json_to_hnsw_option(&json!({ "dimension": 32, "pq_codebook_path": "" })).unwrap();
         assert_eq!(empty.pq_codebook_path, None, "empty must normalize to None");
+    }
+
+    /// Issue #1084: `base_weight` survives the HTTP gateway's
+    /// JSON -> proto -> JSON round-trip when explicitly set, and an absent
+    /// key stays absent (rather than materializing as `0.0`, which would
+    /// silently zero out every vector score for a client that never sent
+    /// it).
+    #[test]
+    fn test_base_weight_round_trips_through_json_and_absent_key_stays_absent() {
+        let json = json!({ "dimension": 32, "base_weight": 2.5 });
+        let opt = json_to_hnsw_option(&json).unwrap();
+        assert_eq!(opt.base_weight, Some(2.5));
+
+        let back = hnsw_option_to_json(&opt);
+        assert_eq!(back.get("base_weight").and_then(|v| v.as_f64()), Some(2.5));
+
+        let plain = json_to_hnsw_option(&json!({ "dimension": 32 })).unwrap();
+        assert_eq!(plain.base_weight, None);
+        assert!(
+            hnsw_option_to_json(&plain).get("base_weight").is_none(),
+            "an unset base_weight must not emit a key"
+        );
+
+        // Flat and Ivf follow the same contract.
+        let flat = json_to_flat_option(&json!({ "dimension": 32 })).unwrap();
+        assert_eq!(flat.base_weight, None);
+        assert!(flat_option_to_json(&flat).get("base_weight").is_none());
+
+        let ivf = json_to_ivf_option(&json!({ "dimension": 32 })).unwrap();
+        assert_eq!(ivf.base_weight, None);
+        assert!(ivf_option_to_json(&ivf).get("base_weight").is_none());
     }
 
     #[test]

--- a/laurus-wasm/src/schema.rs
+++ b/laurus-wasm/src/schema.rs
@@ -295,6 +295,11 @@ impl WasmSchema {
     ///   `quantizer` is "product_quantization"; commits then encode against
     ///   the pre-trained codebook instead of re-training k-means per
     ///   segment. Omitted (default) keeps per-segment training.
+    /// * `baseWeight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. Only matters when a query targets two or more specific
+    ///   vector fields at once; has no effect on the lexical-vs-vector
+    ///   balance of a hybrid search.
     #[wasm_bindgen(js_name = "addHnswField")]
     #[allow(clippy::too_many_arguments)]
     pub fn add_hnsw_field(
@@ -310,6 +315,7 @@ impl WasmSchema {
         subvector_count: Option<u32>,
         rerank_storage: Option<String>,
         pq_codebook_path: Option<String>,
+        base_weight: Option<f32>,
     ) -> Result<(), JsValue> {
         let opt = HnswOption {
             dimension: dimension as usize,
@@ -321,13 +327,19 @@ impl WasmSchema {
             rerank_storage: parse_rerank_storage(rerank_storage.as_deref())?,
             embedder,
             pq_codebook_path,
-            ..Default::default()
+            base_weight: base_weight.unwrap_or(1.0),
         };
         self.inner.fields.insert(name, FieldOption::Hnsw(opt));
         Ok(())
     }
 
     /// Add a flat (brute-force) vector index field.
+    ///
+    /// # Arguments
+    ///
+    /// * `baseWeight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. See `addHnswField` for the full contract.
     #[wasm_bindgen(js_name = "addFlatField")]
     pub fn add_flat_field(
         &mut self,
@@ -335,11 +347,13 @@ impl WasmSchema {
         dimension: u32,
         distance: Option<String>,
         embedder: Option<String>,
+        base_weight: Option<f32>,
     ) -> Result<(), JsValue> {
         let opt = FlatOption {
             dimension: dimension as usize,
             distance: parse_distance(distance.as_deref().unwrap_or("cosine"))?,
             embedder,
+            base_weight: base_weight.unwrap_or(1.0),
             ..Default::default()
         };
         self.inner.fields.insert(name, FieldOption::Flat(opt));
@@ -347,7 +361,14 @@ impl WasmSchema {
     }
 
     /// Add an IVF approximate nearest-neighbor vector field.
+    ///
+    /// # Arguments
+    ///
+    /// * `baseWeight` - This field's relative scoring priority when
+    ///   searched alongside other vector fields (Issue #1084). Defaults to
+    ///   1.0. See `addHnswField` for the full contract.
     #[wasm_bindgen(js_name = "addIvfField")]
+    #[allow(clippy::too_many_arguments)]
     pub fn add_ivf_field(
         &mut self,
         name: String,
@@ -356,6 +377,7 @@ impl WasmSchema {
         n_clusters: Option<u32>,
         n_probe: Option<u32>,
         embedder: Option<String>,
+        base_weight: Option<f32>,
     ) -> Result<(), JsValue> {
         let opt = IvfOption {
             dimension: dimension as usize,
@@ -363,6 +385,7 @@ impl WasmSchema {
             n_clusters: n_clusters.unwrap_or(100) as usize,
             n_probe: n_probe.unwrap_or(1) as usize,
             embedder,
+            base_weight: base_weight.unwrap_or(1.0),
             ..Default::default()
         };
         self.inner.fields.insert(name, FieldOption::Ivf(opt));

--- a/laurus/src/engine/schema.rs
+++ b/laurus/src/engine/schema.rs
@@ -544,10 +544,17 @@ fn classify_vector_common(old: &FieldOption, new: &FieldOption) -> FieldChangeKi
 }
 
 /// Classification for HNSW-specific parameters. `default_ef_search` and
-/// `base_weight` are metadata-only (read only at query/searcher-construction
-/// time) and need no check. `m`/`ef_construction`/`quantizer`/
-/// `rerank_storage`/`pq_codebook_path` all require rebuilding the graph
-/// from the raw vectors already on disk.
+/// `base_weight` are metadata-only: both are read only at query time
+/// (`base_weight` by `VectorStore::search_impl`'s per-field query-weight
+/// computation, Issue #1084; `default_ef_search` by the searcher
+/// construction path), so neither needs an on-disk rebuild. Known gap
+/// (shared by both, not yet fixed): `Engine::update_field`'s
+/// `MetadataOnly` arm updates the persisted schema but does not push the
+/// new value into an already-open `VectorStore` — the change only takes
+/// effect the next time the index is opened, not immediately, despite the
+/// `MetadataOnly` classification's usual "no rebuild needed" implication.
+/// `m`/`ef_construction`/`quantizer`/`rerank_storage`/`pq_codebook_path`
+/// all require rebuilding the graph from the raw vectors already on disk.
 fn classify_hnsw_specific(old: &HnswOption, new: &HnswOption) -> FieldChangeKind {
     let mut kind = FieldChangeKind::MetadataOnly;
     if old.m != new.m
@@ -562,8 +569,11 @@ fn classify_hnsw_specific(old: &HnswOption, new: &HnswOption) -> FieldChangeKind
 }
 
 /// Classification for Flat-specific parameters. `base_weight` is
-/// metadata-only; `quantizer`/`rerank_storage` require rebuilding from the
-/// raw vectors already on disk.
+/// metadata-only (read only at query time by `VectorStore::search_impl`'s
+/// per-field query-weight computation, Issue #1084 — see
+/// `classify_hnsw_specific`'s doc comment for the known "not live-reflected
+/// without reopening" gap); `quantizer`/`rerank_storage` require rebuilding
+/// from the raw vectors already on disk.
 fn classify_flat_specific(old: &FlatOption, new: &FlatOption) -> FieldChangeKind {
     if old.quantizer != new.quantizer || old.rerank_storage != new.rerank_storage {
         FieldChangeKind::Reindex
@@ -575,8 +585,12 @@ fn classify_flat_specific(old: &FlatOption, new: &FlatOption) -> FieldChangeKind
 /// Classification for IVF-specific parameters. `n_probe` and `base_weight`
 /// are metadata-only (search-time only; the persisted `n_probe` value's
 /// read-back is discarded — see `laurus/src/vector/index/ivf/writer.rs`).
-/// `n_clusters` requires re-running k-means; `quantizer`/`rerank_storage`
-/// require rebuilding from the raw vectors already on disk.
+/// `base_weight` is read at query time by `VectorStore::search_impl`'s
+/// per-field query-weight computation (Issue #1084) — see
+/// `classify_hnsw_specific`'s doc comment for the known "not live-reflected
+/// without reopening" gap. `n_clusters` requires re-running k-means;
+/// `quantizer`/`rerank_storage` require rebuilding from the raw vectors
+/// already on disk.
 fn classify_ivf_specific(old: &IvfOption, new: &IvfOption) -> FieldChangeKind {
     if old.n_clusters != new.n_clusters
         || old.quantizer != new.quantizer

--- a/laurus/src/engine/search.rs
+++ b/laurus/src/engine/search.rs
@@ -129,7 +129,10 @@ pub struct VectorSearchOptions {
     pub score_mode: VectorScoreMode,
 
     /// Minimum score threshold. Results below this score are discarded.
-    /// Defaults to `0.0` (no threshold).
+    /// Defaults to `0.0` (no threshold). Compared against the raw
+    /// per-field similarity BEFORE `QueryVector.weight` and the field's
+    /// `base_weight` (Issue #1084) are applied — a similarity floor, not a
+    /// final-score floor.
     pub min_score: f32,
 
     /// Optional Stage 2 rerank factor (Issue #481).

--- a/laurus/src/vector/core/field.rs
+++ b/laurus/src/vector/core/field.rs
@@ -66,7 +66,18 @@ impl FieldOption {
         }
     }
 
-    /// Get the base weight.
+    /// Get this field's relative scoring priority (Issue #1084).
+    ///
+    /// Read by `VectorStore::search_impl` and multiplied into a query's
+    /// per-field weight, so it only matters when a query is routed to two
+    /// or more specific vector fields at once — it has no effect on a
+    /// single-field query, and it does not affect the lexical-vs-vector
+    /// balance in a hybrid search's fusion (`FusionAlgorithm::RRF` is
+    /// rank-only and `WeightedSum` min-max normalizes each side before
+    /// weighting, so a uniform per-field scalar is normalized away on
+    /// either side). Should be a positive, finite value — non-positive or
+    /// non-finite values are clamped to `1.0` (with a warning) wherever
+    /// they are read.
     pub fn base_weight(&self) -> f32 {
         match self {
             FieldOption::Flat(opt) => opt.base_weight,
@@ -94,7 +105,10 @@ pub struct FlatOption {
     /// Distance metric used for similarity computation. Defaults to [`DistanceMetric::Cosine`].
     #[serde(default = "default_distance_metric")]
     pub distance: DistanceMetric,
-    /// Base weight applied to similarity scores from this field. Defaults to `1.0`.
+    /// This field's relative scoring priority when searched alongside
+    /// other vector fields (Issue #1084). See
+    /// [`FieldOption::base_weight`] for the full contract. Defaults to
+    /// `1.0`.
     #[serde(default = "default_weight")]
     pub base_weight: f32,
     /// Quantization method used for the on-disk vector format.
@@ -172,7 +186,10 @@ pub struct HnswOption {
     /// Issue [#644](https://github.com/mosuka/laurus/issues/644).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_ef_search: Option<usize>,
-    /// Base weight applied to similarity scores from this field. Defaults to `1.0`.
+    /// This field's relative scoring priority when searched alongside
+    /// other vector fields (Issue #1084). See
+    /// [`FieldOption::base_weight`] for the full contract. Defaults to
+    /// `1.0`.
     #[serde(default = "default_weight")]
     pub base_weight: f32,
     /// Quantization method used for the on-disk vector format.
@@ -256,7 +273,10 @@ pub struct IvfOption {
     /// Higher values improve recall at the cost of query latency. Defaults to `1`.
     #[serde(default = "default_getting_n_probe")]
     pub n_probe: usize,
-    /// Base weight applied to similarity scores from this field. Defaults to `1.0`.
+    /// This field's relative scoring priority when searched alongside
+    /// other vector fields (Issue #1084). See
+    /// [`FieldOption::base_weight`] for the full contract. Defaults to
+    /// `1.0`.
     #[serde(default = "default_weight")]
     pub base_weight: f32,
     /// Quantization method used for the on-disk vector format.

--- a/laurus/src/vector/index/config.rs
+++ b/laurus/src/vector/index/config.rs
@@ -654,8 +654,10 @@ impl HnswIndexConfig {
     /// * `embedder` — `HnswOption::embedder` is an embedder *name*
     ///   (`Option<String>`) while the config holds an
     ///   `Arc<dyn Embedder>`; resolution happens at the store level.
-    /// * `base_weight` — a scoring-level knob with no config
-    ///   counterpart.
+    /// * `base_weight` — a query-time scoring scalar (Issue #1084),
+    ///   consumed by `VectorStore::search_impl`'s per-field query-weight
+    ///   computation, not by the on-disk index geometry this config
+    ///   describes. It has no counterpart here by design.
     ///
     /// `normalize_vectors` is set to `distance == Cosine` (Issue #794):
     /// L2-normalizing the stored vectors only makes sense for

--- a/laurus/src/vector/index/segmented_field.rs
+++ b/laurus/src/vector/index/segmented_field.rs
@@ -623,6 +623,12 @@ impl VectorFieldReader for SegmentedVectorField {
         let mut merged: HashMap<u64, FieldHit> = HashMap::new();
 
         for query in &request.query_vectors {
+            // Deliberately just `query.weight`, NOT multiplied by the
+            // field's `base_weight` (Issue #1084): that factor is applied
+            // one layer up, in `VectorStore::search_impl`'s per-field
+            // query-weight computation. Applying it here too — if this
+            // type is ever wired back into the production search path —
+            // would double-apply it.
             let effective_weight = query.weight;
             let query_vec = &query.vector.data;
 

--- a/laurus/src/vector/search/searcher.rs
+++ b/laurus/src/vector/search/searcher.rs
@@ -502,6 +502,11 @@ pub struct VectorSearchParams {
     #[serde(default = "default_overfetch")]
     pub overfetch: f32,
     /// Minimum score threshold. Results below this score are filtered out.
+    ///
+    /// Compared against the raw per-field similarity BEFORE `QueryVector`'s
+    /// `weight` and the field's `base_weight` (Issue #1084) are applied —
+    /// this is a similarity floor, not a final-score floor, matching the
+    /// pre-existing contract for `QueryVector.weight`.
     #[serde(default)]
     pub min_score: f32,
     /// List of allowed document IDs (for internal use by Engine filtering).

--- a/laurus/src/vector/store.rs
+++ b/laurus/src/vector/store.rs
@@ -27,6 +27,7 @@ pub mod memory;
 pub mod request;
 pub mod response;
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::Mutex;
@@ -68,6 +69,13 @@ pub struct VectorStore {
     /// [`Self::with_index_type_config`] (the single-index constructor),
     /// which never had a collection-wide config to retain.
     config: Option<VectorIndexConfig>,
+    /// Per-field relative scoring priority (Issue #1084), keyed by field
+    /// name. Seeded from `config.fields` at construction and kept in sync
+    /// by [`Self::add_field`]/[`Self::delete_field`]/[`Self::rebuild_field`].
+    /// A field with no entry (including every field of a store built via
+    /// [`Self::with_index_type_config`]) falls back to `1.0` in
+    /// [`Self::base_weight_of`].
+    base_weights: parking_lot::RwLock<HashMap<String, f32>>,
 }
 
 impl std::fmt::Debug for VectorStore {
@@ -107,11 +115,22 @@ impl VectorStore {
             &field_configs,
             config.embedder.clone(),
         )?;
+        let base_weights = config
+            .fields
+            .iter()
+            .filter_map(|(name, field_config)| {
+                field_config
+                    .vector
+                    .as_ref()
+                    .map(|opt| (name.clone(), Self::sanitize_base_weight(opt.base_weight())))
+            })
+            .collect();
         Ok(Self {
             index: Box::new(index),
             writer_cache: Mutex::new(None),
             searcher_cache: parking_lot::RwLock::new(None),
             config: Some(config),
+            base_weights: parking_lot::RwLock::new(base_weights),
         })
     }
 
@@ -138,6 +157,7 @@ impl VectorStore {
             writer_cache: Mutex::new(None),
             searcher_cache: parking_lot::RwLock::new(None),
             config: None,
+            base_weights: parking_lot::RwLock::new(HashMap::new()),
         })
     }
 
@@ -572,6 +592,32 @@ impl VectorStore {
         self.search_impl(request, Some(parallel_threshold))
     }
 
+    /// Clamp a raw `base_weight` to a usable value (Issue #1084).
+    ///
+    /// `base_weight` is a multiplicative factor on similarity scores, so a
+    /// non-positive or non-finite value would zero out, negate, or NaN-out
+    /// every hit from the field. This also rescues indexes whose
+    /// `schema.toml` already has `base_weight: 0.0` from a pre-#1084
+    /// gRPC/REST-created schema (proto3's non-optional `float` used to
+    /// default to `0.0`, silently distinct from core's `1.0` default).
+    fn sanitize_base_weight(raw: f32) -> f32 {
+        if raw.is_finite() && raw > 0.0 {
+            raw
+        } else {
+            log::warn!(
+                "base_weight must be a positive, finite value; got {raw}, falling back to 1.0"
+            );
+            1.0
+        }
+    }
+
+    /// Look up a field's sanitized `base_weight`, defaulting to `1.0` when
+    /// the field has no entry (schema-less fields, non-vector fields, and
+    /// every field of a store built via [`Self::with_index_type_config`]).
+    fn base_weight_of(&self, field: &str) -> f32 {
+        self.base_weights.read().get(field).copied().unwrap_or(1.0)
+    }
+
     /// Resolve the set of vector fields a single query should be routed to
     /// (Issue #676).
     ///
@@ -710,12 +756,16 @@ impl VectorStore {
                 q
             };
             if targets.is_empty() {
+                // Field-less fanout search (Issue #676): no single field is
+                // known here, so `base_weight` cannot be applied (Issue
+                // #1084 leaves this out of scope — see the store-level doc
+                // comment on `base_weights`).
                 index_queries.push(make(None));
                 query_weights.push(qv.weight);
             } else {
                 for field in &targets {
                     index_queries.push(make(Some(field)));
-                    query_weights.push(qv.weight);
+                    query_weights.push(qv.weight * self.base_weight_of(field));
                 }
             }
         }
@@ -1040,6 +1090,11 @@ impl VectorStore {
             self.index.add_field(name, field_config)?;
         }
 
+        self.base_weights.write().insert(
+            name.to_string(),
+            Self::sanitize_base_weight(vector_opt.base_weight()),
+        );
+
         if let Some(field_embedder) = embedder {
             let index_embedder = self.index.embedder();
             if let Some(pfe) = index_embedder
@@ -1096,6 +1151,8 @@ impl VectorStore {
         // contract (documented above) is unchanged; physical deletion is
         // opt-in via `Self::rebuild_field` (Issue #1080).
         self.index.remove_field(name, false)?;
+
+        self.base_weights.write().remove(name);
 
         // Remove the field-specific embedder from the PerFieldEmbedder if present.
         let index_embedder = self.index.embedder();
@@ -1188,6 +1245,11 @@ impl VectorStore {
         } else {
             self.index.rebuild_field(name, new_config)?;
         }
+
+        self.base_weights.write().insert(
+            name.to_string(),
+            Self::sanitize_base_weight(new_option.base_weight()),
+        );
 
         if let Some(field_embedder) = embedder {
             let index_embedder = self.index.embedder();

--- a/laurus/src/vector/store/config.rs
+++ b/laurus/src/vector/store/config.rs
@@ -459,12 +459,6 @@ impl Default for VectorFieldConfig {
     }
 }
 
-impl VectorFieldConfig {
-    pub fn default_weight() -> f32 {
-        1.0
-    }
-}
-
 // Moved to crate::vector::core::field
 // use crate::vector::core::field::{VectorOption, FlatOption, HnswOption, IvfOption, VectorIndexKind};
 

--- a/laurus/tests/advanced_fusion_test.rs
+++ b/laurus/tests/advanced_fusion_test.rs
@@ -171,3 +171,170 @@ async fn test_field_boosts() -> laurus::Result<()> {
 
     Ok(())
 }
+
+/// #1084: with `FusionAlgorithm::WeightedSum` and `lexical_weight: 0.0`, the
+/// fused score reduces to the vector side alone, so a higher `base_weight`
+/// on the field carrying doc2's vector must make it outrank doc1 even
+/// though both documents share an identical lexical hit.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_base_weight_affects_weighted_sum_fusion() -> laurus::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_config = StorageConfig::File(FileStorageConfig::new(temp_dir.path()));
+    let storage = StorageFactory::create(storage_config)?;
+
+    let config = Schema::builder()
+        .add_field("title", FieldOption::Text(TextOption::default()))
+        .add_field(
+            "vec_a",
+            FieldOption::Hnsw(HnswOption {
+                base_weight: 1.0,
+                ..HnswOption::default()
+            }),
+        )
+        .add_field(
+            "vec_b",
+            FieldOption::Hnsw(HnswOption {
+                base_weight: 5.0,
+                ..HnswOption::default()
+            }),
+        )
+        .build();
+
+    let engine = Engine::new(storage, config).await?;
+
+    let mut shared_vec = vec![0.0; 128];
+    shared_vec[0] = 1.0;
+
+    // Same lexical hit, same vector, one in each field.
+    engine
+        .put_document(
+            "doc1",
+            Document::builder()
+                .add_field("title", "apple")
+                .add_field("vec_a", shared_vec.clone())
+                .build(),
+        )
+        .await?;
+    engine
+        .put_document(
+            "doc2",
+            Document::builder()
+                .add_field("title", "apple")
+                .add_field("vec_b", shared_vec.clone())
+                .build(),
+        )
+        .await?;
+    engine.commit().await?;
+
+    let request = SearchRequestBuilder::new()
+        .lexical_query(LexicalSearchQuery::Obj(Box::new(TermQuery::new(
+            "title", "apple",
+        ))))
+        .vector_query(VectorSearchQuery::Vectors(vec![QueryVector {
+            vector: Vector::new(shared_vec),
+            weight: 1.0,
+            fields: Some(vec!["vec_a".into(), "vec_b".into()]),
+        }]))
+        .fusion_algorithm(FusionAlgorithm::WeightedSum {
+            lexical_weight: 0.0,
+            vector_weight: 1.0,
+        })
+        .build();
+
+    let results = engine.search(request).await?;
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results[0].id,
+        "doc2",
+        "vec_b's higher base_weight must rank doc2 first when the fused \
+         score is entirely vector-driven, got {:?}",
+        results.iter().map(|h| &h.id).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// #1084: `base_weight` cannot affect `FusionAlgorithm::RRF` directly — it
+/// is rank-only and ignores the underlying score entirely, so a uniform
+/// per-field scalar multiplied into two documents that are ALREADY tied on
+/// every other axis (same lexical hit, symmetric vector ranks) cancels out
+/// exactly (rank 1 + rank 2 sums to the same RRF total regardless of which
+/// document holds which rank). This is a deliberate property of RRF, not a
+/// bug: it is why the docs correct the "hybrid search fusion weight"
+/// claim. What `base_weight` DOES still do end-to-end through the Engine
+/// is affect a vector-only query's own ranking (verified below) and,
+/// through it, a `WeightedSum`-fused hybrid search (verified above).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_base_weight_affects_vector_only_query_through_the_engine() -> laurus::Result<()> {
+    let temp_dir = TempDir::new().unwrap();
+    let storage_config = StorageConfig::File(FileStorageConfig::new(temp_dir.path()));
+    let storage = StorageFactory::create(storage_config)?;
+
+    let config = Schema::builder()
+        .add_field(
+            "vec_a",
+            FieldOption::Hnsw(HnswOption {
+                base_weight: 1.0,
+                ..HnswOption::default()
+            }),
+        )
+        .add_field(
+            "vec_b",
+            FieldOption::Hnsw(HnswOption {
+                base_weight: 5.0,
+                ..HnswOption::default()
+            }),
+        )
+        .build();
+
+    let engine = Engine::new(storage, config).await?;
+
+    let mut vec_close = vec![0.0; 128];
+    vec_close[0] = 1.0;
+    let mut vec_far = vec![0.0; 128];
+    vec_far[0] = 0.9;
+    vec_far[1] = 0.1;
+
+    // doc1's vector is the closer match in vec_a (weight 1.0); doc2's is
+    // the farther match, but lives in vec_b (weight 5.0). Without
+    // base_weight, doc1 would rank first on the vector side; with it,
+    // doc2's weighted score overtakes doc1's.
+    engine
+        .put_document(
+            "doc1",
+            Document::builder()
+                .add_field("vec_a", vec_close.clone())
+                .build(),
+        )
+        .await?;
+    engine
+        .put_document(
+            "doc2",
+            Document::builder().add_field("vec_b", vec_far).build(),
+        )
+        .await?;
+    engine.commit().await?;
+
+    // A vector-only request (no `lexical_query`) is a single-mode search
+    // that bypasses `Engine::fuse_results` entirely — the returned score
+    // IS the base_weight-adjusted similarity.
+    let request = SearchRequestBuilder::new()
+        .vector_query(VectorSearchQuery::Vectors(vec![QueryVector {
+            vector: Vector::new(vec_close),
+            weight: 1.0,
+            fields: Some(vec!["vec_a".into(), "vec_b".into()]),
+        }]))
+        .build();
+
+    let results = engine.search(request).await?;
+    assert_eq!(results.len(), 2);
+    assert_eq!(
+        results[0].id,
+        "doc2",
+        "vec_b's base_weight must overtake doc1's closer-but-unweighted \
+         match through the full Engine pipeline: {:?}",
+        results.iter().map(|h| &h.id).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}

--- a/laurus/tests/vector_base_weight_test.rs
+++ b/laurus/tests/vector_base_weight_test.rs
@@ -1,0 +1,296 @@
+//! Integration tests for #1084: `FieldOption::base_weight` wiring.
+//!
+//! `base_weight` is a per-field multiplicative factor on similarity scores,
+//! applied only when a query is routed to one or more specific fields
+//! (`QueryVector.fields` / `VectorSearchParams.fields`) — it has no effect
+//! on a field-less fanout query (`fields: None` everywhere), which is out
+//! of scope for this issue.
+//!
+//! Each test uses two or more HNSW fields sharing the same dimension, and
+//! anchors on documents that carry the EXACT SAME vector as the query, so
+//! int8 quantization error is identical across fields and any score
+//! difference is attributable to `base_weight` alone (see #773 for why
+//! exact-recall assertions on a randomized HNSW graph are avoided
+//! elsewhere in this crate).
+
+use async_trait::async_trait;
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use laurus::lexical::LexicalIndexConfig;
+use laurus::storage::memory::{MemoryStorage, MemoryStorageConfig};
+use laurus::vector::Vector;
+use laurus::vector::core::distance::DistanceMetric;
+use laurus::vector::core::field::HnswOption;
+use laurus::vector::store::config::VectorFieldConfig;
+use laurus::vector::store::request::{
+    QueryVector, VectorScoreMode, VectorSearchParams, VectorSearchRequest,
+};
+use laurus::vector::{FieldOption, VectorIndexConfig, VectorStore};
+use laurus::{DataValue, Document};
+use laurus::{EmbedInput, EmbedInputType, Embedder};
+use laurus::{LaurusError, Result};
+
+#[derive(Debug)]
+struct MockEmbedder {
+    dimension: usize,
+}
+
+#[async_trait]
+impl Embedder for MockEmbedder {
+    async fn embed(&self, input: &EmbedInput<'_>) -> Result<Vector> {
+        match input {
+            EmbedInput::Text(_) => Ok(Vector::new(vec![0.0; self.dimension])),
+            _ => Err(LaurusError::invalid_argument("text only")),
+        }
+    }
+    fn supported_input_types(&self) -> Vec<EmbedInputType> {
+        vec![EmbedInputType::Text]
+    }
+    fn name(&self) -> &str {
+        "mock"
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn hnsw(dimension: usize, base_weight: f32) -> FieldOption {
+    FieldOption::Hnsw(HnswOption {
+        dimension,
+        distance: DistanceMetric::Cosine,
+        m: 16,
+        ef_construction: 100,
+        default_ef_search: None,
+        base_weight,
+        quantizer: Default::default(),
+        rerank_storage: None,
+        embedder: None,
+        pq_codebook_path: None,
+    })
+}
+
+/// A store whose fields are given as `(name, base_weight)` pairs, each an
+/// independent HNSW field of the given dimension.
+async fn setup_store(dimension: usize, fields: &[(&str, f32)]) -> VectorStore {
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let mut field_configs = HashMap::new();
+    for (name, base_weight) in fields {
+        field_configs.insert(
+            name.to_string(),
+            VectorFieldConfig {
+                vector: Some(hnsw(dimension, *base_weight)),
+                lexical: None,
+            },
+        );
+    }
+    let config = VectorIndexConfig {
+        fields: field_configs,
+        embedder: Arc::new(MockEmbedder { dimension }),
+        default_fields: fields.iter().map(|(n, _)| n.to_string()).collect(),
+        metadata: HashMap::new(),
+        deletion_config: laurus::DeletionConfig::default(),
+        shard_id: 0,
+        metadata_config: LexicalIndexConfig::default(),
+    };
+    VectorStore::new(storage, config).unwrap()
+}
+
+async fn upsert(store: &VectorStore, doc_id: u64, field: &str, vector: Vec<f32>) {
+    let doc = Document::builder()
+        .add_field(field, DataValue::Vector(vector))
+        .build();
+    store
+        .upsert_document_by_internal_id(doc_id, doc)
+        .await
+        .unwrap();
+}
+
+fn search_fields(store: &VectorStore, vector: Vec<f32>, fields: &[&str]) -> Vec<(u64, f32)> {
+    let request = VectorSearchRequest {
+        query: laurus::vector::VectorSearchQuery::Vectors(vec![QueryVector {
+            vector: Vector::new(vector),
+            weight: 1.0,
+            fields: Some(fields.iter().map(|f| f.to_string()).collect()),
+        }]),
+        params: VectorSearchParams {
+            limit: 10,
+            score_mode: VectorScoreMode::WeightedSum,
+            ..Default::default()
+        },
+    };
+    let results = store.search(request).unwrap();
+    results
+        .hits
+        .into_iter()
+        .map(|h| (h.doc_id, h.score))
+        .collect()
+}
+
+/// #1084: base_weight reorders hits across vector fields when the same
+/// query is routed to both fields.
+#[tokio::test(flavor = "multi_thread")]
+async fn base_weight_reorders_hits_across_vector_fields() {
+    let store = setup_store(3, &[("a_vec", 1.0), ("b_vec", 3.0)]).await;
+    upsert(&store, 1, "a_vec", vec![1.0, 0.0, 0.0]).await;
+    upsert(&store, 2, "b_vec", vec![1.0, 0.0, 0.0]).await;
+    store.commit().await.unwrap();
+
+    let hits = search_fields(&store, vec![1.0, 0.0, 0.0], &["a_vec", "b_vec"]);
+    let by_id: HashMap<u64, f32> = hits.into_iter().collect();
+
+    let score_a = *by_id.get(&1).expect("doc 1 (a_vec) must be a hit");
+    let score_b = *by_id.get(&2).expect("doc 2 (b_vec) must be a hit");
+
+    assert!(
+        score_b > score_a,
+        "b_vec's base_weight (3.0) must outrank a_vec's (1.0): a={score_a}, b={score_b}"
+    );
+    let ratio = score_b / score_a;
+    assert!(
+        (ratio - 3.0).abs() < 0.05,
+        "score ratio must track the base_weight ratio (~3.0), got {ratio}"
+    );
+}
+
+/// #1084: a field whose `base_weight` is unset (the `HnswOption` default,
+/// `1.0`) scores identically to one with an explicit `1.0`.
+#[tokio::test(flavor = "multi_thread")]
+async fn base_weight_defaults_to_one_when_unset() {
+    let default_weight = HnswOption::default().base_weight;
+    assert_eq!(default_weight, 1.0, "HnswOption::default() must be 1.0");
+
+    let store = setup_store(3, &[("default_vec", default_weight), ("explicit_vec", 1.0)]).await;
+    upsert(&store, 1, "default_vec", vec![1.0, 0.0, 0.0]).await;
+    upsert(&store, 2, "explicit_vec", vec![1.0, 0.0, 0.0]).await;
+    store.commit().await.unwrap();
+
+    let hits = search_fields(
+        &store,
+        vec![1.0, 0.0, 0.0],
+        &["default_vec", "explicit_vec"],
+    );
+    let by_id: HashMap<u64, f32> = hits.into_iter().collect();
+
+    let score_default = *by_id.get(&1).expect("doc 1 must be a hit");
+    let score_explicit = *by_id.get(&2).expect("doc 2 must be a hit");
+    assert!(
+        (score_default - score_explicit).abs() < 1e-6,
+        "default and explicit 1.0 base_weight must score identically: \
+         default={score_default}, explicit={score_explicit}"
+    );
+}
+
+/// #1084: non-positive or non-finite `base_weight` values are clamped to
+/// `1.0` rather than zeroing, negating, or NaN-ing out every hit from the
+/// field — this rescues indexes whose schema already has `base_weight:
+/// 0.0` persisted from before the proto/gateway fix.
+#[tokio::test(flavor = "multi_thread")]
+async fn non_positive_base_weight_falls_back_to_one() {
+    let store = setup_store(
+        3,
+        &[
+            ("baseline", 1.0),
+            ("zero", 0.0),
+            ("negative", -1.0),
+            ("nan", f32::NAN),
+        ],
+    )
+    .await;
+    for (doc_id, field) in ["baseline", "zero", "negative", "nan"]
+        .into_iter()
+        .enumerate()
+    {
+        upsert(&store, doc_id as u64, field, vec![1.0, 0.0, 0.0]).await;
+    }
+    store.commit().await.unwrap();
+
+    let baseline_hits = search_fields(&store, vec![1.0, 0.0, 0.0], &["baseline"]);
+    let baseline_score = baseline_hits
+        .first()
+        .expect("baseline field must have a hit")
+        .1;
+
+    for field in ["zero", "negative", "nan"] {
+        let hits = search_fields(&store, vec![1.0, 0.0, 0.0], &[field]);
+        let score = hits
+            .first()
+            .unwrap_or_else(|| panic!("{field} field must have a hit"))
+            .1;
+        assert!(
+            (score - baseline_score).abs() < 1e-6,
+            "{field}'s base_weight must clamp to 1.0 like baseline: \
+             baseline={baseline_score}, {field}={score}"
+        );
+    }
+}
+
+/// #1084: `min_score` compares the raw, unweighted similarity — a field
+/// with a small `base_weight` that would push the final score below
+/// `min_score` must still return the hit, because filtering happens
+/// before weighting (matching the pre-existing `QueryVector.weight`
+/// contract).
+#[tokio::test(flavor = "multi_thread")]
+async fn min_score_compares_unweighted_similarity() {
+    let store = setup_store(3, &[("low_weight", 0.1)]).await;
+    upsert(&store, 1, "low_weight", vec![1.0, 0.0, 0.0]).await;
+    store.commit().await.unwrap();
+
+    let request = VectorSearchRequest {
+        query: laurus::vector::VectorSearchQuery::Vectors(vec![QueryVector {
+            vector: Vector::new(vec![1.0, 0.0, 0.0]),
+            weight: 1.0,
+            fields: Some(vec!["low_weight".to_string()]),
+        }]),
+        params: VectorSearchParams {
+            limit: 10,
+            score_mode: VectorScoreMode::WeightedSum,
+            // The raw similarity for an identical vector is close to 1.0;
+            // the base_weight-adjusted score is close to 0.1. A min_score
+            // between the two proves which one the filter uses.
+            min_score: 0.5,
+            ..Default::default()
+        },
+    };
+    let results = store.search(request).unwrap();
+    assert_eq!(
+        results.hits.len(),
+        1,
+        "min_score must be compared against the unweighted similarity (~1.0), \
+         not the base_weight-adjusted score (~0.1): got {:?}",
+        results.hits
+    );
+    assert!(
+        results.hits[0].score < 0.5,
+        "the returned score must still be base_weight-adjusted: {:?}",
+        results.hits[0]
+    );
+}
+
+/// #1084: a store built via `with_index_type_config` (no collection-wide
+/// `VectorIndexConfig`, hence no `base_weights` entries) must not panic —
+/// every field falls back to `1.0`.
+#[tokio::test(flavor = "multi_thread")]
+async fn single_index_store_ignores_base_weight() {
+    use laurus::vector::index::config::{FlatIndexConfig, VectorIndexTypeConfig};
+
+    let storage = Arc::new(MemoryStorage::new(MemoryStorageConfig::default()));
+    let config = VectorIndexTypeConfig::Flat(FlatIndexConfig {
+        dimension: 3,
+        ..Default::default()
+    });
+    let store = VectorStore::with_index_type_config(storage, config).unwrap();
+
+    let doc = Document::builder()
+        .add_field("vector", DataValue::Vector(vec![1.0, 0.0, 0.0]))
+        .build();
+    store.upsert_document_by_internal_id(1, doc).await.unwrap();
+    store.commit().await.unwrap();
+
+    let hits = search_fields(&store, vec![1.0, 0.0, 0.0], &["vector"]);
+    assert!(
+        !hits.is_empty(),
+        "search must not panic and must find the doc"
+    );
+}


### PR DESCRIPTION
## Summary

`FieldOption::base_weight` (a per-field vector schema option) had zero call sites across the entire workspace — it was stored and round-tripped through serialization, but never read on any scoring path. This wires it into `VectorStore`'s search scoring, following the same investigation-then-full-wiring approach as #1083 (`term_vectors`).

Investigation (see the earlier comment on #1084) surfaced problems beyond the original scope:

1. The fusion algorithms structurally limit where `base_weight` can matter: `FusionAlgorithm::RRF` is rank-only and ignores the underlying score entirely, and `FusionAlgorithm::WeightedSum` min-max normalizes each side before weighting — a uniform per-field scalar is normalized away on either side. So `base_weight` can only ever affect the *relative priority between multiple vector fields searched together*, never the lexical-vs-vector balance. The docs' claim of a "hybrid search fusion" weight was incorrect and is corrected here.
2. An equivalent mechanism already exists and is documented: `QueryVector.weight` (settable via the DSL's `^` boost syntax).
3. A proto/gRPC/REST default-value mismatch identical in shape to #1083's `term_vectors` issue: core defaults `base_weight` to `1.0`, but the non-optional proto3 `float base_weight` defaulted to `0.0`, and the REST gateway explicitly did `.unwrap_or(0.0)`. Wiring this in as-is would have zeroed out vector scores for every gRPC/REST-created index.
4. An existing, unrelated design gap: `Engine::update_field`'s `MetadataOnly` arm never touches `VectorStore`, so a `MetadataOnly`-classified change (which `base_weight` already is) isn't actually live-reflected without reopening the index. This bug already exists for `default_ef_search`.

Per the maintainer's decision, this PR implements **full wiring**, scoped as follows:

- **In scope**: wire `base_weight` into `VectorStore::search_impl`'s per-field query-weight computation; fix the proto/gateway default-value mismatch (`optional float`, mirroring #1083's `term_vectors` fix); clamp non-positive/non-finite `base_weight` values to `1.0` with a `log::warn!` (this also rescues existing indexes whose `schema.toml` already has `base_weight: 0.0` from a pre-fix gRPC/REST-created schema); expose `base_weight` through the CLI wizard and all 5 language bindings; correct the "hybrid search fusion" documentation error.
- **Out of scope** (documented as known limitations, not silently dropped): making the `MetadataOnly` update live-reflect into an existing `VectorStore` without reopening (shared root cause with the pre-existing `default_ef_search` bug — better tackled together in a follow-up); applying `base_weight` to field-less fanout vector search (`field_name: None`, reachable only via gRPC/REST `query_vectors` omitting `fields` — not reachable via the DSL or Engine payload paths).

## Changes

- **Server-side default reconciliation** (no behavior change on its own): `base_weight` on `HnswOption`/`FlatOption`/`IvfOption` changed from `float` to `optional float` in `index.proto`; `convert/schema.rs` and `gateway/convert.rs` updated on both directions so an unset value resolves to the engine default (`1.0`) instead of the proto3 zero-value.
- **`VectorStore` wiring**: added a `base_weights: RwLock<HashMap<String, f32>>` map, seeded from `config.fields` at construction and kept in sync by `add_field`/`delete_field`/`rebuild_field`. A sanitizing lookup clamps non-positive/non-finite values to `1.0` with a warning. `search_impl`'s per-field query-weight expansion multiplies `qv.weight * base_weight_of(field)` (the field-less fanout path is deliberately left untouched — out of scope, documented above). Also removed the now-fully-dead `VectorFieldConfig::default_weight()` and added a comment in `segmented_field.rs` explaining why `base_weight` must not be applied there (it already is, one layer up, to avoid double-application if that type is ever wired into the production search path).
- **Classification / doc-comment accuracy**: `classify_hnsw_specific`/`classify_flat_specific`/`classify_ivf_specific` doc comments now spell out the known "`MetadataOnly` but not live-reflected without reopening" gap; `FieldOption::base_weight()` and the 3 option structs' doc comments describe the actual effect and contract (positive finite value; non-positive/non-finite clamps to `1.0`).
- **Bindings + CLI**: added a `base_weight` parameter (default `1.0`) to the HNSW/Flat/IVF field builders in all 5 language bindings and the CLI's interactive schema wizard. Ruby's HNSW builder pulls `base_weight` from the `get_kwargs` splat `RHash` rather than the `Opt` tuple, since `magnus::scan_args::ScanArgsOpt` only supports tuples up to 9 elements and the existing option list already used all 9.
- **Docs**: corrected the "hybrid search fusion" wording across English and Japanese `schema_format.md`, `schema_and_fields.md`, `concepts/search/vector_search.md` (Weights section), `laurus-server/grpc_api.md`, and all 5 binding `api_reference.md` files — the actual effect is limited to relative priority among vector fields searched together.

## Upgrade note

Existing indexes created over gRPC or REST before this change may have `base_weight: 0.0` persisted in their `schema.toml` (the proto3 zero-value silently substituting for the engine's `1.0` default). After upgrading, such a field's `base_weight` is automatically clamped to `1.0` at read time (with a `log::warn!`), so vector scores are not zeroed out — no manual migration is needed.

## Test plan

- [x] New integration test suite `laurus/tests/vector_base_weight_test.rs` (5 tests: relative-priority effect, default-value equivalence, non-positive/non-finite clamping, `min_score`'s unweighted-similarity contract, safety on a single-index-typed `VectorStore`)
- [x] New Engine-level tests in `laurus/tests/advanced_fusion_test.rs` (2 tests: `WeightedSum` fusion effect, and a vector-only query proving the effect survives the full Engine pipeline — a planned RRF-order-reversal test was replaced after discovering it always mathematically cancels out for 2 documents, a property of RRF itself, not a bug)
- [x] New server conversion tests in `convert/schema.rs` and `gateway/convert.rs` (unset → `1.0`, explicit value round-trips)
- [x] New binding tests: Python `test_vector_base_weight.py` (3 tests) and Ruby `test_vector_base_weight.rb` (3 tests), both comparing actual scores rather than just that search succeeds
- [x] `cargo test -p laurus` (full suite, 1410 passed)
- [x] `cargo fmt --all -- --check` / `cargo clippy` clean across `laurus`, `laurus-cli`, `laurus-server`, and every binding crate
- [x] `cargo build -p laurus-server` / `cargo test -p laurus-server` (56 passed)
- [x] `cargo check` on every binding crate (`laurus-wasm` on `wasm32-unknown-unknown --tests`)
- [x] Python (104 passed) and Ruby (78 passed) full test suites green
- [x] `mdbook build` clean for both the English and Japanese docs

Closes #1084
