### PR TITLE
fix(query): allow apostrophes in unquoted lexical query terms

### DIFF
--- a/laurus/src/lexical/query/parser.pest
+++ b/laurus/src/lexical/query/parser.pest
@@ -98,11 +98,19 @@ field = @{ (ASCII_ALPHA | "_") ~ (ASCII_ALPHANUMERIC | "_" | ".")* }
 // so CJK / Cyrillic / Greek / accented Latin etc. all parse as bare
 // terms without requiring quoting. `boolean_op` keywords (AND / OR)
 // remain whitespace-bounded as before.
+// `'` is allowed unescaped (issue #1111): it has no syntactic meaning in
+// the DSL, unlike `+`/`-`/`:`/`"` etc., and is extremely common in
+// ordinary English text (contractions like `it's`/`don't`, possessives
+// like `user's`). Added to both `unescaped_term` and `normal_char` — the
+// latter is what `escaped_char+` (tried before `unescaped_term` below)
+// actually consumes a bare, non-backslashed character with, so omitting
+// it there would truncate `it's` to `it` before the apostrophe was ever
+// reached.
 term = @{ escaped_char+ | unescaped_term }
-unescaped_term = @{ (LETTER | NUMBER | "_" | "-")+ }
+unescaped_term = @{ (LETTER | NUMBER | "_" | "-" | "'")+ }
 escaped_char = @{ "\\" ~ special_char | normal_char }
 special_char = { "+" | "-" | "!" | "(" | ")" | "{" | "}" | "[" | "]" | "^" | "\"" | "~" | "*" | "?" | ":" | "\\" | "/" }
-normal_char = @{ LETTER | NUMBER | "_" | "-" }
+normal_char = @{ LETTER | NUMBER | "_" | "-" | "'" }
 
 // Quoted string
 quoted_string = { "\"" ~ quoted_content ~ "\"" }

--- a/laurus/src/lexical/query/parser.rs
+++ b/laurus/src/lexical/query/parser.rs
@@ -1149,6 +1149,51 @@ mod tests {
     }
 
     #[test]
+    fn test_apostrophe_in_unquoted_term() {
+        // Issue #1111: `'` has no syntactic meaning in the DSL, but was
+        // previously absent from both `unescaped_term` and `special_char`,
+        // so it could not appear in a bare term at all -- not even
+        // backslash-escaped. Contractions (`it's`, `don't`) and
+        // possessives (`user's`) are extremely common in ordinary English
+        // text, so this must parse without requiring the whole query to
+        // be wrapped in quotes (which would silently change unquoted
+        // OR-of-tokens semantics into an exact phrase match).
+        let parser = create_test_parser().with_default_field("content");
+
+        for q in ["It's Only the Himalayas", "don't", "user's book", "isn't"] {
+            parser
+                .parse(q)
+                .unwrap_or_else(|e| panic!("failed to parse {q:?}: {e}"));
+        }
+    }
+
+    #[test]
+    fn test_apostrophe_grammar_consumes_the_whole_word() {
+        // The `term` rule must consume the ENTIRE word including the
+        // apostrophe, not stop short at it and strand the rest to be
+        // re-parsed as a spurious second clause. This is the
+        // `normal_char` half of the #1111 fix: `term`'s `escaped_char+`
+        // alternative is tried before `unescaped_term`, and `escaped_char`
+        // bottoms out at `normal_char` for any non-backslashed character
+        // -- so `'` must be in `normal_char` too, or `escaped_char+`
+        // would stop consuming right at the apostrophe.
+        //
+        // Verified directly against the grammar (not through `parse()`)
+        // because the effect of the bug isn't a parse error: without this
+        // fix, `don't` silently parses as two adjacent bare terms (`don`
+        // and `'t`), which `analyze_term` OR's together into a
+        // `BooleanQuery` just like a legitimate two-word query would --
+        // there is no error to assert against, only the wrong split.
+        let pairs = QueryStringParser::parse(Rule::term, "don't")
+            .unwrap_or_else(|e| panic!("failed to parse term \"don't\": {e}"));
+        let matched = pairs.as_str();
+        assert_eq!(
+            matched, "don't",
+            "the term rule must consume the whole word in one match, got {matched:?}"
+        );
+    }
+
+    #[test]
     fn test_unquoted_cjk_boolean() {
         // Whitespace-bounded boolean ops still kick in between CJK terms.
         let parser = create_test_parser().with_default_field("content");


### PR DESCRIPTION
## Summary

`'` (apostrophe) had no syntactic meaning in the lexical query DSL but could not appear in an unquoted term at all — not even backslash-escaped — because it was absent from both `unescaped_term` and `special_char` in `parser.pest`. This broke ordinary English text containing contractions (`it's`, `don't`) or possessives (`user's`) unless the whole query was wrapped in quotes, which silently changes unquoted OR-of-tokens semantics into an exact phrase match.

## Fix

Added `'` to `unescaped_term`'s character class, as suggested in #1111. Also added it to `normal_char`, which turned out to be required beyond what the issue described: `term = @{ escaped_char+ | unescaped_term }` tries `escaped_char+` first, and `escaped_char` bottoms out at `normal_char` for any non-backslashed character. With `'` only in `unescaped_term`, `don't` parsed without an error, but silently split into two separate bare terms (`don` and `'t`) instead of one word — `'t` alone then tokenizes away to nothing, so the query silently became wrong rather than erroring. Verified this concretely by temporarily reverting the `normal_char` change and confirming the regression test fails.

Checked `laurus/src/vector/query/parser.pest` (a separate grammar) too — its `plain_text` rule is a negative-lookahead catch-all that already accepts `'`, so no change needed there.

## Test plan

- [x] `test_apostrophe_in_unquoted_term`: `It's Only the Himalayas`, `don't`, `user's book`, `isn't` all parse without error
- [x] `test_apostrophe_grammar_consumes_the_whole_word`: parses `Rule::term` directly against `"don't"` and asserts the matched span is the whole word — the regression guard for the `normal_char` half of the fix, confirmed to actually catch the bug by temporarily reverting it
- [x] Full `laurus` test suite (1412 tests) passes
- [x] `cargo fmt --all -- --check` / `cargo clippy -p laurus --all-targets --features embeddings-all -- -D warnings` clean

Closes #1111
